### PR TITLE
Research: scheduling algorithms — SM-2, FSRS, graded Leitner

### DIFF
--- a/docs/research/scheduling-algorithms/README.md
+++ b/docs/research/scheduling-algorithms/README.md
@@ -1,0 +1,488 @@
+# Scheduling algorithms: SM-2, FSRS, graded Leitner
+
+Research resolving [Research: scheduling algorithms — SM-2, FSRS, graded Leitner](https://github.com/amin-bf/leitner/issues/2),
+a ticket on [Map: local-first Leitner app spec](https://github.com/amin-bf/leitner/issues/1).
+
+**Research date: 2026-07-26.** Every version and status claim was verified against a live primary
+source on that date, not from model memory.
+
+**This document gathers facts; it does not choose.** The choice belongs to
+[Decide: scheduling algorithm and grade scale](https://github.com/amin-bf/leitner/issues/5). Where
+this document says "note that", it is flagging a constraint the decision must account for, not
+recommending an outcome.
+
+Appendices hold the full evidence with per-claim source URLs:
+
+- [Appendix A — SM-2 and FSRS](./appendix-a-sm2-and-fsrs.md): algorithm text, formulas, Anki source, parameter counts, replay analysis.
+- [Appendix B — Leitner boxes as a UI](./appendix-b-leitner-boxes.md): the original system, the graded-mapping search, shipped-app behaviour, the documented failure mode.
+- [Appendix C — Rust crate landscape](./appendix-c-rust-crates.md): crates.io/GitHub fact tables, `fsrs` API surface, build verification, licences.
+
+---
+
+## Executive summary
+
+1. **SM-2 is fully specified, tiny, and 39 years old.** The published algorithm is four state fields
+   and two formulas ([Appendix A §1–2](./appendix-a-sm2-and-fsrs.md)). It is ~15 lines of code.
+2. **"Ease hell" is Anki's bug, not SM-2's.** Anki replaced SM-2's bounded `f(EF,q)` ease update with
+   fixed additive deltas and no mean reversion. Criticism of "SM-2" in the Anki community is usually
+   criticism of Anki's variant ([Appendix A §3a](./appendix-a-sm2-and-fsrs.md)).
+3. **FSRS has no minimum-review threshold any more, and defaults work from zero history.** The
+   1000-review and 400-review figures that circulate are historical; Anki's own FAQ says the optimizer
+   works with any number of reviews as of Anki 24.06.3. Default parameters were fitted on ~727M reviews
+   from ~10k users and degrade gracefully ([Appendix A §5](./appendix-a-sm2-and-fsrs.md)). **This
+   removes the main practical argument for shipping SM-2 first and migrating later.**
+4. **FSRS is still opt-in in Anki, not the default** — verified against Anki `main` at 2026-07-25 two
+   independent ways. Secondary write-ups frequently get this wrong ([Appendix A §7](./appendix-a-sm2-and-fsrs.md)).
+5. **There is no published mapping of a 4-point grade scale onto box movement. Graded Leitner is
+   always invented per project.** Stronger than mere absence: both academic treatments of Leitner
+   deliberately collapse grades to binary, and the reference open-source implementation is binary and
+   treats even the *demotion* rule as a config flag ([Appendix B §2](./appendix-b-leitner-boxes.md)).
+6. **The box-display-is-a-lie failure mode is documented in a peer-reviewed paper by the vendor who
+   hit it** — Duolingo, ACL 2016 ([Appendix B §4.1](./appendix-b-leitner-boxes.md)). This is direct
+   evidence for the map's standing constraint 4, not speculation.
+7. **`fsrs` (the Rust crate) is production-grade, BSD-3-Clause, and no longer pulls in an ML
+   framework.** It compiles for `wasm32-unknown-unknown` and `aarch64-linux-android`, training path
+   included; 164 KB of wasm for a build exporting both scheduling and training
+   ([Appendix C §0–1](./appendix-c-rust-crates.md)).
+8. **No production-viable SM-2 crate exists, and no Leitner crate exists at all.** Both would be
+   written by hand — SM-2 is ~50 lines ([Appendix C §2–3](./appendix-c-rust-crates.md)).
+9. **Pure replay works for both algorithms' cores, but a specific, enumerable list of things breaks
+   it** — chiefly load balancing, calendar-dependent adjustments, day-boundary/timezone config, and
+   the parameter vector itself ([§5](#5-data-requirements-what-the-review-log-must-record) below).
+
+---
+
+## 1. SM-2
+
+Source: Woźniak's own published text, <https://super-memory.com/english/ol/sm2.htm>, fetched and
+quoted verbatim in [Appendix A §1](./appendix-a-sm2-and-fsrs.md).
+
+### The algorithm
+
+```
+I(1) = 1 day
+I(2) = 6 days
+I(n) = I(n-1) * EF          for n > 2, rounded up to whole days
+
+EF  initial 2.5, floor 1.3
+EF' = EF + (0.1 - (5-q) * (0.08 + (5-q) * 0.02))     applied after every repetition
+    ≡ EF - 0.8 + 0.28q - 0.02q²
+
+grades q ∈ 0..5   (5 perfect … 0 complete blackout)
+q < 3  ⇒  restart the interval ladder at I(1); the reset itself does not touch EF
+```
+
+Per-grade EF deltas: q=5 → +0.10, q=4 → 0 (fixed point), q=3 → −0.14, q=2 → −0.32, q=1 → −0.54,
+q=0 → −0.80.
+
+### State per card
+
+`ef` (f32, init 2.5, floor 1.3), `n` (repetition count), `interval` (days — required because `I(n)`
+is recursive), and `due`/`last_review`. **That is all.** The published algorithm has no lapse counter,
+no leech handling, no sub-day scheduling, and no notion of lateness.
+
+### Weaknesses — and precisely whose they are
+
+| Property | SM-2 as published | Anki's variant |
+|---|---|---|
+| Ease update | bounded quadratic `f(EF, q)`; q=4 is a fixed point | fixed additive deltas: Again −0.20, Hard −0.15, Easy +0.15, floor 1.3, **no mean reversion** |
+| Grade scale | 6 points (0–5) | 4 buttons, one failure option |
+| Sub-day learning | none | configurable learning steps (default `1m 10m`) and relearning steps (default `10m`) |
+| Lateness | ignored | `good = (ivl + days_late/2) * EF` |
+| Lapses | no counter | `lapses` counter, leech tag/suspend at 8 |
+| Fuzz | none | on for intervals ≥ 2.5 days, range-dependent |
+| Load balancing | none | **on by default** |
+
+**"Ease hell" is caused by the Anki row, not the SM-2 row.** Repeated `Again`/`Hard` walk ease
+monotonically down to the 1.3 floor with nothing pushing it back up, after which intervals only ever
+grow ×1.3. The term itself appears in the Anki manual, which also states FSRS does not have the
+problem. FSRS's difficulty update adds mean reversion explicitly to avoid it. Full mechanism and
+source lines in [Appendix A §3a](./appendix-a-sm2-and-fsrs.md).
+
+A second, separate weakness of SM-2 proper: it is a **1987–1989** algorithm with no published
+empirical validation against modern benchmarks, and it models difficulty with a single scalar that
+doubles as the interval multiplier.
+
+---
+
+## 2. FSRS
+
+Sources: the FSRS algorithm wiki (`open-spaced-repetition/awesome-fsrs`), `fsrs-rs` source at commit
+`87c9a28`, Anki `main` at 2026-07-25, `srs-benchmark`. See
+[Appendix A §4–8](./appendix-a-sm2-and-fsrs.md).
+
+### The memory model
+
+Three variables per card, collectively the **memory state**:
+
+- **S — stability**: days for recall probability to fall from 100% to 90%.
+- **D — difficulty**: how hard it is to *increase* stability, clamped to [1, 10].
+- **R — retrievability**: current recall probability, a function of elapsed time and S.
+
+FSRS-6 uses a **power-law** forgetting curve with a *trainable* decay exponent (`w20`, default
+0.1542) — not exponential; that was FSRS v3:
+
+```
+R(t, S) = (1 + factor · t/S)^(-w20),   factor = 0.9^(-1/w20) - 1   (so that R(S,S) = 0.9)
+```
+
+S and D update only on review; R changes continuously. FSRS-6 uses **all** reviews including
+same-day ones (`delta_t == 0` takes a separate short-term stability path). Full update formulas,
+transcribed from `fsrs-rs/src/model.rs`, are in [Appendix A §4](./appendix-a-sm2-and-fsrs.md).
+
+### Parameters and optimisation
+
+- **FSRS-6: 21 trainable parameters.** Historical counts: v1=7, v4=17, FSRS-5=19, FSRS-6=21.
+- "Optimisation" is gradient-descent fitting of those 21 weights to minimise log-loss on the recall
+  outcomes implied by *your own* review log.
+- Recommended cadence (Anki FAQ): monthly, or every time the review count doubles.
+
+### The minimum-review question — the historical answer is wrong
+
+> "That was the case in earlier versions of Anki. In **Anki 24.06.3** (and newer versions), the
+> optimizer can be used with any number of reviews."
+> — <https://faqs.ankiweb.net/frequently-asked-questions-about-fsrs.html>
+
+Historical thresholds were 1000 reviews (pre-24.04) and 400 (24.04); the 400 figure survives only as
+a stale comment in Anki source. Current Anki has **no numeric threshold in the UI**. The only
+surviving guidance is qualitative — the optional health check flags "less than a few hundred"
+reviews.
+
+### Zero history
+
+**FSRS works from a cold start and degrades gracefully.** `FSRS::new(&[])` substitutes
+`DEFAULT_PARAMETERS`; the defaults were fitted by running the optimizer on **several hundred million
+reviews from ~10k users** and the project states plainly that even with defaults FSRS beats SM-2.
+Quantitatively, the benchmark's 0-trainable-parameter row sits at log-loss 0.3629 versus 0.3437
+optimised — worse, same league. Anki additionally has a `historical_retention` knob (default 0.9) to
+fill gaps in imported history, and a `memory_state_from_sm2` conversion for cards that only have
+SM-2 `interval`/`ease`.
+
+### Version and status
+
+- **Shipped production version is FSRS-6.** `fsrs-rs` published 6.6.2 (2026-07-08); Anki pins 6.6.1.
+- **FSRS-7 exists but only in the research benchmark repo** — 35 parameters, dual power-law curve,
+  fractional intervals. Not in `fsrs-rs`, not in `py-fsrs`, not in Anki, and **no primary write-up of
+  its formulas exists yet**. Nothing suggests it lands in Anki soon.
+- **FSRS is opt-in in Anki, not the default.** Verified two ways against Anki `main` @ 2026-07-25:
+  the manual calls it "an alternative to Anki's legacy SuperMemo 2 (SM-2) algorithm", and
+  `BoolKey::Fsrs` falls through to `false` with no code path enabling it for new collections.
+  Available since Anki/AnkiMobile 23.10, AnkiDroid 2.17+.
+- Licences: **`fsrs-rs` BSD-3-Clause**; `py-fsrs` and `fsrs4anki` MIT; Anki itself AGPL-3.0-or-later.
+
+### Grade scale
+
+Four ratings: 1 Again, 2 Hard, 3 Good, 4 Easy. **Hard is a passing grade** — it takes the success
+branch with a penalty multiplier (`w15`). The Anki manual is emphatic that this is the one habit FSRS
+cannot adapt to: pressing Hard when you actually failed inflates every interval. FSRS-6 has **no
+lapse-count term** in the model at all; post-lapse stability depends on D, S and R, and is capped so
+a lapse can never raise stability.
+
+---
+
+## 3. Graded Leitner
+
+Full evidence: [Appendix B](./appendix-b-leitner-boxes.md).
+
+### The original specifies capacity, not intervals
+
+The best available description of Leitner's own system (5 partitions of **1, 2, 5, 8, 14 cm**) says
+review is triggered when *"a partition became full"* — a capacity/backpressure rule. Intervals are
+**emergent** from box geometry and study rate, not specified. The German description gives a third
+mechanism again: proportional sampling (all of box 1, ½ of box 2, ¼ of box 3 per session) with a
+minimum 8-hour session gap.
+
+Two caveats that matter:
+
+- **Leitner's book was not read.** Every claim about "the original" is second-hand, and the specific
+  passages relied on are *uncited* Wikipedia prose on an article carrying a "more citations needed"
+  tag. Publication year is genuinely disputed in citable literature (1970 / 1972 / 1974).
+- **The famous 1-2-4-8-16 day table is not Leitner's.** It traces to C. A. Mace, *The Psychology of
+  Study* (1932) — 40 years earlier. Duolingo's ACL 2016 figure captioned "The Leitner System" uses
+  exactly Mace's schedule. This is the clearest documented case of Leitner folklore.
+
+### There is no published 4-point → box mapping
+
+The answer to the ticket's question is a plain **no**, and the evidence is stronger than absence:
+
+- **Reddy et al., KDD 2016** (the "Leitner queue network" paper) had Mnemosyne's 0–5 grades available
+  and threw them away: *"We discretize grades into binary outcomes, where recall ≜ grade ≥ 2."* Their
+  box rule is binary, one step in each direction. They also state flatly that *"all existing schemes
+  for assigning review frequencies to decks in the Leitner system … are based on heuristics with no
+  formal optimality guarantees."*
+- **Settles & Meeder, ACL 2016** (Duolingo) formalise Leitner as a two-feature binary special case of
+  half-life regression: `half_life = 2^(#correct − #incorrect)`. No place for Hard or Easy.
+- **`open-spaced-repetition/leitner-box`**, from the same org that maintains FSRS, ships
+  `Rating.{Fail, Pass}` only — and makes even *demotion* a config flag (`on_fail: "first_box" |
+  "prev_box"`), i.e. the canonical implementers consider the rule undetermined by the source material.
+- A Java library implementing Leitner, SM-2 and FSRS side by side keeps a 4-point rating for FSRS and
+  gives Leitner a bare `boolean`.
+- **The two graded implementations found in real code contradict each other:**
+
+  | | Again | Hard | Good | Easy |
+  |---|---|---|---|---|
+  | `yro7/panglot-public` (Rust) | box 0 (reset) | **demote one** | promote one | **same as Good** |
+  | `SouichiroTsujimoto/xanki` (spec) | relearning phase | **box unchanged** | box +1 | **box +2** |
+
+  Hard is a demotion in one and a no-op in the other; Easy is information-free in one and a
+  double-promotion in the other.
+- Woźniak's "Normalized Leitner" — the one attempt at a normative spec — is also binary, and
+  explicitly calls one-step-back demotion an *"incorrect mutation"* of the system.
+
+**Conclusion: if this project defines an Again/Hard/Good/Easy → box mapping, it is inventing one, and
+the spec should say so outright rather than implying a pedigree.**
+
+### What shipped apps that show boxes actually do
+
+| App | Box/level shown? | Underlying scheduler | Display ↔ state |
+|---|---|---|---|
+| **Anki** | No box. New/Learning/Review/Relearn phases; Young/Mature | SM-2 variant, or FSRS (opt-in) | Young/Mature is a **pure interval threshold at 21 days** |
+| **WaniKani** | **Yes — 9 named stages, prominently** | stage → fixed interval table | **1:1 — the stage *is* the state** |
+| **Duolingo 2012–16** | Yes — 4-bar strength meters | Leitner variant | projection; **documented as failing** |
+| **Duolingo 2016–18** | Yes — same meters | half-life regression | bars = predicted recall probability |
+| **Duolingo 2018+** | Crowns | progress counter | **decoupled from memory state by design** |
+| **Memrise** | Levels | 8-rung fixed ladder, reset on failure | effectively a real box system |
+| **Mnemosyne** | No box, 0–5 grades | SM-2 variant | n/a |
+| **Quizlet Learn** | Rounds/progress | undisclosed ML | **could not verify** |
+
+Three findings worth carrying into the decision:
+
+1. **Anki's learning/relearning steps *are* a Leitner ladder** — "Good moves to the next step, Again
+   goes back to the first step" — while its review phase is a continuous interval. So Anki is a
+   bounded Leitner ladder up front and an interval scheduler afterwards.
+2. **WaniKani is the trustworthy-box counter-example, and it runs the arrow the other way**: stage is
+   primary state, interval is derived from stage. Its demotion is the only formula-driven graded box
+   rule found in any shipped app — and its "grade" is error count within a review, not self-report.
+3. **Duolingo's eventual resolution to the box-vs-memory tension was to stop claiming the level means
+   memory state at all.**
+
+### The failure mode is documented, in a refereed venue, by the vendor
+
+> "In fact, when it first launched, Duolingo used a variant similar to Figure 3 to manage skill meter
+> decay and practice. **The present research was motivated by the need for a more accurate model, in
+> response to student complaints that the Leitner-based skill meters did not adequately reflect what
+> they had learned.**"
+> — Settles & Meeder, ACL 2016, <https://research.duolingo.com/papers/settles.acl16.pdf>
+
+Quantitatively, Leitner's mean absolute error on predicted recall was **0.235 vs HLR's 0.128** — the
+display was roughly twice as far from the truth. The same paper records the behavioural cost: users
+optimised for the meter, practising *"just to keep the tree gold"* while feeling the practice
+reviewed the wrong things.
+
+A second, mechanically distinct instance from Anki: **a displayed interval can decrease after a
+passing grade** (fuzz plus the `good ≥ hard + 1` minimum-gap constraint). Any box number derived from
+a *displayed interval* inherits that non-monotonicity and can go **down** after a successful review.
+
+### If a box must be derived, the candidate derivations disagree
+
+| Derivation | Form | Source |
+|---|---|---|
+| Duolingo HLR (published) | `interval ∝ 2^box`, `box = log₂(half_life)` | Settles & Meeder, ACL 2016 |
+| Woźniak "Normalized Leitner" | `box = log_EF(interval / Int1)`; conceptually box discretises **stability** | supermemo.guru |
+| Reddy et al. (empirically fitted, 859k reviews) | `interval ∝ box` — **linear** | KDD 2016 |
+| Anki Young/Mature (shipped) | threshold: two buckets at 21 days | Anki manual |
+
+The only *empirically fitted* relationship is linear; the two normative ones are exponential. No
+paper reconciles this. Note also Woźniak's framing — *"well known cards are shunted to boxes
+corresponding with higher memory stability"* — which points at discretising **stability** rather than
+the scheduled interval. Stability is monotone under successful review; the scheduled interval
+demonstrably is not (see the Anki case above).
+
+**There is no canonical box count.** 3, 5, 8, 9 and 12 all appear in real sources. Only two
+Leitner repos on GitHub clear 20 stars, so there is no authoritative open-source convention to copy.
+
+---
+
+## 4. Rust availability
+
+Full fact tables, API surface and build evidence: [Appendix C](./appendix-c-rust-crates.md).
+
+### `fsrs` — the crate is called `fsrs`, not `fsrs-rs`
+
+| | |
+|---|---|
+| crates.io | `fsrs` **6.6.1**, published 2026-06-09 (`fsrs-rs` and `fsrs-optimizer` are 404) |
+| Downloads | 339,191 total / 51,424 in 90 days |
+| Licence | **BSD-3-Clause** — permissive, attribution + no-endorsement, **no source-disclosure obligation** |
+| Maintenance | 29 commits in 90 days, 4 open issues, not archived, active dependabot |
+| Production use | **Anki pins the published crate** (`version = "6.6.1"` in its workspace manifest, matching `Cargo.lock` checksum) |
+| Scope | **One crate holds both scheduler and optimizer.** There is no separate optimizer crate. |
+
+**Two facts that overturn common assumptions:**
+
+1. **`burn` is gone.** As of 6.3.0 (2026-06-04), `burn` is a *dev-dependency only*; training was
+   rewritten with hand-rolled analytic gradients over `ndarray`. The 10 runtime dependencies are
+   `itertools, log, ndarray, priority-queue, rand, rayon, serde, snafu, strum`. There is no feature
+   gate separating training from scheduling — and none is needed, because training costs no extra
+   dependencies.
+2. **It builds for both target platforms, training path included** (verified locally, not inferred):
+   `wasm32-unknown-unknown` builds clean once `getrandom` has the `wasm_js` feature; `cargo check
+   --target aarch64-linux-android` passes. A release `cdylib` exporting *both* `next_states` and
+   `compute_parameters` is **164 KB of `.wasm`** at `opt-level="z"` with LTO and strip, before
+   `wasm-opt`.
+
+Multi-platform corroboration: `fsrs-browser` (npm, BSD-3-Clause, v6.6.0) is the org's official wasm
+packaging and does **in-browser parameter training** — 24,394 revlogs in 3.5 s in an optimised build,
+"days" in a debug build. AnkiDroid ships `fsrs` inside an Android `.so` via Anki's `rslib`.
+
+### API surface (real names)
+
+```rust
+pub struct FSRSReview { pub rating: u32, pub delta_t: u32 }   // that is the entire model input
+pub struct FSRSItem   { pub reviews: Vec<FSRSReview> }        // one card's whole ordered history
+pub struct MemoryState { pub stability: f32, pub difficulty: f32 }
+pub struct FSRS { /* [f32; 21] — 84 bytes, no backend, no device */ }
+
+impl FSRS {
+    fn next_states(&self, Option<MemoryState>, desired_retention: f32, days_elapsed: u32) -> Result<NextStates>;
+    fn next_interval(&self, Option<f32>, desired_retention: f32, rating: u32) -> f32;
+    fn memory_state(&self, FSRSItem, starting_state: Option<MemoryState>) -> Result<MemoryState>;
+    fn historical_memory_states(&self, FSRSItem, Option<MemoryState>) -> Result<Vec<MemoryState>>;
+    fn memory_state_from_sm2(&self, ease_factor: f32, interval: f32, sm2_retention: f32) -> Result<MemoryState>;
+    fn evaluate<F>(&self, Vec<FSRSItem>, F) -> Result<ModelEvaluation>;
+}
+pub fn compute_parameters(input: ComputeParametersInput) -> Result<Vec<f32>>;   // free fn, not a method
+```
+
+`FSRS::new(&[])` and `FSRS::default()` both give the fitted default parameters.
+
+### Caveats to carry into the decision
+
+- **`rayon` is a hard dependency**, but call-site analysis shows it is reached only from `simulate`,
+  `optimal_retention`, `cost_adr` and time-series evaluation — **not** from scheduling or
+  `compute_parameters`. That `fsrs-browser` bundles `wasm-bindgen-rayon` is evidence some path needs
+  real threads. *Not runtime-verified* — worth a short spike before relying on in-app training on wasm.
+- **`MemoryState` derives `Serialize` but not `Deserialize`.** Persisting it needs a local shim.
+- **`priority-queue = "=2.7.0"` is an exact pin** — will hard-conflict with any other consumer.
+- **6.x moves fast**: nine versions in the eleven days 2026-05-29 → 2026-06-09, with breaking API
+  changes inside the 6.x line. Pin exactly.
+- `rs-fsrs` (MIT, scheduler-only, `chrono` and little else) is a lighter alternative but is **21
+  months stale on crates.io** despite an active repo, and has no optimizer. `fsrsrs` has no
+  repository and no readable licence — treat as unlicensed.
+
+### SM-2 and Leitner in Rust: nothing worth depending on
+
+- **No production-viable SM-2 crate.** The two with real download counts (`spaced-rs` 6k,
+  `ebirsu` 4k) are **GPL and abandoned**. `sm-2` (MIT, same org as fsrs) has 1 GitHub star, 24
+  downloads in 90 days, no commits in 11 months, forces `chrono` + `serde_json`, and returns
+  `Err(NotDue)` if you review early. `srs-sm2` (MIT/Apache, `no_std`, pure function) has the best
+  shape but was **5 days old** at research time with 0 stars. All are 95–200 LOC.
+- **Writing SM-2 directly is the lower-risk option on the facts**: ~15 lines of core arithmetic,
+  40–80 with a `Rating` enum, serde and tests. Both crates above publish usable test vectors that can
+  serve as free cross-check oracles without taking the dependency.
+- **No Leitner crate exists** — `leitner` is a 404 on crates.io and no crate in any search implements
+  a box scheduler as a library. Leitner would be written from scratch.
+- **Nothing exists in Rust** for SM-17/18 (proprietary and unpublished), Ebisu (the crate name is a
+  0-LOC squat), or half-life regression.
+- **`fsrs` is the only way to optimise FSRS parameters without introducing a non-Rust runtime.** The
+  Python `fsrs-optimizer` requires PyTorch.
+
+### Licences
+
+Clean path: **`fsrs` BSD-3-Clause** — fine for a distributed Android/web client with an attribution
+screen. Traps to avoid: `spaced-rs` (GPL-3.0-only), `ebirsu` (GPL-3.0-or-later), and above all
+**Anki's own `rslib` (AGPL-3.0)** — §13 network copyleft would be fatal for a synced client. `fsrs`
+is deliberately BSD so it can be reused independently of Anki. A transitive licence audit
+(`cargo deny check licenses`) has not been run.
+
+---
+
+## 5. Data requirements: what the review log must record
+
+This is the section that feeds **standing constraint 1** on the map ("the log records raw grades and
+timestamps, never only derived state") and constraint 3 (device identity and ordering).
+
+### What each algorithm actually consumes
+
+| Algorithm | Model input | Derived state |
+|---|---|---|
+| **SM-2** | ordered grades `q ∈ 0..5`; timestamps only needed if lateness is honoured (Anki's addition, not SM-2's) | `ef`, `n`, `interval` |
+| **FSRS-6** | `{rating: 1..4, delta_t: days}` per review, chained per card. **Nothing else.** Not answer time. | `MemoryState { stability, difficulty }` |
+| **Graded Leitner** | ordered grades + the invented mapping | `box` |
+
+FSRS's minimal input is confirmed three ways: `fsrs-rs/src/dataset.rs`, the benchmark's input-feature
+legend (interval lengths, grades, same-day reviews — no answer time), and the Anki FAQ's *"FSRS only
+uses interval lengths and grades."*
+
+**But `delta_t` is derived, not recorded.** Anki computes it as a difference of *day buckets*, where
+the bucket boundary is the user's configured rollover hour in their timezone. So the log must carry
+enough to reconstruct the bucketing — an absolute instant plus the rollover/timezone in force —
+or the derived `delta_t` will silently change if either is ever adjusted.
+
+### The recommended event shape
+
+Superset of everything SM-2, FSRS-6 and a graded box system need, with the distinctions Anki learned
+the hard way that it needed:
+
+| Field | Why |
+|---|---|
+| `card_id` | which card |
+| `reviewed_at` | absolute instant (ms precision), so day bucketing is reconstructible |
+| `tz_offset` / rollover config | `delta_t` is bucket-relative; without this the same instants bucket differently |
+| `rating` | 1–4 (or 0–5 if SM-2's scale is kept) — the raw grade, per constraint 1 |
+| `event_kind` | graded review vs **manual reschedule** vs **reset** vs **cram/preview**. Anki's `review_kind` is load-bearing: the optimiser walks history backwards to find the start of the current memory trace and must drop resets and crams. A log of only graded reviews cannot reproduce state after a user manually sets a due date. |
+| `state_before` | new / learning / review / relearning — distinguishes intraday from interday |
+| `scheduled_interval_before`, `scheduled_due_before` | recovers lateness; also records what *was* chosen |
+| `duration_ms` | not used by either memory model; useful for retention-cost tuning and analytics |
+| `device_id`, ordering marker | map constraint 3 — a device must be able to tell it is ahead of or behind another |
+
+Anki's own `RevlogEntry` and `py-fsrs`'s `ReviewLog` are transcribed field-by-field in
+[Appendix A §6](./appendix-a-sm2-and-fsrs.md) for comparison.
+
+### Replay: what works, and exactly what breaks it
+
+**The cores are pure.** SM-2's `(EF, n, I)` is a deterministic function of the grade sequence alone.
+FSRS-6's `step` function is pure with no RNG and no global state; `forward_reviews` recomputes
+`(S, D)` from a review sequence — which is precisely how Anki recomputes memory state after
+re-optimisation. So `(card, timestamp, grade)` ⇒ scheduling state, **conditional on** the following:
+
+| Breaker | Replayable? | What it means for us |
+|---|---|---|
+| **The parameter vector** | Must be versioned | Re-optimising changes every card's computed `(S, D)`. Bit-exact replay requires pinning/versioning the 21 weights alongside the log. |
+| **Anki-style fuzz** | **Yes, if seeded from card identity** | Anki seeds from `card_id + reps`, so fuzz is exactly reproducible. `py-fsrs` uses unseeded `random()` and is not. Copy Anki's approach. |
+| **Load balancing** | **No — depends on the whole collection** | Picks a day inside the fuzz range weighted by how many *other* cards are due each day. On by default in Anki. Not recoverable from one card's log. |
+| **Easy Days** | **No — depends on calendar weekday** | The adjustment depends on which weekday each candidate due date lands on. |
+| **Sibling avoidance** | **No — depends on other cards** | Biases against days already holding a card from the same note. |
+| **Day cutoff / rollover / timezone** | Only if recorded | Change the rollover hour or timezone and identical instants bucket into different days ⇒ different `delta_t` ⇒ different state. |
+| **Manual / reset / cram events** | Only if logged as first-class events | Otherwise state after a manual due-date change cannot be reproduced. |
+| **Config drift** | Must be versioned | Interval modifier, easy/hard/lapse multipliers, max/min intervals, learning steps, desired retention, `historical_retention` are all *current-config* inputs to the interval, not stored per event. |
+| **Answer wall-clock beyond the timestamp** | No hidden dependence found | The only clock inputs are the logged instant and the day-timing config. Answer duration feeds neither memory model. |
+
+**The design rule this implies:** any scheduling adjustment that depends on state outside the card's
+own history — load balancing, calendar shaping, sibling spreading — must either be **disabled**, or
+have its *chosen* outcome **persisted on the event** so the non-replayable decision becomes recorded
+data rather than something recomputed. This is a real tension with map constraint 1 and belongs in
+the event-log format decision, not just the algorithm decision.
+
+**Swappability by replay** (the second half of constraint 1) holds if the log records raw grades,
+absolute timestamps, the day-bucketing config, and the event-kind discriminator. That set is a strict
+superset of SM-2's, FSRS-6's, and any box system's inputs — so a later algorithm change is a
+re-derivation, not a migration. The one thing that does *not* survive a swap is the *scheduled dates*
+already shown to the user; those change under the new algorithm by construction.
+
+---
+
+## 6. Open questions this research did not close
+
+Carried forward honestly; the full per-appendix lists are longer.
+
+1. **Leitner's book was never read.** Every claim about the original system is second-hand from
+   uncited Wikipedia prose. Unverified: whether the 1/2/5/8/14 cm partitions are actually in the book,
+   whether Leitner states any day-interval, whether demotion is "back one" or "back to box 1", and
+   whether he even says five boxes. ISBN 978-3-451-05060-2 (18th ed., Herder 2011) if this matters.
+2. **FSRS-7's formulas have no primary write-up.** Only a qualitative benchmark-README description
+   exists. Pinning them would mean reading `srs-benchmark` source.
+3. **Runtime `rayon` behaviour on wasm is unverified.** Compilation was proven; execution was not.
+   A short spike — run `compute_parameters` under `wasm-bindgen-test` without a thread pool — would
+   settle whether in-app optimisation works on web.
+4. **`compute_parameters` wall-clock on a mid-range Android device is unmeasured.** The only anecdote
+   is 3.5 s for 24k revlogs in an optimised browser build, with a *catastrophic* debug/release gap.
+5. **Android linking was not proven end-to-end** — `cargo check` passed, but no `.so` was produced,
+   and only `aarch64` was tested. (AnkiDroid shipping `fsrs` is strong indirect evidence.)
+6. **The linear-vs-exponential box↔interval contradiction is unreconciled** by any paper.
+7. **No cited instance of "card shown in a high box but actually due now."** The mechanism is
+   established (non-monotone displayed intervals); the manifestation through a box UI is predicted,
+   not observed — plausibly because few apps ship a box UI over an interval scheduler at all.
+8. **supermemo.guru returns HTTP 403 to automated fetchers**, so Woźniak's own retrospective
+   criticism of SM-2 could not be quoted directly (quotes used were retrieved with a browser
+   user-agent).

--- a/docs/research/scheduling-algorithms/appendix-a-sm2-and-fsrs.md
+++ b/docs/research/scheduling-algorithms/appendix-a-sm2-and-fsrs.md
@@ -1,0 +1,723 @@
+# SM-2 and FSRS: primary-source research notes
+
+Research date: **2026-07-26**. All version claims below were verified on the web / against source
+checkouts on that date, not from memory.
+
+Source checkouts used (so claims are reproducible):
+
+- `ankitects/anki` @ `e10ce15` (2026-07-25), sparse clone of `rslib`, `proto`, `ftl`, `ts/routes/deck-options` — https://github.com/ankitects/anki
+- `ankitects/anki-manual` @ HEAD (2026-07) — https://github.com/ankitects/anki-manual
+- `open-spaced-repetition/fsrs-rs` @ `87c9a28` (2026-07-08), version **6.6.2** — https://github.com/open-spaced-repetition/fsrs-rs
+- `open-spaced-repetition/py-fsrs` @ `3abe686` (2026-03-10), version **6.3.1** — https://github.com/open-spaced-repetition/py-fsrs
+- `open-spaced-repetition/awesome-fsrs` wiki (the *current* FSRS algorithm wiki; the old `fsrs4anki` wiki pages now redirect here) — https://github.com/open-spaced-repetition/awesome-fsrs/wiki/The-Algorithm
+- `open-spaced-repetition/srs-benchmark` README — https://github.com/open-spaced-repetition/srs-benchmark
+
+---
+
+## 1. SM-2: the actual published algorithm
+
+Primary source: Piotr Woźniak, *"SuperMemo 2: Algorithm"* / "Application of a computer to improve the
+results obtained in working with the SuperMemo method", extracted from his 1990 Master's Thesis
+(University of Technology in Poznań), published on the web 1998.
+
+- https://super-memory.com/english/ol/sm2.htm (Woźniak's own site — canonical)
+- https://www.supermemo.com/en/archives1990-2015/english/ol/sm2 (same text on supermemo.com, dated 11.08.1990)
+
+Both URLs were fetched and contain byte-for-byte the same algorithm text. Verbatim quotes below.
+
+### Provenance / age
+
+> "I wrote the first SuperMemo program in December 1987 (Turbo Pascal 3.0, IBM PC)."
+
+> "Let us now consider the final form of the SM-2 algorithm that with minor changes was used in the
+> SuperMemo programs, versions 1.0-3.0 between December 13, 1987 and March 9, 1989 (the name SM-2 was
+> chosen because of the fact that SuperMemo 2.0 was by far the most popular version implementing this
+> algorithm)."
+
+So SM-2 is a **1987–1989 algorithm**, ~39 years old as of 2026.
+(Source: https://super-memory.com/english/ol/sm2.htm)
+
+### The seven published steps (verbatim)
+
+> 1. Split the knowledge into smallest possible items.
+> 2. With all items associate an E-Factor equal to 2.5.
+> 3. Repeat items using the following intervals:
+>    `I(1):=1`
+>    `I(2):=6`
+>    `for n>2: I(n):=I(n-1)*EF`
+>    where: I(n) - inter-repetition interval after the n-th repetition (in days), EF - E-Factor of a given item
+>    If interval is a fraction, round it up to the nearest integer.
+> 4. After each repetition assess the quality of repetition response in 0-5 grade scale:
+>    5 - perfect response
+>    4 - correct response after a hesitation
+>    3 - correct response recalled with serious difficulty
+>    2 - incorrect response; where the correct one seemed easy to recall
+>    1 - incorrect response; the correct one remembered
+>    0 - complete blackout.
+> 5. After each repetition modify the E-Factor of the recently repeated item according to the formula:
+>    `EF':=EF+(0.1-(5-q)*(0.08+(5-q)*0.02))`
+>    where: EF' - new value of the E-Factor, EF - old value of the E-Factor, q - quality of the response in the 0-5 grade scale.
+>    If EF is less than 1.3 then let EF be 1.3.
+> 6. If the quality response was lower than 3 then start repetitions for the item from the beginning
+>    **without changing the E-Factor** (i.e. use intervals I(1), I(2) etc. as if the item was memorized anew).
+> 7. After each repetition session of a given day repeat again all items that scored below four in the
+>    quality assessment. Continue the repetitions until all of these items score at least four.
+
+(Source: https://super-memory.com/english/ol/sm2.htm)
+
+### Additional facts stated on the same page
+
+- The EF update is also given in the equivalent reduced form `EF':=EF-0.8+0.28*q-0.02*q*q`, and:
+  "Note, that for q=4 the E-Factor does not change." (So q=5 raises EF by +0.1, q=4 leaves it, q=3
+  lowers it by −0.14, q=2 by −0.32, q=1 by −0.54, q=0 by −0.80.)
+- Initial EF = 2.5; hard floor 1.3. Rationale for the 1.3 floor, verbatim:
+  > "Items having E-Factors lower than 1.3 were repeated annoyingly often and always seemed to have
+  > inherent flaws in their formulation (usually they did not conform to the minimum information
+  > principle). Thus not letting E-Factors fall below 1.3 substantially improved the throughput of the
+  > process and provided an indicator of items that should be reformulated."
+- Note that the original text also says the *earlier* SM-2 era allowed EF between 1.1 and 2.5 before
+  the 1.3 floor was introduced; the published final algorithm uses 1.3.
+
+### Failure rule (q < 3) — be precise
+
+On q < 3 the repetition count `n` is reset to 1 (next interval `I(1)=1` day, then `I(2)=6`), and
+**EF is explicitly NOT changed** by the reset step. EF *is* still modified by step 5 for every
+repetition including failed ones (step 5 says "After each repetition"), so a failing grade does lower
+EF via the formula; it is only the *reset* that is EF-neutral. Sources disagree on nothing here, but
+note that many reimplementations (including Anki) deviate — see §3.
+
+---
+
+## 2. SM-2: state that must be stored per card
+
+To run SM-2 exactly as published you need, per item:
+
+| Field | Type | Why |
+|---|---|---|
+| `ef` (E-Factor) | float, init 2.5, floor 1.3 | multiplier in `I(n)=I(n-1)*EF` |
+| `n` (repetition number) | int, ≥0 | selects `I(1)=1`, `I(2)=6`, or `I(n-1)*EF`; reset to 0 on q<3 |
+| `interval` (last `I(n)`) | int days | needed because `I(n)` is recursive on `I(n-1)` |
+| `due` / `last_review` date | date | to know when the item is due (the paper works in whole days) |
+
+Notes:
+- `interval` is strictly redundant *if* you keep the full grade history and replay from scratch, but
+  it is required for incremental operation.
+- The published algorithm has **no** lapse counter, no leech handling, no per-item difficulty beyond
+  EF, and no sub-day scheduling.
+- Step 7 (same-day repetition of anything graded <4) is part of the published algorithm but is a
+  *session* rule, not per-card persistent state.
+
+(Source: https://super-memory.com/english/ol/sm2.htm)
+
+---
+
+## 3. SM-2: known weaknesses, and precisely what is Anki's vs SM-2 proper
+
+### 3a. "Ease hell"
+
+The term is an Anki-community term, **not** a SuperMemo one. The most authoritative source that uses
+it is the Anki manual itself:
+
+> "(Re)learning steps of 1 day or greater are not recommended when using FSRS. The main reason they
+> were popular with the legacy SM-2 algorithm is because repeatedly failing a card after it has
+> graduated from the learning phase could reduce its ease a lot, leading to what some people called
+> **"ease hell"**. This is not a problem that FSRS suffers from."
+> — `src/deck-options.md` line 543, https://github.com/ankitects/anki-manual/blob/main/src/deck-options.md
+> (rendered: https://docs.ankiweb.net/deck-options.html#learning-and-relearning-steps)
+
+**Precise mechanism, and it is Anki-specific.** In *published* SM-2 a failure resets `n` but the
+reset itself does not touch EF, and EF changes are bounded by the `f(EF,q)` formula. In **Anki**,
+review-state answers apply *fixed additive deltas* to ease, floored at 1.3:
+
+```rust
+// rslib/src/scheduler/states/review.rs (Anki @ e10ce15)
+pub const INITIAL_EASE_FACTOR: f32 = 2.5;
+pub const MINIMUM_EASE_FACTOR: f32 = 1.3;
+pub const EASE_FACTOR_AGAIN_DELTA: f32 = -0.2;
+pub const EASE_FACTOR_HARD_DELTA: f32 = -0.15;
+pub const EASE_FACTOR_EASY_DELTA: f32 = 0.15;
+```
+(https://github.com/ankitects/anki/blob/main/rslib/src/scheduler/states/review.rs)
+
+Because `Again` is −0.20 and `Hard` is −0.15 with no upward pressure other than `Easy` (+0.15), a card
+that is failed or "Hard"-ed repeatedly monotonically walks its ease down to the 1.3 floor, at which
+point its interval only ever grows by ×1.3 and it recurs indefinitely often. There is no mean
+reversion. FSRS's difficulty update deliberately adds mean reversion "to avoid 'ease hell'" — that
+phrase appears verbatim in the FSRS v3 and v4 sections of the algorithm wiki:
+https://github.com/open-spaced-repetition/awesome-fsrs/wiki/The-Algorithm
+
+Anki also documents a *mitigation* it added: successive failures while a card is in the learning
+phase do **not** decrease ease. Anki FAQ, verbatim:
+
+> "successive failures while cards are in learning do not result in further decreases to the card's ease"
+> — https://faqs.ankiweb.net/what-spaced-repetition-algorithm.html
+
+Verified in code: `ease_factor` is only mutated in `ReviewState::answer_*` (review.rs); `LearnState`
+only ever sets `ctx.initial_ease_factor`, never decrements
+(`rslib/src/scheduler/states/learning.rs`).
+
+Note on secondary sources: popular explanations of ease hell (e.g. https://readbroca.com/anki/ease-hell/)
+describe the same mechanism, but they are **secondary** — I have cited the Anki manual/source instead.
+
+### 3b. Anki is not raw SM-2 — the enumerated differences
+
+Anki FAQ, "What spaced repetition algorithm does Anki use?", verbatim points:
+
+> "As of Anki 23.10, Anki has two available algorithms. The first one is based on the SuperMemo 2
+> algorithm, and the second one is called FSRS."
+> …Anki gives users "complete control over initial learning step lengths" rather than SM-2's fixed 1-day
+> and 6-day intervals; offers "four response choices instead of six, with only one failure option";
+> "answering cards later than scheduled will be factored into the next interval calculation";
+> and "successive failures while cards are in learning do not result in further decreases to the card's ease."
+> — https://faqs.ankiweb.net/what-spaced-repetition-algorithm.html
+
+Verified in Anki source (`rslib/src/deckconfig/mod.rs`, `rslib/src/scheduler/states/*`):
+
+| Anki addition | Default | Where | Not in SM-2 proper? |
+|---|---|---|---|
+| **Learning steps** (sub-day, before graduation) | `learn_steps: vec![1.0, 10.0]` minutes | `deckconfig/mod.rs:96` | Yes — SM-2 has only `I(1)=1d`, `I(2)=6d` |
+| **Relearning steps** | `relearn_steps: vec![10.0]` minutes | `deckconfig/mod.rs:97` | Yes |
+| **Graduating interval** | `graduating_interval_good: 1`, `graduating_interval_easy: 4` days | `deckconfig/mod.rs:52-53` | Yes |
+| **Starting ease** | `initial_ease: 2.5` | `deckconfig/mod.rs:46` | Same value as SM-2, but configurable |
+| **Easy bonus** | `easy_multiplier: 1.3` | `deckconfig/mod.rs:47` | Yes — SM-2 has no per-grade multiplier |
+| **Hard interval** | `hard_multiplier: 1.2` (applied to *previous* interval, not `EF`) | `deckconfig/mod.rs:48` | Yes |
+| **New interval** (on lapse) | `lapse_multiplier: 0.0` | `deckconfig/mod.rs:49` | SM-2 resets to `I(1)`; Anki lets you retain a fraction. Manual recommends leaving it at 0 and cites SuperMemo on post-lapse stability: https://supermemo.guru/wiki/Post-lapse_stability |
+| **Interval modifier** | `interval_multiplier: 1.0` | `deckconfig/mod.rs:50` | Yes — a global retention knob; manual gives the SuperMemo-derived formula `log(desired retention%)/log(current retention%)` |
+| **Maximum interval** | `maximum_review_interval: 36_500` days (100 y) | `deckconfig/mod.rs:51` | Yes |
+| **Minimum lapse interval** | `minimum_lapse_interval: 1` day | `deckconfig/mod.rs:52` | Yes |
+| **Leech threshold / action** | `leech_threshold: 8`, `leech_action: TagOnly` | `deckconfig/mod.rs:60-61` | Yes — SM-2 has no lapse counter at all |
+| **Fuzz** | always on for intervals ≥ 2.5 d | `scheduler/states/fuzz.rs` | Yes |
+| **Late-review bonus** | `good = (ivl + days_late/2) * EF`, `easy = (ivl + days_late) * EF * easy_mult` | `states/review.rs:220-254` | Yes — SM-2 ignores lateness |
+| **Monotonicity guard** | hard < good < easy enforced; "Anki forces a new interval to be at least 1 day longer than it was previously" | `states/review.rs`, manual line ~698 | Yes |
+| **Easy Days / load balancer** | load balancer default **on** | `config/bool.rs:69` (`LoadBalancerEnabled` defaults `true`), `states/load_balancer.rs` | Yes |
+
+Leech behaviour, verbatim from the manual:
+
+> "Each time a review card 'lapses' (is failed while it is in review mode), a counter increases. When
+> this counter reaches 8, Anki tags the note as a leech and suspends the card. … If you keep failing
+> that card, Anki will continue to alert you about the leech periodically. These warnings occur at half
+> the initial leech threshold."
+> — https://github.com/ankitects/anki-manual/blob/main/src/leeches.md (rendered https://docs.ankiweb.net/leeches.html)
+
+Confirmed in code (`leech_threshold_met` in `states/review.rs:294`): fires at `lapses >= threshold`
+and every `ceil(threshold/2)` thereafter.
+
+Anki's fuzz (exact, from `rslib/src/scheduler/states/fuzz.rs`):
+
+```rust
+static FUZZ_RANGES: [FuzzRange; 3] = [
+    FuzzRange { start: 2.5,  end: 7.0,      factor: 0.15 },
+    FuzzRange { start: 7.0,  end: 20.0,     factor: 0.1  },
+    FuzzRange { start: 20.0, end: f32::MAX, factor: 0.05 },
+];
+fn fuzz_delta(interval: f32) -> f32 {
+    if interval < 2.5 { 0.0 } else {
+        FUZZ_RANGES.iter().fold(1.0, |delta, range|
+            delta + range.factor * (interval.min(range.end) - range.start).max(0.0))
+    }
+}
+```
+i.e. no fuzz below 2.5 days; otherwise ±(1 day + 0.15·days in 2.5–7 + 0.1·days in 7–20 + 0.05·days above 20).
+The manual's rationale: "Anki also applies a small amount of random 'fuzz' to prevent cards that were
+introduced at the same time and given the same ratings from sticking together and always coming up for
+review on the same day." — https://github.com/ankitects/anki-manual/blob/main/src/studying.md#fuzz-factor
+
+---
+
+## 4. FSRS: the memory model (DSR)
+
+Primary source: the FSRS algorithm wiki (now under `awesome-fsrs`;
+https://github.com/open-spaced-repetition/awesome-fsrs/wiki/The-Algorithm) and the ABC of FSRS
+(https://github.com/open-spaced-repetition/awesome-fsrs/wiki/ABC-of-FSRS), cross-checked against
+`fsrs-rs` source.
+
+> "FSRS springs from [DHP model](https://www.maimemo.com/paper/), which is based on the 'Three
+> Component Model of Memory'. … These three variables include:
+> * **Retrievability (R)**: The probability that the person can successfully recall a particular piece
+>   of information at a given moment. It depends on the time elapsed since the last review and the
+>   memory stability (S).
+> * **Stability (S)**: The time, in days, required for R to decrease from 100% to 90%. For example,
+>   S = 365 means that an entire year will pass before the probability of recalling a particular card
+>   drops to 90%.
+> * **Difficulty (D)**: The inherent complexity of a particular information. It represents how difficult
+>   it is to increase memory stability after a review. In FSRS, it affects how fast stability (and hence
+>   intervals) grows after each review."
+> — https://github.com/open-spaced-repetition/awesome-fsrs/wiki/ABC-of-FSRS
+
+> "In FSRS, these three values are collectively called the 'memory state'. The value of R changes daily,
+> while D and S change only after a card has been reviewed. Older versions of FSRS take into account only
+> the first review of the day, **FSRS-6 uses all reviews**. Each card has its own DSR values."
+> — ibid.
+
+`D ∈ [1, 10]`; in `fsrs-rs`: `S_MIN = 0.001`, `S_MAX = 36500.0`, `D_MIN = 1.0`, `D_MAX = 10.0`
+(`src/simulation.rs:58-61`).
+
+### Forgetting curve form: POWER function (not exponential)
+
+FSRS-6 uses a **power-law** forgetting curve with a *trainable* decay exponent `w20`. Wiki, verbatim:
+
+> "The forgetting curve's decay is trainable:
+> R(t,S) = (1 + factor · t/S)^(−w₂₀), where factor = 0.9^(−1/w₂₀) − 1 to ensure R(S,S) = 90%."
+> — https://github.com/open-spaced-repetition/awesome-fsrs/wiki/The-Algorithm
+
+Confirmed in `fsrs-rs/src/model.rs`:
+```rust
+pub(crate) fn power_forgetting_curve(w: &[f32], t: f32, s: f32) -> f32 {
+    let decay = -w[20];
+    let factor = (0.9f32.ln() / decay).exp() - 1.0;
+    (t / s * factor + 1.0).powf(decay)
+}
+pub(crate) fn next_interval(w: &[f32], stability: f32, desired_retention: f32) -> f32 {
+    let decay = -w[20];
+    let factor = (0.9f32.ln() / decay).exp() - 1.0;
+    stability / factor * (desired_retention.powf(1.0 / decay) - 1.0)
+}
+```
+History (from the same wiki page): FSRS v3 used the **exponential** `R = 0.9^(t/S)`; v4 used power with
+`DECAY = −1, FACTOR = 1/9`; FSRS-4.5 used `DECAY = −0.5, FACTOR = 19/81`; **FSRS-6 made the decay a
+trainable parameter `w20`** (default 0.1542). Note the sign convention differs between the wiki
+(`^(−w20)`) and the code (`decay = -w[20]`, then `.powf(decay)`) — they are the same thing.
+> "The new forgetting curve drops sharply before S and flatly after S." — wiki, FSRS-4.5 section.
+
+### Stability and difficulty updates (FSRS-6, verbatim from `fsrs-rs/src/model.rs`)
+
+```rust
+init_stability(w, rating)   = w[rating-1]                     // rating 1..4 -> w0..w3
+init_difficulty(w, rating)  = w[4] - exp(w[5] * (rating-1)) + 1.0
+
+linear_damping(dD, D)       = (10.0 - D) * dD / 9.0
+next_difficulty(w, D, G)    = D + linear_damping(-w[6] * (G - 3.0), D)
+mean_reversion(w, D')       = w[7] * (init_difficulty(w, 4) - D') + D'   // target = D0(Easy)
+
+// success (G >= 2), inter-day
+stability_after_success(w, S, D, R, G) =
+    S * ( exp(w[8]) * (11.0 - D) * S^(-w[9]) * (exp((1.0 - R) * w[10]) - 1.0)
+          * hard_penalty(w[15] if G==2 else 1) * easy_bonus(w[16] if G==4 else 1) + 1.0 )
+
+// failure (G == 1), inter-day  (post-lapse stability, capped)
+stability_after_failure(w, S, D, R) =
+    min( w[11] * D^(-w[12]) * ((S + 1.0)^w[13] - 1.0) * exp((1.0 - R) * w[14]),
+         S / exp(w[17] * w[18]) )
+
+// same-day / short-term (delta_t == 0)
+stability_short_term(w, S, G) =
+    S * { let sinc = exp(w[17] * (G - 3.0 + w[18])) * S^(-w[19]);
+          if G >= 2 { max(sinc, 1.0) } else { sinc } }
+```
+Driver (`fn step`): compute `R = power_forgetting_curve(w, delta_t, S)`; pick
+`stability_after_failure` if `G==1` else `stability_after_success`; **override with
+`stability_short_term` if `delta_t == 0`**; `D' = clamp(mean_reversion(next_difficulty(D,G)), 1, 10)`;
+on the very first review (`nth==0 && S==0`) use `init_stability`/`init_difficulty` instead;
+`G==0` (manual reschedule) leaves state untouched. Final `S` is clamped to `[0.001, 36500]`.
+
+Interpretive notes given on the wiki (still valid for the success formula): SInc decreases with D,
+decreases with S, increases as R decreases (spacing effect), and is always ≥ 1 for a successful
+review. — https://github.com/open-spaced-repetition/awesome-fsrs/wiki/The-Algorithm
+
+---
+
+## 5. FSRS parameters, optimisation, and the minimum-review threshold
+
+### Parameter count
+
+- **FSRS-6 has 21 trainable parameters.** Wiki: "This version uses 21 parameters." —
+  https://github.com/open-spaced-repetition/awesome-fsrs/wiki/The-Algorithm ; also
+  `fsrs-rs/src/inference.rs`: `pub static DEFAULT_PARAMETERS: [f32; 21]`.
+- Historical counts (srs-benchmark README): v1=7, v2=14, v3=13, v4=17, 4.5=17, FSRS-5=19, FSRS-6=21,
+  FSRS-7=35. — https://github.com/open-spaced-repetition/srs-benchmark
+
+### Default parameters (FSRS-6)
+
+```
+[0.212, 1.2931, 2.3065, 8.2956, 6.4133, 0.8334, 3.0194, 0.001, 1.8722, 0.1666,
+ 0.796, 1.4835, 0.0614, 0.2629, 1.6483, 0.6014, 1.8729, 0.5425, 0.0912, 0.0658, 0.1542]
+```
+Identical in the wiki (`## Default parameters`, FSRS-6 section) and in
+`fsrs-rs/src/inference.rs` (`DEFAULT_PARAMETERS`, with `w20 = FSRS6_DEFAULT_DECAY = 0.1542`).
+Doc comment in `fsrs-rs`: *"The default parameters. Fits the average person's learning habits."*
+
+Provenance of the defaults, verbatim:
+> "If a user doesn't have enough reviews yet, the default parameters are used instead. They have been
+> found by running the FSRS optimizer on **several hundred million reviews from ~10k users**. Even with
+> the default parameters, FSRS is better than SM-2 algorithm."
+> — https://github.com/open-spaced-repetition/awesome-fsrs/wiki/ABC-of-FSRS
+
+### What "optimisation" means
+
+> "The FSRS optimizer uses machine learning to learn your memory patterns and find parameters that best
+> fit your review history."
+> — Anki manual, `deck-options.md` (https://docs.ankiweb.net/deck-options.html#fsrs-parameters)
+
+> "When you click the Optimize button, FSRS will analyze your review history, and generate parameters that
+> are optimal for your memory and your cards."
+> — `ftl/core/deck-config.ftl:463`
+
+It is gradient-descent fitting of the 21 weights to minimise log-loss on the recall outcomes implied
+by the user's own review log (see `fsrs-rs/src/training.rs`, and
+https://github.com/open-spaced-repetition/awesome-fsrs/wiki/The-mechanism-of-optimization).
+Manual: "Do not change the parameters manually or copy them from someone else." Parameters and
+desired retention are **per-preset**; enabling FSRS at all is **global**.
+
+### MINIMUM number of reviews before optimisation is meaningful — the actual stated threshold
+
+This is the question where the historical answer and the current answer differ, so be careful:
+
+**Current official answer: there is no hard minimum since Anki 24.06.3.** Anki FSRS FAQ, verbatim:
+
+> Q: (do I need N reviews to optimise?) — "That was the case in earlier versions of Anki. In
+> **Anki 24.06.3** (and newer versions), the optimizer can be used with any number of reviews."
+> — https://faqs.ankiweb.net/frequently-asked-questions-about-fsrs.html
+
+Historical thresholds (for context, from fsrs4anki docs / older manual text, recovered via search —
+treat the exact version boundaries as **secondary**): **1000 reviews** in versions before Anki 24.04,
+**400 reviews** in Anki 24.04. The 400 figure still survives as a comment in current Anki source:
+
+> `/// Note this does not return an error if there are less than 400 items - the caller should instead
+> /// check the fsrs_items count in the return value.`
+> — `rslib/src/scheduler/fsrs/params.rs:78`, https://github.com/ankitects/anki/blob/main/rslib/src/scheduler/fsrs/params.rs
+
+Current Anki has **no numeric threshold in the UI**. The only guidance is qualitative, in the
+optional health check:
+
+> Common reasons why FSRS may not perform well include "**Low number of reviews (less than a few
+> hundred)** … Like any machine learning algorithm, FSRS needs data to learn from."
+> — Anki manual, `deck-options.md` (https://docs.ankiweb.net/deck-options.html#fsrs-parameters)
+
+Code behaviour: `Collection::compute_params` returns the *current* params unchanged if
+`fsrs_items == 0`; otherwise it trains on whatever it has (`rslib/src/scheduler/fsrs/params.rs`).
+The UI message when nothing is found is `deck-config-fsrs-params-no-reviews = No reviews found.…`
+(`ftl/core/deck-config.ftl:492`).
+
+Re-optimisation cadence, verbatim from the FAQ:
+> "Once per month should be more than enough. A more sophisticated rule is to optimize every time the
+> number of reviews doubles: after you did 100 reviews, then after 200, then after 400, etc."
+> — https://faqs.ankiweb.net/frequently-asked-questions-about-fsrs.html
+The manual says "once every month is sufficient."
+
+### Does FSRS work with ZERO history using defaults? Does it degrade gracefully?
+
+**Yes on both counts, and this is stated explicitly.**
+
+- `fsrs-rs`: `FSRS::new(&[])` is valid and substitutes `DEFAULT_PARAMETERS`
+  (`check_and_fill_parameters`, `src/model.rs:336`: `0 => DEFAULT_PARAMETERS.to_vec()`);
+  `impl Default for FSRS` = "parameters that fit the average person's learning habits".
+- Anki manual setup step: "Click the 'Optimize' button … If you see a message that says 'The FSRS
+  parameters currently appear to be optimal', that's fine." — i.e. defaults are a legitimate resting state.
+- Wiki: "Even with the default parameters, FSRS is better than SM-2 algorithm."
+  — https://github.com/open-spaced-repetition/awesome-fsrs/wiki/ABC-of-FSRS
+- Quantitatively, the benchmark reports `FSRS-7 default param.` (0 trainable params) at
+  log-loss 0.3629 vs optimised `FSRS-7` at 0.3437 and `FSRS-5` (19 optimised params) at 0.3560 —
+  i.e. default-parameter FSRS is worse than optimised FSRS but in the same league, and the degradation
+  is graceful. (The benchmark does not publish a `FSRS-6 default param.` row; the 0-parameter row is
+  for FSRS-7.) — https://github.com/open-spaced-repetition/srs-benchmark
+- Anki also has a `historical_retention` knob (default 0.9) used to fill gaps when review history is
+  missing: "When some of your review history is missing, FSRS needs to fill in the gaps. By default, it
+  will assume that when you did those old reviews, you remembered 90% of the material."
+  — `deck-options.md`, and `historical_retention: 0.9` in `rslib/src/deckconfig/mod.rs`.
+- When a card has *no* FSRS memory state but has SM-2 `ivl`/`factor`, FSRS converts them:
+  `S = Interval / IntervalModifier` and `D = 11 − (factor−1)/(e^{w8}·S^{−w9}·(e^{w10(1−R)}−1))`.
+  — https://github.com/open-spaced-repetition/fsrs4anki/wiki/How-does-the-scheduler-work%3F
+  (that wiki page is flagged as outdated for the *scheduler* mechanics but the conversion formulas are
+  the ones still described; treat as **weaker evidence** than the source code path
+  `rslib/src/scheduler/fsrs/memory_state.rs`.)
+
+---
+
+## 6. What a review log must record for FSRS (MOST IMPORTANT)
+
+### The model's actual input is minimal
+
+`fsrs-rs` trains and infers on `FSRSItem { reviews: Vec<FSRSReview> }` where a review is **just two
+fields**:
+
+```rust
+// fsrs-rs/src/dataset.rs
+pub struct FSRSReview {
+    /// 1 = Again, 2 = Hard, 3 = Good, 4 = Easy
+    pub rating: u32,
+    /// The number of days that passed. `delta_t` for item first(initial) review must be 0
+    pub delta_t: u32,
+}
+```
+An `FSRSItem` is the **whole ordered review history of one card**; for training, Anki emits one
+`FSRSItem` per review (a growing prefix of the card's history).
+— https://github.com/open-spaced-repetition/fsrs-rs/blob/main/src/dataset.rs
+
+Corroborated by the benchmark's "Input features" column: FSRS-6 / FSRS-rs are marked
+**`IL, G, SR`** = **i**nterval **l**engths (in days), **g**rades, **s**ame-day reviews. They do
+**not** use `AT` (answer time). And the FSRS FAQ says so explicitly:
+> "FSRS only uses interval lengths and grades."
+> — https://faqs.ankiweb.net/frequently-asked-questions-about-fsrs.html
+(Answer time is used only by "Compute minimum recommended retention", not by the memory model.)
+— https://github.com/open-spaced-repetition/srs-benchmark
+
+### But `delta_t` is *derived*, so the log must record enough to derive it
+
+Anki computes `delta_t` in whole days from revlog timestamps bucketed by the user's day cutoff:
+
+```rust
+// rslib/src/scheduler/fsrs/params.rs
+let delta_ts = iter::once(0).chain(entries.iter().tuple_windows().map(|(previous, current)| {
+    previous.days_elapsed(next_day_at) - current.days_elapsed(next_day_at)
+})).collect_vec();
+// where days_elapsed(next_day_at) = (next_day_at.elapsed_secs_since(self.id.as_secs()) / 86_400).max(0)
+```
+So: **timestamp per review + the day-cutoff/rollover configuration** ⇒ `delta_t`.
+
+### Anki's actual revlog row — the concrete field list to copy
+
+```rust
+// rslib/src/revlog/mod.rs
+pub struct RevlogEntry {
+    pub id: RevlogId,          // epoch MILLISECONDS of the review == the timestamp (also the PK)
+    pub cid: CardId,           // card id
+    pub usn: Usn,              // sync marker (not algorithmic)
+    pub button_chosen: u8,     // "ease": 1..4; 0 == manual rescheduling
+    pub interval: i32,         // new interval; positive = days, negative = seconds
+    pub last_interval: i32,    // previous interval; positive = days, negative = seconds
+    pub ease_factor: u32,      // SM-2 ease ×1000 (2500 = 250%). Under FSRS, difficulty normalised
+                               // to 100-1100 so that difficulty 0 is distinguishable from SM-2 learning
+    pub taken_millis: u32,     // answer duration in ms
+    pub review_kind: RevlogReviewKind, // 0 Learning, 1 Review, 2 Relearning, 3 Filtered, 4 Manual, 5 Rescheduled
+}
+```
+— https://github.com/ankitects/anki/blob/main/rslib/src/revlog/mod.rs
+
+Why each non-obvious field matters for FSRS fitting:
+- `review_kind` is load-bearing. Anki walks the history backwards to find the *last* `Learning` entry
+  (start of the current memory trace) and to detect `Manual` resets and filtered-deck "cramming":
+  `is_reset()` = `Manual` + `ease_factor == 0`; `is_cramming()` = `Filtered` + `ease_factor == 0`;
+  `has_rating_and_affects_scheduling()` filters out both. Entries before a reset are dropped.
+  (`rslib/src/revlog/mod.rs`, `rslib/src/scheduler/fsrs/params.rs::reviews_for_fsrs`)
+- `interval` / `last_interval` with their sign convention distinguish **intraday** (`|ivl| < 86400 s`)
+  from **interday** reviews: `let interday = entry.interval >= 1 || entry.interval <= -86400;`.
+- `button_chosen == 0` marks non-graded (manual) entries which must be excluded.
+- `ignore_revlogs_before` (a per-preset date) can exclude old history from fitting
+  (`ignore_revlogs_before_date` in `DeckConfigInner`).
+
+### The reference "minimal" log, per py-fsrs
+
+`py-fsrs` (v6.3.1, MIT) defines the log a client should keep as exactly:
+
+```python
+@dataclass
+class ReviewLog:
+    card_id: int
+    rating: Rating              # 1..4
+    review_datetime: datetime
+    review_duration: int | None # ms, optional; not used by the model
+```
+and the per-card state as:
+```python
+class Card:
+    card_id: int
+    state: State                # Learning / Review / Relearning
+    step: int | None            # index into learning/relearning steps
+    stability: float | None
+    difficulty: float | None
+    due: datetime
+    last_review: datetime | None
+```
+— https://github.com/open-spaced-repetition/py-fsrs/blob/main/fsrs/review_log.py ,
+  https://github.com/open-spaced-repetition/py-fsrs/blob/main/fsrs/card.py
+
+### The published research dataset schema (a good sanity check on "what to record")
+
+`open-spaced-repetition/anki-revlogs-10k` (727 M reviews, 10k users) exposes per review:
+`card_id`, `day_offset` (days since the user's first review), `rating` (1 again / 2 hard / 3 good /
+4 easy), `state` (0 new / 1 learning / 2 review / 3 relearning), `duration` (ms, 0–60000),
+`elapsed_days` (−1 for new), `elapsed_seconds` (−1 for new).
+— https://huggingface.co/datasets/open-spaced-repetition/anki-revlogs-10k
+
+### Recommendation for our own review log (synthesis, not a source claim)
+
+Record per review event: `card_id`, `reviewed_at` (absolute instant, ms + timezone offset),
+`rating` (1–4), `state_before` (new/learning/review/relearning), `scheduled_interval_before`
+(signed days/seconds or an explicit unit), `scheduled_due_before`, `duration_ms`, and an
+`event_kind` discriminator (graded review vs manual reschedule vs reset vs cram/preview).
+That is a strict superset of everything FSRS-6 and SM-2 need and it preserves the
+reset/cram/manual distinctions that Anki learned the hard way it needs.
+
+---
+
+## 7. Current FSRS version, status in Anki, licence
+
+### Version
+
+- **Shipped / production version is FSRS-6 (21 parameters).** `fsrs-rs` released version is **6.6.2**
+  (`Cargo.toml`, 2026-07-08); `py-fsrs` is **6.3.1**; the algorithm wiki's newest documented version is
+  FSRS-6. — https://github.com/open-spaced-repetition/fsrs-rs , https://github.com/open-spaced-repetition/py-fsrs ,
+  https://github.com/open-spaced-repetition/awesome-fsrs/wiki/The-Algorithm
+- **FSRS-7 exists but only in the research/benchmark repo as of 2026-07-26.** srs-benchmark README:
+  > "FSRS-7: the newest version. Unlike all previous versions, which have been designed to work with
+  > integer interval lengths, FSRS-7 has been designed to work with fractional interval lengths. It is
+  > the only version that can give realistic predictions of probability of recall for same-day reviews.
+  > The biggest change is that the forgetting curve now has 8 optimizable parameters and uses a rather
+  > complex formula."
+  > — https://github.com/open-spaced-repetition/srs-benchmark
+  It has **35** trainable parameters and beats FSRS-6/FSRS-rs on log-loss (0.3437 vs 0.3443). It is
+  **not** in `fsrs-rs`, not in `py-fsrs`, and not in Anki. The algorithm wiki has no FSRS-7 section yet,
+  so I have **no primary write-up of the FSRS-7 formulas** — see open questions.
+
+### Status in Anki: OPT-IN, not the default
+
+This contradicts a lot of secondary writing, so it is worth stating carefully. Verified two ways
+against Anki main @ `e10ce15` (2026-07-25):
+
+1. Manual, verbatim: "The Free Spaced Repetition Scheduler (FSRS) is **an alternative to Anki's legacy
+   SuperMemo 2 (SM-2) algorithm**." and the setup instruction "**Enable FSRS** under the 'FSRS' section,
+   at the bottom of the deck options page. FSRS can only be enabled globally; you cannot enable it for
+   some presets and disable it for others."
+   — https://docs.ankiweb.net/deck-options.html#fsrs
+2. Source: `BoolKey::Fsrs` is not in the list of keys that default to `true`, so it falls through to
+   `other => self.get_config_default(other)` = **false**
+   (`rslib/src/config/bool.rs:62-75`). The only places that set it true are unit tests
+   (`storage/sqlite.rs:682`, `scheduler/answering/mod.rs:710`). There is no code path that enables FSRS
+   for new collections.
+
+Availability, verbatim: "Ensure all of your Anki clients support FSRS. **Anki 23.10, AnkiMobile 23.10**,
+and AnkiWeb support it. **AnkiDroid supports it in 2.17+**." — https://docs.ankiweb.net/deck-options.html#fsrs
+Also: "As of Anki 23.10, Anki has two available algorithms." — https://faqs.ankiweb.net/what-spaced-repetition-algorithm.html
+
+FSRS version inside Anki: Anki main pins `fsrs = "6.6.1"` (`Cargo.toml` / `Cargo.lock`), and
+`DeckConfigInner` carries `fsrs_params_4`, `fsrs_params_5`, `fsrs_params_6` with `fsrs_params()`
+preferring the 6 field — so **Anki ships FSRS-6**. Latest Anki tags on the remote:
+stable **26.05**, betas **26.08b1 / 26.08b2** (`git ls-remote --tags ankitects/anki`).
+
+### Licences
+
+| Component | Licence | Source |
+|---|---|---|
+| `fsrs-rs` (the implementation Anki links) | **BSD-3-Clause** | `Cargo.toml` `license = "BSD-3-Clause"` + `LICENSE` ("BSD 3-Clause License, Copyright (c) 2023, Open Spaced Repetition") — https://github.com/open-spaced-repetition/fsrs-rs/blob/main/LICENSE |
+| `py-fsrs` | **MIT** | https://github.com/open-spaced-repetition/py-fsrs/blob/main/LICENSE |
+| `fsrs4anki` (the add-on/custom-scheduler project) | **MIT** | https://github.com/open-spaced-repetition/fsrs4anki/blob/main/LICENSE |
+| Anki itself | **AGPL-3.0-or-later** | file headers: "License: GNU AGPL, version 3 or later" |
+
+For a Rust project, `fsrs-rs` under BSD-3-Clause is the permissively-licensed reference
+implementation; Anki's AGPL applies to Anki's own scheduler code, not to `fsrs-rs`.
+
+---
+
+## 8. FSRS grade scale and lapse / relearning handling
+
+**Four buttons.** `fsrs-rs/src/dataset.rs` doc comment:
+> "Rating scale: 1 = Again (forgot anything you want to remember); 2 = Hard (remembered with
+> difficulty); 3 = Good (remembered correctly); 4 = Easy (remembered effortlessly)"
+
+Wiki symbol table: `G`: 1 `again`, 2 `hard`, 3 `good`, 4 `easy`.
+— https://github.com/open-spaced-repetition/awesome-fsrs/wiki/The-Algorithm
+
+Anki's user-facing definitions (`studying.md`):
+> **Again**: "your answer is incorrect or when you couldn't recall the answer … You'll typically use this
+> button about 5-20% of the time." **Hard**: "your answer is correct, but you had doubts about it or it
+> took a long time to recall." **Good**: "correct, but it took some mental effort … should be the most
+> commonly used button. You'll typically use this button about 80-95% of the time." **Easy**: "correct and
+> it took no mental effort."
+> — https://github.com/ankitects/anki-manual/blob/main/src/studying.md#answer-buttons
+
+**Hard is a PASSING grade.** This matters:
+> "FSRS can adapt to almost any habit, except for one: pressing 'Hard' instead of 'Again' when you forget
+> the information. When you press 'Hard', FSRS assumes you have recalled the information correctly
+> (though with hesitation and a lot of mental effort). If you press 'Hard' when you have failed to recall
+> the information, all intervals will be unreasonably high."
+> — https://docs.ankiweb.net/deck-options.html#fsrs
+Confirmed in code: `stability_after_failure` is used only when `rating == 1.0`; Hard takes the success
+branch with a `w[15]` "hard penalty" multiplier.
+
+**"Again" handling / lapses / relearning:**
+- The memory-model effect is `stability_after_failure` (post-lapse stability), **capped** at
+  `S / exp(w17·w18)` so a lapse cannot *increase* stability, and it depends on `D`, `S` and `R` —
+  not on a lapse counter. FSRS-6 has **no** `lapses` term in the model (FSRS v1 did; v2 onward dropped it).
+  — https://github.com/open-spaced-repetition/awesome-fsrs/wiki/The-Algorithm , `fsrs-rs/src/model.rs`
+- Anki still tracks `lapses` on the card and still applies **leech** tagging/suspension under FSRS
+  (`Card.lapses`, `leech_threshold: 8` — these are Anki bookkeeping, not FSRS).
+- Relearning steps under FSRS: Anki puts a failed card through the configured relearning steps, and
+  "In FSRS, fuzz is applied when the card leaves the relearning stage"
+  (`rslib/src/scheduler/states/review.rs:81-83`). Anki recommends relearning steps < 1 day, and in the
+  latest version FSRS can own short-term scheduling entirely if the steps field is left empty
+  ("This is an experimental feature.") — https://docs.ankiweb.net/deck-options.html#learning-and-relearning-steps
+- FSRS-6 also models **same-day** re-reviews (`delta_t == 0` ⇒ `stability_short_term`), which is what
+  makes intraday relearning meaningful to the model. FSRS-5 introduced same-day data; FSRS-6 improved
+  the formula. — srs-benchmark README, ABC of FSRS.
+
+---
+
+## 9. CROSS-CUTTING: is scheduling state re-derivable by replaying (card, timestamp, grade)?
+
+Short answer: **for the pure algorithms, yes. For Anki's implementations of them, not quite — and the
+things that break it are specific and enumerable.**
+
+### 9a. SM-2 proper — fully replayable
+
+`(EF, n, I)` are a deterministic function of the ordered grade sequence alone. Intervals are whole
+days and lateness is ignored, so you don't even need timestamps to recover `EF`/`n`/`I` — only to know
+whether a review happened. Fully replayable. (https://super-memory.com/english/ol/sm2.htm)
+
+### 9b. FSRS-6 core model — fully replayable
+
+`FSRSReview { rating, delta_t }` is the entire input; `fn step` is pure and deterministic (no RNG, no
+global state). `FSRS::forward_reviews(reviews, starting_state)` recomputes `(S, D)` from a review
+sequence — this is exactly how Anki recomputes memory state after re-optimisation
+(`rslib/src/scheduler/fsrs/memory_state.rs`). So `(card, timestamp, grade)` + parameters + desired
+retention ⇒ `(S, D)` and the ideal interval, deterministically.
+Caveat: **the parameters themselves are part of the state.** Re-optimising changes every card's
+computed `(S, D)`. If you want bit-exact reproduction you must version/pin the parameter vector
+alongside the log.
+
+### 9c. Things that break pure replay in practice
+
+| Breaker | Replayable? | Detail / source |
+|---|---|---|
+| **Anki's fuzz** | **YES — deterministic** | Anki seeds the RNG from card identity, not wall-clock: `get_fuzz_seed_for_id_and_reps(card_id, reps) = Some(card_id + reps)`, then `StdRng::seed_from_u64(seed).random_range(0.0..1.0)` (`rslib/src/scheduler/answering/mod.rs:669-691`). Given `card_id` and the rep count you reproduce the fuzz exactly. (It is also disabled entirely under test.) |
+| **py-fsrs fuzz** | **NO** | `_get_fuzzed_interval` calls bare `random()` with no seed (`py-fsrs/fsrs/scheduler.py:846`). Unseeded ⇒ unreproducible. Can be disabled via `enable_fuzzing=False`. |
+| **Load balancer** | **NO — depends on the whole collection** | Enabled **by default** (`BoolKey::LoadBalancerEnabled` is in the defaults-to-`true` list, `rslib/src/config/bool.rs:69`). `find_interval` picks a day inside the fuzz range weighted by `(1/cards_due)^2 * (1/target_interval)`, using `days_by_preset` — the count of *other* cards due on each candidate day (`rslib/src/scheduler/states/load_balancer.rs:192-265`). The chosen interval therefore depends on the due-date distribution of every other card in the preset at answer time. Not recoverable from one card's log. |
+| **Easy Days** | **NO — depends on calendar weekday** | `calculate_easy_days_modifiers(easy_days_load, &weekdays, &review_counts)` with `interval_to_weekday(...)` — the result depends on which weekday each candidate due date lands on, i.e. on absolute calendar position. Manual: "After the interval is calculated, it will be adjusted by a small amount to change the due date. This feature works with both FSRS and the legacy SM-2 algorithm." (https://docs.ankiweb.net/deck-options.html#easy-days) |
+| **Sibling avoidance** | **NO — depends on sibling cards** | `calculate_sibling_modifiers(..., note_id)` biases against days that already hold a card from the same note (`load_balancer.rs:247`). Cross-card coupling. |
+| **Day cutoff / rollover hour / timezone** | **Partially — must be recorded** | Everything day-shaped goes through `timing.days_elapsed` / `next_day_at`. `delta_t` for FSRS is `previous.days_elapsed(next_day_at) - current.days_elapsed(next_day_at)` (`fsrs/params.rs`), and SM-2 `elapsed_days` is `interval - (due - timing.days_elapsed)` (`answering/current.rs:104-106`). Change the rollover hour or the timezone and the *same* absolute timestamps bucket into different days ⇒ different `delta_t` ⇒ different state. So the rollover hour and the timezone in force must be part of the log or a pinned config. |
+| **Lateness (SM-2, Anki)** | **YES if timestamps are logged** | `days_late = elapsed_days - scheduled_days`, feeding `good = (ivl + days_late/2)*EF`. Deterministic from timestamps + prior scheduled interval — but it does mean SM-2-in-Anki needs *timestamps*, not just grade order. |
+| **Non-graded / manual events** | **Must be in the log** | `Manual` (set due date), `Rescheduled`, `Filtered`+cram entries, and `is_reset()` truncate or alter the effective history (`reviews_for_fsrs` walks backwards and drops everything before a reset). If your log only records graded reviews you cannot reproduce state after a user has manually set a due date or reset a card. |
+| **Configuration drift** | **Must be versioned** | Interval modifier, easy/hard/lapse multipliers, max/min intervals, learning & relearning steps, leech threshold, desired retention, `historical_retention`, `ignore_revlogs_before_date`, and the FSRS parameter vector are all *current-config* inputs to the interval, not stored per event. A replay under today's config will not reproduce yesterday's scheduling if any of them changed. |
+| **Wall-clock at answer time beyond the timestamp** | No hidden dependence found | The scheduler's only clock inputs are `self.now` and `timing` (both derivable from the logged instant + rollover config). Answer duration (`taken_millis`) is recorded but does not feed either algorithm. |
+| **Queue composition (which cards you see today)** | Not part of card state | Daily limits, gathering/sorting order, burying etc. determine *whether* a card was answered on a given day. Since your log records what actually happened, this doesn't affect replay of state — but it does mean you cannot replay a *simulation* of what would have happened. |
+
+### 9d. Practical conclusion for a replayable design
+
+You get pure, exact replay from `(card_id, timestamp, grade)` if you (a) pin/version the parameter
+vector and the per-preset config, (b) record the rollover hour + timezone (or store `delta_t`
+alongside), (c) log manual/reset/cram events as first-class entries, and (d) either disable load
+balancing / easy-days / sibling avoidance, or persist the *chosen* interval on each event so the
+non-replayable choice is recorded as data rather than recomputed. Fuzz specifically is *not* a problem
+if you copy Anki's approach of seeding from `(card_id, reps)`.
+
+---
+
+## Unverified / open questions
+
+1. **FSRS-7 formulas.** I could not find a primary write-up. The `awesome-fsrs` wiki "The Algorithm"
+   page documents only up to FSRS-6; the srs-benchmark README describes FSRS-7 qualitatively (35
+   params, dual power-law forgetting curve, fractional intervals, 8 curve parameters) and DeepWiki
+   summaries mention "a weighted combination of two power-law curves" — **DeepWiki is a generated
+   secondary source and I did not treat it as authoritative.** To pin the formulas you'd need to read
+   `srs-benchmark/src/*` directly. Nothing suggests FSRS-7 will land in Anki soon.
+2. **"FSRS-7 is likely the final version."** This appeared in a search-result summary attributed to the
+   OSR team; I could not locate the primary statement. Treat as unverified.
+3. **Historical minimum-review thresholds (1000 → 400 → none).** The *current* "no minimum since Anki
+   24.06.3" is primary (Anki FSRS FAQ). The 1000-and-400 history came from search summaries of
+   `fsrs4anki` docs/older manual revisions; the `400` figure is corroborated by a live comment in Anki
+   source, but the exact version boundaries are **secondary**.
+4. **Whether any Anki fork/client defaults FSRS on.** I verified only Anki desktop main
+   (`BoolKey::Fsrs` ⇒ false). AnkiDroid/AnkiMobile defaults were not checked; AnkiDroid reads the same
+   collection config so it should inherit, but I did not verify their new-profile behaviour.
+5. **supermemo.guru pages** (e.g. `Algorithm_SM-2`, `Post-lapse_stability`) return **HTTP 403** to
+   automated fetches, so I could not quote Woźniak's own retrospective criticism of SM-2. The Anki
+   manual cites `supermemo.guru/wiki/Post-lapse_stability` for the claim that preserving part of the
+   interval after a lapse is counter-productive; I am relaying Anki's citation, not the page itself.
+6. **Anki 26.05/26.08 release notes.** GitHub API rate-limited; I read tags via `git ls-remote` and the
+   source tree at `main` (2026-07-25) instead. I did not read per-release changelogs, so if FSRS default-on
+   is announced in an unreleased beta I would have missed it — though the `main` branch code says otherwise.
+7. **`FSRS-6 default param.` benchmark row** does not exist; the 0-parameter benchmark row is FSRS-7.
+   So the exact quantitative penalty for running FSRS-**6** with defaults instead of optimised params
+   is not directly published in that table.
+8. **Anki's SM-2 "early review" path** (`passing_early_review_intervals`) is flagged in-source as
+   needing rework ("FIXME: this needs reworking in the future; it overly penalizes reviews done shortly
+   before the due date"). Behaviour is deterministic and replayable but is an acknowledged wart.

--- a/docs/research/scheduling-algorithms/appendix-b-leitner-boxes.md
+++ b/docs/research/scheduling-algorithms/appendix-b-leitner-boxes.md
@@ -1,0 +1,398 @@
+# Leitner boxes as a UI over an interval scheduler — verifiable facts
+
+Research date: 2026-07-26. Every claim below carries a URL. Claims are tagged:
+
+- **[PRIMARY]** — traceable to the originator (Leitner's book, a peer-reviewed paper, official app docs, or the actual source code).
+- **[SECONDARY]** — a reputable third party asserting something about a primary source.
+- **[FOLKLORE]** — widely repeated, no traceable origin found.
+
+A hard caveat up front: **I could not read Leitner's book *So lernt man lernen* itself.** Every statement about "the original Leitner system" below is therefore at best [SECONDARY]. This matters more than it sounds — see §1.4.
+
+---
+
+## 1. The Leitner system as published
+
+### 1.1 Bibliographic facts (mostly settled, with one inconsistency)
+
+- Sebastian Leitner, German science journalist. The book was first published **1972** under the title *Lernen lernen*; the current title is *So lernt man lernen*. German Wikipedia: "Dieses System entwickelte Sebastian Leitner, der es 1972 in seinem Schlüsselwerk *Lernen lernen* vorstellte (heutiger Titel: *So lernt man lernen*)" — https://de.wikipedia.org/wiki/Lernkartei **[SECONDARY]**
+- English Wikipedia agrees on 1972 and cites the 18th edition: "Leitner, Sebastian. *So lernt man lernen*. Freiburg: Verlag Herder, 2011 (18th ed.), ISBN 978-3-451-05060-2" — https://en.wikipedia.org/wiki/Leitner_system **[SECONDARY]**
+- **Inconsistency in the academic literature.** Settles & Meeder (ACL 2016) cite "S. Leitner. 1972. *So lernt man lernen*. Angewandte…" — https://research.duolingo.com/papers/settles.acl16.pdf. Reddy et al. (KDD 2016) cite "[13] S. Leitner. *So lernt man lernen*. Herder, 1974." **and in prose say the system was "first introduced in 1970"** — https://www.cs.cornell.edu/~tj/publications/reddy_etal_16c.pdf. So three different years (1970 / 1972 / 1974) appear in citable literature. Nobody cites a page number. **[unresolved]**
+
+### 1.2 What the original actually specified: box *capacity*, not per-box intervals
+
+This is the single most important finding for the ticket.
+
+English Wikipedia, *Method* section: *"In Leitner's original method, published in his book So lernt man Lernen (How to learn to learn), the schedule of repetition was governed by the size of the partitions in the learning box. These were 1, 2, 5, 8, and 14 cm. Only when a partition became full was the learner to review some of the cards it contained, moving them forward or back depending on whether they remembered them."* — https://en.wikipedia.org/wiki/Leitner_system **[SECONDARY]**
+
+Reading that literally:
+
+- **5 partitions**, sized 1 / 2 / 5 / 8 / 14 cm.
+- The trigger for review is **"partition became full"** — i.e. a *capacity/backpressure* rule, not a per-card due date and not a per-box interval.
+- The intervals are therefore **emergent**, not specified: how long a card waits depends on how fast that partition fills, which depends on deck size, study rate, and the learner's accuracy.
+- The promotion/demotion rule is stated only as "moving them forward or back depending on whether they remembered them" — a **binary** signal, and the direction on failure ("back") is not pinned down to "back one" vs "back to box 1" in this sentence.
+
+**Caveat on the sourcing of this passage:** I checked the article's wikitext (https://en.wikipedia.org/w/index.php?title=Leitner_system&action=raw). The 1/2/5/8/14 cm sentence has **no inline `<ref>` of its own**. The article carries a `{{More citations needed}}` maintenance tag dated April 2023, and its lead-sentence footnotes are Medium posts and study blogs, not Leitner. The Leitner book appears once as a bare citation supporting the lead. So even this most-specific claim about the original is not properly footnoted.
+
+### 1.3 The German-language description: proportional sampling, again not intervals
+
+German Wikipedia's worked example is a **rate-based / sampling** scheduler, which is a different mechanism again from both "per-box interval" and "partition full":
+
+> "Ein Beispiel: drei Fächer: 1, 2 und 3. […] Die Karten im Fach 1 werden täglich wiederholt, die Karten im Fach 2 jeden zweiten Tag und die Karten im Fach 3 jeden vierten. **Für jeden Lernvorgang werden somit alle Karten aus Fach 1, die Hälfte der Karten aus Fach 2 und ein Viertel der Karten aus Fach 3 zufällig ausgewählt.**"
+> ("For each study session, all cards from box 1, half the cards from box 2, and a quarter of the cards from box 3 are selected at random.")
+> — https://de.wikipedia.org/wiki/Lernkartei **[SECONDARY]**
+
+Other details from the same source:
+
+- Demotion is **to box 1**, not one step back: "War die Lösung bei erster Vorlage nicht bekannt, so wandert sie nicht in das jeweils nächste, sondern wieder ganz nach vorne in Fach 1."
+- Promotion requires being correct **on first presentation** in the session; within-session repeats until mastered do not earn promotion: "Damit eine Karteikarte in das nächste Fach wandert, muss der Kandidat somit die Antwort bei erstmaliger Vorlage wissen."
+- Only a **minimum session gap** is specified, no per-box interval: "sollte zwischen den Abfragen genügend Zeit (mindestens 8 Stunden) liegen."
+- Boxes should have **increasing physical capacity**, box 1 being small (20–30 cards): "Das erste Fach ist sehr klein (20 bis 30 Karteikarten), das zweite Fach schon etwas größer…" — consistent with §1.2's capacity-driven reading.
+- Like the English article, none of this is inline-cited to Leitner. The German article's *Literatur* section lists Leitner's 18th ed. plus four German study-technique books (Beelich & Schwede 1979; Born & Oehler 2011; Fenske 2002 — *Bio-logisch lernen mit der 5-Fächer-Lernbox*; Krueger 2014, pp. 153–163). Krueger is the only one cited inline anywhere.
+
+### 1.4 Bottom line on Q1
+
+**Answer to "does the original specify review scheduling, or only the box-shuffling rule?": the best available evidence says it specifies neither a per-box interval nor a per-card due date.** It specifies (a) a box-shuffling rule on a binary signal, and (b) a *capacity* rule that indirectly determines when a box gets reviewed. Timing is a consequence of physical geometry, not a schedule.
+
+**What is folklore:** the near-universal "Box 1 = 1 day, Box 2 = 2 days, Box 3 = 4 days…" table presented as "the Leitner system". I found **no source that traces any specific day-interval table to Leitner's book.** See §5 for where those numbers actually come from.
+
+Piotr Woźniak (SuperMemo) makes the same point from the other direction:
+
+> "Leitner system is often incorrectly labelled as a spaced repetition system. Spaced repetition is computational in nature. Without an effort to compute optimum intervals, prioritized review is little more than an inefficient form of scheduling… In other words, Leitner is a hit-or-miss system."
+> — https://supermemo.guru/wiki/Leitner_system **[PRIMARY as Woźniak's opinion]** (403s to plain fetchers; retrieved with a browser user-agent; page last edited 2018-11-21)
+
+---
+
+## 2. Is there an established mapping of a 4-point grade scale (Again/Hard/Good/Easy) onto box movement?
+
+**Plain finding: no. I found no published, peer-reviewed, or standards-like specification mapping a 4-point grade scale onto Leitner box movement. Every graded-Leitner scheme I found in the wild is ad-hoc, and the schemes contradict each other.**
+
+The evidence is not merely absence — it is that the serious literature *deliberately collapses grades to binary* when it touches Leitner.
+
+### 2.1 The main academic Leitner paper explicitly discretises grades to binary
+
+Reddy, Labutov, Banerjee & Joachims, **"Unbounded Human Learning: Optimal Scheduling for Spaced Repetition", KDD 2016** — https://arxiv.org/abs/1602.07032, PDF: https://www.cs.cornell.edu/~tj/publications/reddy_etal_16c.pdf. This is the "Leitner queue network" paper; code at https://github.com/rddy/leitnerq. **[PRIMARY]**
+
+Their data source *had* a 6-point scale and they threw it away:
+
+> "Each interaction is annotated with a grade (on a 0-5 scale) that was self-reported by the user. Users are instructed by the Mnemosyne software to use a grade of 0 or 1 to indicate that they did not recall the item, and a grade of 2-5 to indicate that they did recall the item, with higher grades implying easier recall. **We discretize grades into binary outcomes, where recall ≜ grade ≥ 2**, and observe an overall recall rate of 0.56 in the data."
+
+Their box-movement rule is strictly binary and **one step in each direction**:
+
+> "It comprises of a series of n decks of flashcards, indexed as {1, 2, …, n}, where new items enter the system at deck 1, and items upon being reviewed either move up a deck if recalled correctly or down if forgotten. […] items in deck 1 are reflected (i.e., they remain in deck 1 if they are incorrectly reviewed), and all items which are recalled at deck n (which in experiments we take as n = 5), are declared to be 'mastered' and removed from the system."
+
+Transition probabilities (their Eqn. 3-region):
+
+```
+P[k → k+1]              = exp(−θ · D_k / k)
+P[k → max{k−1, 1}]      = 1 − exp(−θ · D_k / k)
+```
+
+and they are blunt that per-box timing has never had a principled basis:
+
+> "Existing schemes for assigning review frequencies to different decks are based on heuristics that are not founded on any formal reasoning, and hence, have no optimality guarantees."
+> "…all existing schemes for assigning review frequencies to decks in the Leitner system, and in fact, in all other spaced repetition systems, are based on heuristics with no formal optimality guarantees."
+
+Note also that their model is a **rate/queue** model, not a due-date model: each deck *k* gets a service rate μ_k, new items arrive at rate λ_ext, subject to λ_ext + Σμ_k ≤ U (the learner's review-frequency budget). It is a Jackson network of M/M/1 queues. This is much closer to §1.3's proportional-sampling picture than to "box 3 = 7 days".
+
+### 2.2 The other academic treatment also treats Leitner as binary
+
+Settles & Meeder, **"A Trainable Spaced Repetition Model for Language Learning", ACL 2016** (Duolingo) — https://research.duolingo.com/papers/settles.acl16.pdf **[PRIMARY]**. They formalise Leitner as a special case of their half-life regression, with a **two-feature binary** parameterisation:
+
+> "Analyzing the Leitner variant from Figure 3 is even simpler: this corresponds to Θ = {x⊕ : 1, x⊖ : -1}, where x⊕ is the number of past correct responses (i.e., doubling the interval), and x⊖ is the number of incorrect responses (i.e., halving the interval)."
+
+Combined with their ĥ_Θ = 2^(Θ·x), this yields **half-life = 2^(#correct − #incorrect)**. That is a genuinely published box↔interval identity — but the "box" is a *net binary streak*, with no place for Hard or Easy. (See §4.3, this is one of only two principled box↔interval derivations I found.)
+
+### 2.3 Open-source: the reference implementation is binary by design
+
+`open-spaced-repetition/leitner-box` (v0.3.0), from the same org that maintains FSRS — https://github.com/open-spaced-repetition/leitner-box. Source read directly: `src/leitner_box/leitner_box.py`. **[PRIMARY]**
+
+```python
+class Rating(IntEnum):
+    Fail = 0
+    Pass = 1
+```
+
+```python
+if rating == Rating.Fail:
+    if self.on_fail == "first_box":
+        new_card.box = 1
+    elif self.on_fail == "prev_box" and new_card.box > 1:
+        new_card.box -= 1
+elif rating == Rating.Pass:
+    if new_card.box < len(self.box_intervals):
+        new_card.box += 1
+```
+
+- Two ratings only. **No 4-point scale.**
+- `on_fail` is a *configuration choice* between `"first_box"` (default) and `"prev_box"` — i.e. the org shipping the canonical implementation treats the demotion rule as genuinely undetermined by the source material.
+- Defaults `box_intervals = [1, 2, 7]` (3 boxes), with a hard constraint `if box_intervals[0] != 1: raise ValueError("Box 1 must have an interval of 1 day. This may change in future versions.")`.
+
+`nickhnsn/facharbeit-spaced-repetition` — a Java library that implements **Leitner, SM-2, and FSRS side by side** — https://github.com/nickhnsn/facharbeit-spaced-repetition. Its `FSRSRating` is a 4-point enum, but `LeitnerAlgorithm.java` takes `boolean retrievalSuccessful` and nothing else: **[PRIMARY]**
+
+```java
+if (this.retrievalSuccessful) { boxId = this.boxId + 1; }   // else boxId stays 1 (reset)
+switch (boxId) { case 1: interval = 1; case 2: 3; case 3: 7; case 4: 30; case 5: 30*6; }
+```
+
+This is telling: an author who had a 4-point scale available for FSRS **chose to keep Leitner binary**.
+
+### 2.4 Ad-hoc graded schemes that do exist in shipped/public code — and they disagree
+
+Found via GitHub code search. These are the closest thing to a "graded Leitner spec" and they are mutually incompatible:
+
+**(a) `yro7/panglot-public`, `core/src/srs/leitner.rs`** — https://github.com/yro7/panglot-public/blob/main/core/src/srs/leitner.rs **[PRIMARY]**
+
+```rust
+const BOX_INTERVALS: [f64; 5] = [1.0, 3.0, 7.0, 14.0, 30.0];
+const fn next_box(current: usize, rating: Rating) -> usize {
+    match rating {
+        Rating::Again => 0,
+        Rating::Hard  => if current == 0 { 0 } else { current - 1 },
+        Rating::Good | Rating::Easy => if current >= MAX_BOX { MAX_BOX } else { current + 1 },
+    }
+}
+```
+Again → box 0 (reset). Hard → **demote one**. Good and Easy → **identical**, promote one. So Easy carries zero information, and Hard is treated as a failure.
+
+**(b) `SouichiroTsujimoto/xanki`, `docs/spec/leitner-study.md`** — https://github.com/SouichiroTsujimoto/xanki/blob/main/docs/spec/leitner-study.md **[PRIMARY, written spec]** (Japanese). Review-phase behaviour:
+
+| grade | box effect | interval used |
+|---|---|---|
+| `0` もう一度 / Again | → relearning phase | relearning step[0] |
+| `1` 難しい / Hard | **box unchanged** (箱据置) | `hardInterval` (default 1 day) |
+| `2` 正解 / Good | **box +1** (max 5) | that box's review interval |
+| `3` 簡単 / Easy | **box +2** (max 5) | that box's review interval |
+
+Review boxes are 2..5 with intervals **1, 3, 7, 21 days**; graduating interval 1 day, easy interval 4 days.
+
+So across two real graded implementations: Hard is *demote one* in (a) and *no change* in (b); Easy is *identical to Good* in (a) and *skip a box* in (b). There is no convention.
+
+**(c) Note what xanki's own spec says about showing the box to users:**
+
+> "開発者向け用語 **Box**（`review_state.box`）。**UI では非表示。**"
+> ("**Box** is a developer-facing term (`review_state.box`). **Not displayed in the UI.**")
+
+An app that literally names its feature "Leitner" keeps the box number internal and shows Anki-style next-interval labels on the buttons instead. That is a data point directly on the ticket's question.
+
+### 2.5 Woźniak's "Normalized Leitner" — a spec, but still binary
+
+The one attempt I found at a normative Leitner spec: **[PRIMARY as Woźniak's own definition]** — https://supermemo.guru/wiki/Leitner_system
+
+> "I use the term **Normalized Leitner** to refer to a software implementation with adjustments that can turn Leitner into a spaced repetition system […] This is how Normalized Leitner works:
+> - boxes are associated with intervals
+> - first interval is set to Int1, and successive intervals are set to Int1*power(E-Factor, repetition)
+> - **failure results in reversal to box #1 (violating this principle worsens the performance of the algorithm)**
+> - target recall at review claim is set to 90%"
+
+Binary again, and it explicitly calls one-step-back demotion wrong — the page captions the one-step-back diagram as *"An **incorrect mutation** of the Leitner system where failed answers are moved back by one box only… This variant was in use in Duolingo for a while."*
+
+### 2.6 Verdict on Q2
+
+**Graded Leitner is always ad-hoc.** There is no published mapping. The two academic treatments of Leitner (KDD'16, ACL'16) both reduce recall to binary; the reference open-source implementation is binary and treats even the *demotion* rule as a config flag; and the two graded implementations I found in real code disagree with each other on both Hard and Easy. If this project defines an Again/Hard/Good/Easy → box mapping, it is inventing one, and should say so.
+
+---
+
+## 3. What shipped apps that display boxes/levels actually do underneath
+
+| App | Does it display a box/level? | Underlying scheduler | Display ↔ state relationship |
+|---|---|---|---|
+| **Anki** | No box. Shows *states* (New/Learning/Review/Relearn) and Young/Mature. | SM-2 variant, or FSRS (DSR) since 23.10 | Young/Mature is a **pure interval threshold** (21 days). States are real. |
+| **Mnemosyne** | No box; 0–5 grades | SM-2 variant | n/a |
+| **WaniKani** | **Yes — 9 named SRS stages, prominently** | Stage → fixed interval table | **1:1. The stage *is* the scheduling state.** |
+| **Duolingo (2012–2016)** | Yes — 4-bar strength meters | Leitner variant (one-step-back) | Projection; **documented as failing** (§4.1) |
+| **Duolingo (2016–~2018)** | Yes — same 4-bar meters | Half-life regression (HLR) | Bars = predicted recall probability |
+| **Duolingo (2018+)** | Crowns / levels | progress counter | **Decoupled from memory state by design** |
+| **Memrise** | Levels/"words to review" | Fixed interval ladder, reset on failure | Effectively a box system |
+| **Quizlet Learn** | "rounds"/progress | ML "Learning Assistant Platform" | Not documented in enough detail |
+
+### 3.1 Anki — no box metaphor, but its *learning steps* are a box ladder
+
+Card states, quoted verbatim from https://docs.ankiweb.net/getting-started.html **[PRIMARY]**:
+
+- **New** — "Cards that you have downloaded or created yourself, but have never studied before."
+- **Learning** — "Cards that were seen for the first time recently, and are still being learned."
+- **Review** — "Cards that you have finished learning. These cards will be shown again after their delay (interval) has elapsed."
+- **Relearn** — "Cards that you forgot in the review stage. These cards are returned to the relearning state to be learned again."
+- **Young** — "A young card is one that has an interval of less than 21 days."
+- **Mature** — "A mature card is one that has an interval of 21 days or greater."
+
+Two important observations:
+
+1. **These four states are a *phase* machine, not a box ladder.** A card in `Review` has a continuous real-valued interval; there is no integer level. So the box metaphor is *absent* from Anki's review phase.
+2. **But Anki's learning/relearning steps *are* a box ladder** — and Anki documents exactly the Leitner shuffle over them: *"Each time you click **Good** during review, the card moves to the next step. Each time you click **Again**, the card goes back to the first step."* — https://docs.ankiweb.net/deck-options.html **[PRIMARY]**. Example steps given as `1m 10m 1d`. Graduating interval = "the number of days to wait before showing a card again, after the Good button is used on the final learning step"; easy interval is the analogue for Easy. So Anki *is* a bounded Leitner ladder during learning and a continuous interval scheduler afterwards.
+3. **Young/Mature is the cleanest real-world example of a discrete display derived from an interval by threshold** (< 21 d / ≥ 21 d). If you want a precedent for "cosmetic level = f(interval)", this is it, and note that Anki chose **two** buckets and a single, documented, fixed threshold.
+
+Anki's answer buttons, from https://docs.ankiweb.net/studying.html **[PRIMARY]**: Again (1) incorrect/not recalled; Hard (2) correct but with doubt or slow; Good (3) correct with moderate effort, "the most commonly used button"; Easy (4) correct with no mental effort.
+
+Algorithms, from https://faqs.ankiweb.net/what-spaced-repetition-algorithm **[PRIMARY]**: *"As of Anki 23.10, Anki has two available algorithms. The first one is based on the SuperMemo 2 algorithm, and the second one is called FSRS."* FSRS tracks Retrievability, Stability, Difficulty. Anki's SM-2 "uses 4 response choices rather than 6".
+
+### 3.2 Mnemosyne — 0–5 grades, SM-2 variant, no boxes
+
+Mnemosyne's own principles page: the algorithm "is very similar to SM2 used in one of the early versions of SuperMemo, with some modifications that deal with early and late repetitions, and also to add a small, healthy dose of randomness to the intervals" — https://mnemosyne-proj.org/principles.php **[PRIMARY]**. Grades 0–5; 0/1 = not memorised, 2–5 = recalled with increasing ease (https://mnemosyne-proj.org/help/getting-started.php). No box display. Mnemosyne's logs are the dataset Reddy et al. binarised (§2.1).
+
+### 3.3 WaniKani — the strongest counter-example: the box display IS the state
+
+WaniKani shows every item's stage by name, and the stage is the scheduling state. From https://knowledge.wanikani.com/wanikani/srs-stages/ **[PRIMARY]**:
+
+| Stage | Name | Interval to next |
+|---|---|---|
+| 1–4 | Apprentice 1–4 | 4 h → 8 h → 1 d → 2 d |
+| 5–6 | Guru 1–2 | 1 w → 2 w |
+| 7 | Master | 1 mo |
+| 8 | Enlightened | 4 mo |
+| 9 | Burned | — |
+
+(Levels 1–2 use accelerated Apprentice timings: 2 h → 4 h → 8 h → 1 d.)
+
+Promotion: *"If you get an item correct, it goes up one stage."*
+
+Demotion is **multi-step and formula-driven** — the closest thing to a "graded" box rule I found in any shipped app:
+
+> `new_srs_stage = current_srs_stage - (incorrect_adjustment_count * srs_penalty_factor)`
+> where `incorrect_adjustment_count` is "the number of incorrect times you have answered divided by two and rounded up", and `srs_penalty_factor` is "2 if the current_srs_stage is at or above 5. Otherwise it is 1".
+
+Note the grade here is **error count within a review**, not a self-reported Again/Hard/Good/Easy. Still binary per answer; the "grading" emerges from repeated wrong answers.
+
+The API confirms the display and the state are the same field: `srs_stage` (0–9), `starting_srs_stage` (1–8), `ending_srs_stage` (1–9), with a `spaced_repetition_system` object whose `stages[]` carry `position` + `interval` + `interval_unit`, and positions 0 (unlocking) and 9 (burning) having null intervals — https://docs.api.wanikani.com/20170710/#reviews **[PRIMARY]**. *"If the review goes well and there are no wrong answers, we move the assignment up to the next SRS stage."*
+
+**Takeaway for the ticket: WaniKani's stage display is trustworthy precisely because the stage is the primary state and the interval is derived from it — the opposite direction to what the ticket contemplates.**
+
+### 3.4 Duolingo — the documented case of boxes over an interval model going wrong
+
+See §4.1. Sequence, all from the ACL 2016 paper unless noted:
+
+1. **At launch**: *"when it first launched, Duolingo used a variant similar to Figure 3 to manage skill meter decay and practice."* Figure 3 is captioned "The Leitner System for flashcards" with boxes **1 → 2 → 4 → 8 → 16**.
+2. **Strength meters were a projection of a probability, not of a box**: *"Duolingo uses strength meters to visualize the student model… These meters represent the average probability that the student can, at any moment, correctly recall a random target word from the lessons in this skill… At four bars, the skill is 'golden' and considered fresh in the student's memory. At fewer bars, the skill has grown stale and may need practice. […] As time passes, strength meters continuously update and decay until the student practices."* **4 discrete bars over a continuous probability.**
+3. **2016**: replaced by HLR (half-life regression). *"The underlying spaced repetition algorithm determined strength meter values in the skill tree… as well as the ranking of target words for practice sessions, but otherwise the two conditions were identical."* A/B test over six weeks, just under 1 million students.
+4. **~2018**: crowns replaced strength bars *and the decay mechanic entirely*. Reported by TechCrunch at launch — https://techcrunch.com/2018/04/09/duolingo-adds-new-language-exercises-and-revamps-its-leveling-system — and described on the Duolingo Wiki: the crown system "replaced both the fluency badge and the skill deterioration mechanic" — https://duolingo.fandom.com/wiki/Legendary **[SECONDARY]**. In other words, **Duolingo's resolution to the "level vs. memory state" tension was to stop claiming the level means memory state at all.**
+
+I did **not** find an official Duolingo engineering post documenting the crown scheduler; TechCrunch and the fan wiki are the best available and are secondary.
+
+### 3.5 Memrise — an interval ladder with reset-to-first on failure
+
+Memrise's own help centre: *"The review schedule is as follows: 4 hours > 12 hours > 24 hours > 6 days > 12 days > 48 days > 96 days > 6 months. If you get an item wrong during a review, it will be moved back to the first interval i.e. it will be up for review in 4 hours."* Max interval 180 days — https://memrise.zendesk.com/hc/en-us/articles/360015889057-How-does-the-spaced-repetition-system-work **[PRIMARY]**
+
+This is a **binary, 8-rung, reset-to-box-1 Leitner system with explicit per-rung intervals** — functionally exactly what folklore calls "the Leitner system", published by a shipping app. Note it is **not** a doubling ladder (4 h, 12 h, 24 h, 6 d, 12 d, 48 d, 96 d, 6 mo).
+
+### 3.6 Quizlet Learn — not documented at the needed resolution
+
+Quizlet says Learn is "powered by the Learning Assistant Platform", uses ML over "millions of anonymous study sessions", and that its Long-Term Learning "uses a standard spaced repetition algorithm, similar to SuperMemo or Anki" — https://quizlet.com/blog/spaced-repetition-for-all-cognitive-science-meets-big-data-in-a-procrastinating-world and https://quizlet.com/content/science-behind-spaced-repetition **[PRIMARY but vague]**. **I could not verify how any Quizlet progress display maps to scheduling state.** Treat as unknown.
+
+---
+
+## 4. The failure mode
+
+### 4.1 The best-documented case: Duolingo's Leitner-based strength meters, in a peer-reviewed paper
+
+Settles & Meeder, ACL 2016, §3.2 — https://research.duolingo.com/papers/settles.acl16.pdf **[PRIMARY]**:
+
+> "Several electronic flashcard programs use the Leitner system to schedule practice, by organizing items into 'virtual' boxes. In fact, when it first launched, Duolingo used a variant similar to Figure 3 to manage skill meter decay and practice. **The present research was motivated by the need for a more accurate model, in response to student complaints that the Leitner-based skill meters did not adequately reflect what they had learned.**"
+
+This is close to the exact failure the ticket is worried about, stated by the vendor in a refereed venue: a discrete box display over a memory model produced a *user-visible dishonesty* strong enough to motivate replacing the scheduler. Quantitatively, in their Table, **Leitner's MAE on predicted recall was 0.235 vs HLR's 0.128** — the display was ~2× further off the truth under Leitner.
+
+The paper also documents the *second-order* failure after they fixed it — worth noting because it is the same class of bug:
+
+> "Several months later, active students pointed out that particular words or skills would decay rapidly, regardless of how often they practiced. Upon closer investigation, these complaints could be traced to lexeme tag features with highly negative weights in the HLR model… This implied that some feature-based overfitting had occurred, despite the L2 regularization term."
+
+And a behavioural finding that speaks to *why* a lying meter is expensive: users optimised for the meter rather than for learning.
+
+> "Prior to the experiment, many students claimed that they would practice instead of learning new material 'just to keep the tree gold,' but that practice sessions did not review what they thought they needed most."
+
+### 4.2 Displayed number decreasing while the underlying state improved — Anki/FSRS
+
+Anki forum thread "Interval goes down without any parameter changes (i.e. no optimization)" — https://forums.ankiweb.net/t/interval-goes-down-without-any-parameter-changes-i-e-no-optimization/67995 **[PRIMARY, dev/maintainer discussion]** (Dec 2025 – Jan 2026). User reported intervals *decreasing* after pressing **Good**. Maintainer explanation quoted in-thread:
+
+> "Anki forces [good_interval >= hard_interval+1]… Due to fuzz, a 3 day interval can be 2, 3 or 4 days. In this case, it was 4 days. After 4 days elapsed, the hard interval was still 2 days, and the good interval was 3 days, which was less than 4 days."
+
+Mechanism: **interval fuzz + minimum-gap constraints mean the *displayed* number is not a monotone function of the *underlying* memory state.** Any box number derived from the displayed interval will inherit this non-monotonicity and can go *down* after a successful review. This is a concrete, cited instance of the exact bug class.
+
+Related and worth knowing: Anki's own manual notes Hard **increases** the interval (it is a passing grade), which users routinely read as counter-intuitive. There is an add-on, `lambdadog/passfail2` — https://github.com/lambdadog/passfail2 — whose whole premise is reducing Anki to two buttons because the 4-point scale confuses people. **[PRIMARY as an artifact; I did not read its full rationale]**
+
+### 4.3 Is there a principled way to derive a box number from an interval or from stability?
+
+Yes — I found **three** defensible derivations, and they disagree on the functional form. That disagreement is itself the finding.
+
+**(a) Logarithmic, from Duolingo's HLR (published).** Leitner as an HLR special case gives half-life `h = 2^(x⊕ − x⊖)`; identifying box `b` with the net streak `x⊕ − x⊖` gives
+
+```
+interval(b) ∝ 2^b        ⟺        b = log2(half_life)
+```
+— https://research.duolingo.com/papers/settles.acl16.pdf, Appendix A.2. **[PRIMARY]**
+
+**(b) Logarithmic with a tunable base, from Woźniak's Normalized Leitner.** "first interval is set to Int1, and successive intervals are set to Int1*power(E-Factor, repetition)" gives
+
+```
+b = log_EF(interval / Int1)      (Int1 = 1, EF = 2 ⇒ boxes at 1, 2, 4, 8, 16 days)
+```
+— https://supermemo.guru/wiki/Leitner_system. Woźniak also states the conceptual mapping directly: **"Well known cards are shunted to boxes corresponding with higher memory stability."** So box ≈ a discretisation of **stability**, not of interval — which is the more robust choice, since stability is monotone under successful review whereas the scheduled interval is not (§4.2). **[PRIMARY as Woźniak's definition]**
+
+**(c) Linear, from Reddy et al.'s empirically-fitted memory model.** They tested three candidates for memory strength *s* on 859,591 Mnemosyne interactions (2,742 users, 88,892 items) and found:
+
+> "**Leitner position vs. number of reviews:** Setting the memory strength s to be equal to the Leitner deck position q_ij performs better than setting it to be proportional to the number of past reviews n_ij, which in turn is better than using a constant s."
+
+giving `P[recall] = exp(−θ · d_i / q_i)`. Solving for the interval at a fixed target retention p*:
+
+```
+d = q · (−ln p*) / θ        ⟹        interval ∝ box  (LINEAR)
+⟺  box = θ · interval / (−ln p*)
+```
+— https://www.cs.cornell.edu/~tj/publications/reddy_etal_16c.pdf. **[PRIMARY]**
+
+So the only *empirically fitted* box↔interval relationship I found is **linear**, while the two hand-picked/normative ones are **exponential**. The same paper also found deck position is a *better* memory-strength proxy than raw review count, which is a genuine argument that a box number carries real information — just not the information the doubling folklore assumes.
+
+**(d) The interval-threshold approach, as actually shipped.** Anki's Young/Mature split at a 21-day interval — https://docs.ankiweb.net/getting-started.html. Two buckets, one documented threshold. **[PRIMARY]**
+
+### 4.4 What I could NOT find
+
+- **No issue thread or dev discussion I could cite where a *box/level* display specifically was called "a lie" or "misleading" in an open-source SRS.** I searched GitHub (repo + code search via `gh api search/*`), Anki forums, and general web. The Duolingo ACL paper (§4.1) is the only first-party documentation of the box-display-is-wrong complaint that I could verify. **Absence of evidence here may just reflect that few open-source apps ship a box UI over an interval scheduler** — the largest Leitner repos on GitHub are tiny (see §5.3) and xanki deliberately hides its box (§2.4c).
+- **No documented case of "card shown in a high box that is actually due immediately."** The closest verified thing is §4.2 (displayed interval decreasing after a pass). The mechanism is plausible for a derived box number but I did not find it reported for a box UI specifically.
+
+---
+
+## 5. Box-count and interval conventions in practice — and where the numbers come from
+
+### 5.1 The doubling table 1-2-4-8-16 is **Mace (1932), not Leitner**
+
+Woźniak, on his Normalized Leitner boxes at Int1=1, EF=2: *"This would associate boxes with intervals: 1, 2, 4, 8, and 16 days (i.e. **as in the schedule suggested in C.A. Mace book of 1932**)."* — https://supermemo.guru/wiki/Leitner_system **[PRIMARY as attribution]**
+
+Corroborated by SuperMemo's history article: *"In 1932, C. A. Mace hinted on the efficient learning methods in his book 'The psychology of study'. He mentioned 'active rehearsal' and 'repetitive revisions' that should be spaced in gradually increasing intervals, roughly **'intervals of one day, two days, four days, eight days, and so on'**."* — https://www.supermemo.com/en/blog/the-true-history-of-spaced-repetition **[SECONDARY re: Mace]**
+
+Note the same page **does not mention Leitner at all**. Duolingo's Figure 3 ("The Leitner System for flashcards") uses exactly 1-2-4-8-16 — https://research.duolingo.com/papers/settles.acl16.pdf — which means the canonical academic *illustration* of "the Leitner system" is in fact Mace's 1932 schedule. **This is the clearest documented case of Leitner folklore: an interval table universally attributed to Leitner that traces to a different author, 40 years earlier.**
+
+### 5.2 Box counts and intervals actually used, with provenance
+
+| Boxes | Intervals | Source | Provenance quality |
+|---|---|---|---|
+| 5 partitions | 1, 2, 5, 8, 14 **cm** (capacity, not days) | https://en.wikipedia.org/wiki/Leitner_system | closest to Leitner; **uncited** in the article |
+| 3 | 1 d, every 2nd d, every 4th d — with proportional sampling (all / ½ / ¼) | https://de.wikipedia.org/wiki/Lernkartei | uncited |
+| 3 | 1 d, 3 d, 5 d | https://en.wikipedia.org/wiki/Leitner_system, "Three boxes" section | **uncited**; section has no refs at all |
+| 12 (10 rotating + Current + Retired) | session-number scheduling, "identical to a 5-box Leitner system" | https://en.wikipedia.org/wiki/Leitner_system, "Proficiency levels" | **uncited**; unattributed scheme |
+| 5 | 1, 2, 4, 8, 16 d | Mace 1932 via Woźniak & Duolingo Fig. 3 | **traceable to Mace, not Leitner** |
+| 3 (default) | **1, 2, 7 d** | `open-spaced-repetition/leitner-box` code | PRIMARY code, but numbers are the author's choice |
+| 5 | **1, 3, 7, 30, 180 d** | `nickhnsn/facharbeit-spaced-repetition`, `LeitnerAlgorithm.java` | PRIMARY code, author's choice |
+| 5 | **1, 3, 7, 14, 30 d** | `yro7/panglot-public`, `leitner.rs` | PRIMARY code, author's choice |
+| 5 (boxes 2–5 for review) | **1, 3, 7, 21 d** + steps 1 m/10 m | `SouichiroTsujimoto/xanki` spec | PRIMARY spec, author's choice |
+| 8 | **4 h, 12 h, 24 h, 6 d, 12 d, 48 d, 96 d, 6 mo** (cap 180 d) | https://memrise.zendesk.com/hc/en-us/articles/360015889057-How-does-the-spaced-repetition-system-work | PRIMARY, shipped |
+| 9 | **4 h, 8 h, 1 d, 2 d, 1 w, 2 w, 1 mo, 4 mo, burned** | https://knowledge.wanikani.com/wanikani/srs-stages/ | PRIMARY, shipped |
+| n = 5 (in experiments) | rate-based μ_k, no fixed intervals | Reddy et al. KDD'16 | PRIMARY, peer-reviewed |
+| 2 (display only) | threshold at 21 d | https://docs.ankiweb.net/getting-started.html | PRIMARY, shipped |
+
+**Conclusion for Q5: there is no canonical box count and no canonical interval table.** 3, 5, 8, 9, and 12 all appear. Every day-interval table I found is either (i) an implementer's arbitrary choice, (ii) Mace's 1932 doubling schedule mis-attributed to Leitner, or (iii) uncited Wikipedia prose. **5 boxes** is the most defensible count if you want a nod to the original, on the strength of the 1/2/5/8/14 cm partition claim and Reddy et al. taking n = 5 "in experiments"; note that Woźniak-referenced German literature also markets a "5-Fächer-Lernbox" (Fenske, *Bio-logisch lernen mit der 5-Fächer-Lernbox*, AOL-Verlag 2002, listed at https://de.wikipedia.org/wiki/Lernkartei).
+
+### 5.3 Scale check on the open-source Leitner ecosystem
+
+Via `gh api search/repositories q='leitner spaced repetition stars:>20'`: only **two** repos clear 20 stars — `rddy/leitnerq` (32★, the KDD paper's code) and `nickhnsn/facharbeit-spaced-repetition` (29★). A `q='leitner box flashcards'` search returns a long tail of 0–8★ projects (`RezaGooner/Leitner-Box` 8★, `mohamad-mgn/Leitner-Box` 3★, `Tobi-De/leerming` 3★, `FarzamTP/Leitner` 2★, `paulreece/Leitner-Flashcards` "4 boxes", `riccardo-montanari/flashcard-leitner` "5 box", etc.). **There is no widely-adopted open-source Leitner app whose scheduling decisions carry authority.** Anything you copy from that tail is one person's guess.
+
+---
+
+## 6. Unverified / open questions
+
+1. **Leitner's book itself — unread.** I could not obtain *So lernt man lernen* in any edition. Everything in §1 is second-hand. In particular I could **not** verify: (a) whether the 1/2/5/8/14 cm partition sizes are actually in the book; (b) whether Leitner states *any* day-interval; (c) whether Leitner's demotion rule is "back one" or "back to box 1"; (d) whether he even says five boxes. **If this decision matters, someone should read the book.** ISBN 978-3-451-05060-2 (18th ed., Herder 2011).
+2. **Publication year is genuinely disputed in citable literature**: 1970 (Reddy et al. prose), 1972 (both Wikipedias, Settles & Meeder), 1974 (Reddy et al. reference list). Unresolved.
+3. **Duolingo strength-bar → probability threshold mapping: NOT documented.** The ACL paper says the bars "represent the average probability that the student can… correctly recall a random target word" and that four bars = golden. It gives **no formula or thresholds** for how a probability becomes 1/2/3/4 bars. ⚠️ **A first automated read of the PDF produced a formula `strength = min(1, −0.5/ln(p)·c)`; I re-extracted the PDF text with `pdftotext` and confirmed that string does not appear in the paper. It was a hallucination. Do not use it.**
+4. **Duolingo's post-2018 crown scheduler is undocumented by Duolingo.** I have only TechCrunch and a fan wiki for "crowns replaced the decay mechanic". No official engineering description found. Also flagged (fan wiki, unverified) that the crown system itself was changed again around Oct–Nov 2022.
+5. **Quizlet Learn:** cannot verify any mapping from its progress display to scheduling state. Their published descriptions are marketing-level.
+6. **No cited example found of "high box, actually due now."** §4.2 gives the mechanism (fuzz + minimum-gap constraints break monotonicity of the displayed interval) but I found no report of it manifesting through a box UI. Consider this a predicted, not observed, failure.
+7. **The linear vs. exponential box↔interval discrepancy (§4.3) is unreconciled.** Reddy et al.'s empirical fit says interval ∝ box; Mace/Woźniak/Duolingo-Fig-3 folklore says interval ∝ 2^box. I found no paper that addresses this contradiction. Reddy et al.'s fit is on Mnemosyne (SM-2) logs, where deck position was *reconstructed*, not native — that may be a confound, but I could not confirm how they derived `q_ij` for a system with no decks.
+8. **`supermemo.guru` returns HTTP 403 to plain fetchers.** All Woźniak quotes above were retrieved with `curl -A "Mozilla/5.0 …"`. Page last edited 2018-11-21; permalink oldid=12663.
+9. **GitHub code search coverage is partial** (it indexes a subset of repos and the default-branch only). Some of the `search/code` hits for graded-Leitner specs are in small, possibly AI-assisted repos; I read the two most substantive (`panglot-public`, `xanki`) directly and quote their actual code/spec, but their *authority* is nil — they are evidence that graded Leitner is invented per-project, not evidence of a convention.

--- a/docs/research/scheduling-algorithms/appendix-c-rust-crates.md
+++ b/docs/research/scheduling-algorithms/appendix-c-rust-crates.md
@@ -1,0 +1,643 @@
+# Rust crate landscape: spaced-repetition scheduling algorithms
+
+Research date: **2026-07-26**. All version/download/licence data pulled live from the
+crates.io JSON API; commit recency and dependents from the GitHub API; build results from
+locally executed `cargo build` / `cargo check` (Rust 1.97.0, cargo 1.97.0).
+
+No files in the leitner-app working tree were modified. Build experiments were run in
+throwaway crates under `/tmp/wasmtest` and `/tmp/andtest`.
+
+---
+
+## 0. Headline facts (the two that change the decision)
+
+1. **`fsrs` no longer depends on `burn` (or any ML/tensor framework) at runtime.**
+   `burn` was demoted to a `[dev-dependencies]` entry in
+   [PR #411](https://github.com/open-spaced-repetition/fsrs-rs/pull/411)
+   ("Speed up FSRS inference, evaluation, and training without production Burn dependency",
+   merged 2026-06-04, commit `ca31a0d`). First published version without `burn` as a normal
+   dependency is **6.3.0** (2026-06-04); 6.2.0 and earlier still had it. Verified per-version
+   via `https://crates.io/api/v1/crates/fsrs/<v>/dependencies`.
+   The 21-parameter model, inference and gradient-based training are now hand-written over
+   `ndarray` (`src/analytic.rs`, `src/training.rs`).
+
+2. **`fsrs` 6.6.1 compiles for both `wasm32-unknown-unknown` and `aarch64-linux-android`,
+   including the parameter-training path.** Verified by building locally (details in §1.6).
+   A release `cdylib` exposing *both* `next_states` and `compute_parameters`, built with
+   `opt-level="z"`, `lto=true`, `strip=true`, `panic="abort"`, is **164 KB of `.wasm`**
+   (pre-`wasm-opt`, pre-gzip).
+
+---
+
+## Fact table
+
+| crate | latest version | release date | downloads (total / last 90d) | licence (SPDX as published) | maintenance status |
+|---|---|---|---|---|---|
+| [`fsrs`](https://crates.io/crates/fsrs) | **6.6.1** | 2026-06-09 | 339,191 / 51,424 | `BSD-3-Clause` | **Actively maintained.** 29 commits in last 90d, 58 in last 365d. Anki depends on it. |
+| [`rs-fsrs`](https://crates.io/crates/rs-fsrs) | 1.2.1 | 2024-10-28 | 13,663 / 6,622 | MIT (`license-file`, so crates.io shows `non-standard`) | Repo alive (commits to 2026-06-23) but **no crates.io release in 21 months**. Scheduler only, no optimiser. |
+| [`fsrsrs`](https://crates.io/crates/fsrsrs) | 1.1.0 | 2025-01-05 | 3,884 / 27 | `non-standard` | No repository field. 152 LOC. Effectively abandoned. |
+| [`sm-2`](https://crates.io/crates/sm-2) | 0.2.0 | 2025-08-18 | 1,366 / 24 | `MIT` | Dormant since 2025-08-18. 199 LOC, 1 GitHub star. Same org as fsrs-rs. |
+| [`srs-sm2`](https://crates.io/crates/srs-sm2) | 0.1.1 | 2026-07-21 | 48 / 48 | `MIT OR Apache-2.0` (GitHub detects only Apache-2.0) | **5 days old.** 0 stars, 155 LOC, `no_std`. Unproven. |
+| [`spaced-rs`](https://crates.io/crates/spaced-rs) | 0.3.1 | 2022-08-28 | 6,072 / 19 | **`GPL-3.0-only`** | Abandoned (4 years). ⚠️ copyleft |
+| [`memo_rs`](https://crates.io/crates/memo_rs) | 1.0.0 | 2023-04-09 | 1,491 / 7 | `MIT` | Abandoned. 95 LOC, single release. |
+| [`sra`](https://crates.io/crates/sra) | 0.1.0 | 2021-08-23 | 2,389 / 81 | `MIT OR Apache-2.0` | Abandoned (5 years). 139 LOC. |
+| [`spaced-repetition`](https://crates.io/crates/spaced-repetition) | 1.1.0 | 2022-04-16 | 2,800 / 15 | `BSD-2-Clause` | Abandoned. 734 LOC. |
+| [`spaced-repetition-rs`](https://crates.io/crates/spaced-repetition-rs) | 0.1.0 | 2022-02-19 | 1,600 / 8 | `BSD-2-Clause` | Abandoned; superseded by `spaced-repetition` (same author). |
+| [`ebirsu`](https://crates.io/crates/ebirsu) | 0.2.0 | 2023-08-17 | 4,113 / 15 | **`GPL-3.0-or-later`** | Abandoned. 478 LOC. ⚠️ copyleft |
+| [`fitts`](https://crates.io/crates/fitts) | 0.2.1 | 2025-12-28 | 1,455 / 12 | `MIT OR Apache-2.0` | Low activity. Fitts'-Law difficulty + SM-2 intervals. 1,021 LOC. |
+| [`learnforge-core`](https://crates.io/crates/learnforge-core) | 0.1.0 | 2026-06-19 | 18 / 18 | `MIT` | Single release, 1 month old. Claims WASM-portable BKT + SM-2. Unproven. |
+| [`ebisu`](https://crates.io/crates/ebisu) | 0.0.0 | 2022-01-24 | 1,628 / 7 | `Unlicense` | **Empty name squat — 0 lines of code, 828-byte crate.** |
+| [`anki`](https://crates.io/crates/anki) | 0.0.1 | 2019-12-31 | 2,143 / 14 | `AGPL-3.0-or-later` | **Placeholder — 0 LOC.** Description: "This crate is currently only available through the GitHub repo." |
+| `leitner` | — | — | — | — | **Does not exist on crates.io** (404). No Leitner-box crate found by any search. |
+
+---
+
+## 1. `fsrs` (repo: `open-spaced-repetition/fsrs-rs`)
+
+### 1.1 Identity, version, licence
+
+- crates.io name is **`fsrs`**, not `fsrs-rs` (`fsrs-rs` and `fsrs-optimizer` are 404 on crates.io).
+  <https://crates.io/api/v1/crates/fsrs>
+- Latest published: **6.6.1**, published **2026-06-09T06:24:14Z** by `asukaminato0721`.
+  Checksum `b8a99ea3dec9af37c9ed3835463ff6820a578a0026a8e370b4c1c0db48dfab3f`, crate size 126,197 bytes, edition **2024**.
+- Repo `main` branch already carries `version = "6.6.2"` (unpublished at time of research).
+- **Licence: `BSD-3-Clause`** — consistent on crates.io (every version back to 1.0.0) and in
+  the GitHub licence detection. Permissive, no copyleft.
+- Total downloads **339,191**; last-90-day downloads **51,424**. 73 published versions since 2024-01-27.
+- docs.rs builds successfully: <https://docs.rs/crate/fsrs/latest> returns HTTP 200.
+
+### 1.2 Maintenance status
+
+<https://api.github.com/repos/open-spaced-repetition/fsrs-rs>
+
+- 398 stars, 42 forks, created 2023-08-16, `pushed_at` **2026-07-20**, **not archived**.
+- **4 open issues** and **4 open PRs** (GitHub's `open_issues_count: 8` combines both).
+- Commit volume: **29 commits in the last 90 days**, **58 in the last 365 days**.
+  Latest commit on `main`: `87c9a28`, 2026-07-08, "Bump the non-breaking group with 2 updates (#431)".
+- Substantive (non-dependabot) work in June/July 2026 includes: #411 burn removal, #419
+  "Speed up compute_parameters without SIMD", #420 "Expose training hyperparameters",
+  #421 "Support card IDs in time-series evaluation", #424 "Skip validation during parameter
+  training", #433 "Fix Cost ADR seed isolation".
+- Dependabot is configured and active — dependency bumps land within days.
+
+### 1.3 Anki dependency (strong maintenance evidence) — CONFIRMED
+
+Anki's workspace manifest pins the published crate:
+
+`https://raw.githubusercontent.com/ankitects/anki/main/Cargo.toml`
+```toml
+[workspace.dependencies.fsrs]
+version = "6.6.1"
+# git = "https://github.com/open-spaced-repetition/fsrs-rs.git"
+# path = "../open-spaced-repetition/fsrs-rs"
+```
+
+`rslib/Cargo.toml` line 66: `fsrs.workspace = true`.
+`Cargo.lock` line 1404 confirms `name = "fsrs"`, `version = "6.6.1"`,
+`source = "registry+https://github.com/rust-lang/crates.io-index"` with the same checksum as
+the crates.io release. Anki consumes the *published crate*, not a git pin — so releases are
+production-exercised.
+
+Note: only **5 reverse dependencies** are recorded on crates.io
+(`flashy`, plus others pinning `^1`, `^1.3.4`, `^5.2.0`, `^6.6.1`). Anki itself is not
+published to crates.io, so this number massively understates real-world usage.
+
+### 1.4 Public API surface (read from `src/` at commit `87c9a28`)
+
+Everything below is re-exported from the crate root (`src/lib.rs`). Modules are private;
+`Model<B: Backend>` and the `burn` batcher types are `#[cfg(test)]`-gated and **not** public.
+
+**Review-history item type** — `src/dataset.rs`:
+```rust
+pub struct FSRSItem {
+    pub reviews: Vec<FSRSReview>,   // chronological; one FSRSItem per review, carrying its own prefix
+}
+
+pub struct FSRSReview {
+    pub rating: u32,   // 1=Again 2=Hard 3=Good 4=Easy
+    pub delta_t: u32,  // days since previous review; MUST be 0 for the first review
+}
+```
+Both derive `Debug, Clone, Deserialize, Serialize, PartialEq, Eq` (`FSRSReview` also `Copy`).
+`FSRSItem::long_term_review_cnt() -> usize` is public. Also public: `filter_outlier(...)`.
+
+**Memory-state type** — `src/inference.rs`:
+```rust
+pub struct MemoryState {   // Debug, PartialEq, Clone, Copy, Serialize  (note: NOT Deserialize)
+    pub stability: f32,
+    pub difficulty: f32,
+}
+```
+
+**The main handle** — `src/model.rs`:
+```rust
+pub struct FSRS { parameters: [f32; 21] }   // that is the entire struct: 84 bytes, no backend, no device
+impl FSRS { pub fn new(parameters: &Parameters) -> Result<Self> }  // &[] => defaults
+impl Default for FSRS                                              // DEFAULT_PARAMETERS
+pub fn check_and_fill_parameters(parameters: &Parameters) -> Result<Vec<f32>, FSRSError>
+pub type Parameters = [f32];                                       // always length 21
+pub static DEFAULT_PARAMETERS: [f32; 21];
+pub const FSRS5_DEFAULT_DECAY: f32 = 0.5;
+pub const FSRS6_DEFAULT_DECAY: f32 = 0.1542;
+```
+
+**(a) Scheduling / next intervals** — `src/inference.rs`:
+```rust
+impl FSRS {
+    pub fn next_states(
+        &self,
+        current_memory_state: Option<MemoryState>,  // None = new card
+        desired_retention: f32,
+        days_elapsed: u32,
+    ) -> Result<NextStates>;
+
+    pub fn next_interval(
+        &self,
+        stability: Option<f32>,     // None => init stability from rating
+        desired_retention: f32,
+        rating: u32,
+    ) -> f32;                        // note: infallible, returns f32 days (fractional)
+}
+
+pub struct NextStates { pub again: ItemState, pub hard: ItemState, pub good: ItemState, pub easy: ItemState }
+pub struct ItemState  { pub memory: MemoryState, pub interval: f32 }
+
+pub fn current_retrievability(state: MemoryState, days_elapsed: f32, decay: f32) -> f32;
+```
+
+**(b) Optimising / training parameters from history** — `src/training.rs`:
+```rust
+pub fn compute_parameters(input: ComputeParametersInput) -> Result<Vec<f32>>;   // free function, not a method
+
+pub struct ComputeParametersInput {
+    pub train_set: Vec<FSRSItem>,
+    pub card_ids: Option<Vec<i64>>,
+    pub progress: Option<Arc<Mutex<CombinedProgressState>>>,
+    pub enable_short_term: bool,                  // default true
+    pub num_relearning_steps: Option<usize>,
+    pub training_config: Option<TrainingConfig>,
+}
+impl Default for ComputeParametersInput { .. }
+
+pub struct TrainingConfig {                       // Default: 5 epochs, batch 512, seed 2023,
+    pub num_epochs: usize,                        //          lr 4e-2, max_seq_len 256, gamma 1.0
+    pub batch_size: usize,
+    pub seed: u64,
+    pub learning_rate: f64,
+    pub max_seq_len: usize,
+    pub gamma: f64,
+}
+
+pub struct CombinedProgressState { .. }           // new_shared() -> Arc<Mutex<Self>>, current(), total(), finished()
+pub fn benchmark(..) -> ..;                       // testing/quick-validation counterpart; panics instead of Err
+```
+
+**(c) Memory state from a review sequence** — `src/inference.rs`:
+```rust
+impl FSRS {
+    pub fn memory_state(&self, item: FSRSItem, starting_state: Option<MemoryState>) -> Result<MemoryState>;
+    pub fn memory_state_batch(&self, items: Vec<FSRSItem>, starting_states: Vec<Option<MemoryState>>) -> Result<Vec<MemoryState>>;
+    pub fn historical_memory_states(&self, item: FSRSItem, starting_state: Option<MemoryState>) -> Result<Vec<MemoryState>>;
+    pub fn historical_memory_state_batch(&self, items: Vec<FSRSItem>, starting_states: Option<Vec<Option<MemoryState>>>) -> Result<Vec<Vec<MemoryState>>>;
+
+    /// SM-2 → FSRS migration path for cards with truncated history
+    pub fn memory_state_from_sm2(&self, ease_factor: f32, interval: f32, sm2_retention: f32) -> Result<MemoryState>;
+}
+```
+
+**Evaluation:**
+```rust
+impl FSRS {
+    pub fn evaluate<F: FnMut(ItemProgress) -> bool>(&self, items: Vec<FSRSItem>, progress: F) -> Result<ModelEvaluation>;
+    pub fn universal_metrics<F>(..) -> ..;
+}
+pub struct ModelEvaluation { pub log_loss: f32, pub rmse_bins: f32 }
+pub struct ItemProgress   { pub current: usize, pub total: usize }
+pub fn evaluate_with_time_series_splits<F>(..) -> ..;
+```
+
+**Simulation** (re-exported from `src/simulation.rs`):
+`Card`, `RevlogEntry`, `RevlogReviewKind`, `SimulatorConfig`, `SimulationResult`,
+`PostSchedulingContext`, `PostSchedulingFn`, `ReviewPriorityFn`, `CMRRTargetFn`,
+`simulate`, `optimal_retention`, `expected_workload`, `expected_workload_with_existing_cards`,
+`extract_simulator_config`.
+
+**Errors:** `pub use error::{FSRSError, Result}` (`src/error.rs` is 15 lines; `snafu`-based).
+
+Source size: 11,925 lines across `src/*.rs` including `#[cfg(test)]` modules
+(`convertor_tests.rs` 774, `batch_shuffle.rs` 176, `test_helpers.rs` 57 are test-only).
+Largest real modules: `simulation.rs` 2,876, `training.rs` 1,721, `cost_adr.rs` 1,632,
+`inference.rs` 1,517, `analytic.rs` 978, `model.rs` 878.
+
+### 1.5 Dependencies and build weight
+
+Full `[dependencies]` of 6.6.1 / repo `main`
+(<https://raw.githubusercontent.com/open-spaced-repetition/fsrs-rs/main/Cargo.toml>):
+
+```toml
+itertools      = "0.15.0"   # 0.14.0 in the published 6.6.1
+log            = "0.4"
+ndarray        = "0.17.2"
+priority-queue = "=2.7.0"
+rand           = "0.10.1"
+rand_distr     = { version = "0.6.0", optional = true }
+rayon          = "1.12.0"
+serde          = { version = "1.0.228", features = ["derive"] }
+snafu          = "0.9.1"
+strum          = { version = "0.28.0", features = ["derive"] }
+```
+
+Features:
+```toml
+[features]
+default = []
+experimental_cost_adr = ["dep:rand_distr"]   # "APIs may change without semver compatibility guarantees"
+```
+
+`[dev-dependencies]`: `burn 0.17.1` (default-features off, features `std, train, ndarray,
+sqlite-bundled, metrics`), `chrono`, `chrono-tz`, `criterion`, `csv`, `fern`, `rusqlite`.
+
+**Answers to the specific questions:**
+
+- **Does it pull in a tensor/ML framework?** **No** (as of 6.3.0+). `burn` is dev-only.
+  Only `ndarray` — a plain N-d array crate, no autodiff, no GPU, no `build.rs` codegen.
+- **Which backend(s)?** N/A. There is no backend abstraction in the public API any more.
+  `Model<B: Backend>` and the `burn` imports in `dataset.rs`/`training.rs`/`model.rs` are all
+  `#[cfg(test)]`. Historically (≤6.2.0) it was `burn` with the `ndarray` backend.
+- **Does a training feature gate away the ML dependency — i.e. can you use scheduling
+  without the training dependency?** **The question is now moot: there is no feature gate,
+  and none is needed.** `compute_parameters` is unconditionally compiled and adds no extra
+  dependencies. The whole crate — scheduling *and* training — sits on the 10 crates above.
+  There is *no* way to feature-gate training out, but there is also no cost to it: it is
+  pure `ndarray`/`rayon` arithmetic. See §0 for the measured 164 KB wasm figure covering both.
+- **Separate crate for optimizer vs scheduler?** **No.** One crate, `fsrs`, contains both
+  ("FSRS for Rust, including Optimizer and Scheduler"). There is no `fsrs-optimizer` crate on
+  crates.io. `rs-fsrs` is a *scheduler-only* alternative (see §3.1) but is not the optimiser
+  half of a pair.
+
+**`rayon` caveat (the one real multi-platform gotcha).** `rayon` is a hard, non-optional
+dependency, but it is used in only three places (`grep` over `src/`, excluding tests):
+
+| file | usage | reachable from |
+|---|---|---|
+| `src/inference.rs:659` | `rayon::spawn` | `evaluate_with_time_series_splits` only |
+| `src/simulation.rs:1396` | `.into_par_iter()` | `optimal_retention` / `simulate` machinery |
+| `src/cost_adr.rs:438,466,659` | `.par_iter()` / `.into_par_iter()` | `experimental_cost_adr` feature only |
+
+`src/model.rs`, `src/training.rs` and `src/analytic.rs` contain **zero** `rayon` references,
+and `inference.rs` has exactly one (in the time-series-split evaluator). So
+`next_states`, `next_interval`, `memory_state*`, `current_retrievability` and
+`compute_parameters` do **not** touch the rayon thread pool. On `wasm32-unknown-unknown`
+without `wasm-bindgen-rayon`, `std::thread::spawn` is unsupported at runtime — so the
+*simulation / optimal-retention / time-series-eval* paths are the ones at runtime risk, not
+the scheduling or training paths. **This runtime distinction is inferred from static call-site
+analysis; I did not execute the wasm binary to confirm it. See open questions.**
+
+### 1.6 wasm and Android support — VERIFIED BY BUILDING
+
+**Build evidence I produced locally** (throwaway crate `/tmp/wasmtest`, `fsrs = "6.6.1"`):
+
+- `cargo build --target wasm32-unknown-unknown` initially fails, but **only** inside
+  `getrandom 0.4.3`:
+  `error: The wasm32/64-unknown-unknown are not supported by default; you may need to enable the "wasm_js" crate feature`.
+  `rayon-core 1.13.0` compiled for wasm32 without complaint.
+- With `getrandom = { version = "0.4", features = ["wasm_js"] }` for the wasm target plus
+  `RUSTFLAGS='--cfg getrandom_backend="wasm_js"'`, the build **succeeds** — `fsrs v6.6.1`
+  and the wrapper compile clean, debug and `--release`.
+- The wrapper exercised `FSRS::default().next_states(..)`, `FSRS::memory_state(..)` **and
+  `compute_parameters(..)`** — i.e. the training path is wasm-compilable, not just scheduling.
+- Release `cdylib` with `opt-level="z"`, `lto=true`, `strip=true`, `panic="abort"`, exporting
+  both a scheduling and a training entry point: **164 KB `.wasm`** before `wasm-opt`/gzip.
+- `cargo check --target aarch64-linux-android` (after `rustup target add aarch64-linux-android`):
+  **passes clean**, scheduling and training entry points included. (`check` needs no NDK
+  linker, so this proves source/target compatibility, not final linking.)
+
+**Upstream / documented evidence:**
+
+- **`fsrs-browser` is the org's official wasm packaging** —
+  <https://github.com/open-spaced-repetition/fsrs-browser> (52 stars, BSD-3-Clause,
+  `pushed_at` 2026-06-14, not archived), published to npm as
+  [`fsrs-browser`](https://www.npmjs.com/package/fsrs-browser) **v6.6.0, 2026-06-13,
+  BSD-3-Clause**. Its `Cargo.toml` is `crate-type = ["cdylib"]` and depends on
+  `fsrs = "6.6.0"`, `getrandom = { version = "0.4", features = ["wasm_js"] }`,
+  `wasm-bindgen = "=0.2.100"`, **`wasm-bindgen-rayon = "1.3.0"`**, `rayon = "1.12.0"`,
+  `serde-wasm-bindgen`. It re-exports `pub use wasm_bindgen_rayon::init_thread_pool;` —
+  independent confirmation that `wasm-bindgen-rayon` is the sanctioned way to make the
+  rayon paths work in a browser.
+  Its README: *"This project runs fsrs-rs in the browser with support for training FSRS
+  parameters"* and *"training 24,394 revlogs on `./dev` takes days, while `./prod.sh` takes
+  3.5 seconds"* — so **in-browser parameter training is a supported, benchmarked use case**,
+  but only with a release/optimised build.
+  `fsrs-browser` versions track `fsrs-rs` major.minor: npm has 2.0.3, 2.0.4, 3.0.0, 4.1.1,
+  5.2.0, 6.6.0.
+- `fsrs-rs` has a long-lived `fsrs-browser` git branch with a dedicated
+  `.github/workflows/auto-merge.yml` ("Auto merge main into fsrs-browser") that fires on
+  release — i.e. wasm packaging is wired into the release process.
+- Issue [#99 "support WASM"](https://github.com/open-spaced-repetition/fsrs-rs/issues/99) and
+  PR [#89 "wasm support"](https://github.com/open-spaced-repetition/fsrs-rs/pull/89) are both
+  **closed**.
+- **Android:** AnkiDroid's backend
+  [`ankidroid/Anki-Android-Backend`](https://github.com/ankidroid/Anki-Android-Backend)
+  (88 stars, `pushed_at` 2026-07-23) builds `rslib-bridge` as
+  `crate-type = ["cdylib"]` with `anki = { path = "../anki/rslib", features = ["rustls"] }`
+  + `jni`. Since Anki's `rslib` depends on `fsrs = 6.6.1`, **`fsrs` ships inside every
+  AnkiDroid release as an Android `.so`**. This is the strongest available Android evidence.
+- **Not verified:** `fsrs-rs`'s own CI does *not* test wasm or Android. `.github/workflows/`
+  contains only `autofix.yml`, `auto-merge.yml`, `check.yml` + `check.sh`; `check.yml` runs
+  `build-linux` / `build-macos` (and reportedly Windows) on the host target only.
+  So there is no upstream CI gate protecting the wasm/Android builds from regressing.
+
+---
+
+## 2. SM-2 in Rust
+
+### 2.1 Candidates found (exhaustive crates.io search)
+
+Searched `spaced repetition`, `flashcard`, `srs`, `fsrs`, `supermemo`, `leitner`,
+`half-life regression`, `memory model` (20 results each) via
+`https://crates.io/api/v1/crates?q=...`. Library candidates (CLI/TUI apps such as
+`forne`, `carddown`, `speki`, `flashed`, `crablit`, `hashcards`, `vultan`, `deckster`,
+`spaced-review`, `melete`, `kbsr`, `reps`, `okul`, `fastcards`, `alix`, `ankr` excluded —
+they are binaries, not schedulers you can depend on):
+
+**`sm-2` 0.2.0** — MIT, 2025-08-18, 1,366 downloads (24 in 90d), 199 LOC.
+<https://github.com/open-spaced-repetition/sm-2-rs> — **1 star, 0 open issues,
+`pushed_at` 2025-08-18** (dormant ~11 months). Same org as fsrs-rs; author `joshdavham`
+(also the py-fsrs maintainer). API:
+```rust
+pub struct Card { pub card_id: u128, pub n: u32, pub ef: f32, pub i: u32,
+                  pub due: DateTime<Utc>, pub needs_extra_review: bool }
+pub struct ReviewLog { .. }
+pub struct Scheduler;   // stateless unit struct
+impl Scheduler {
+    pub fn review_card(card: &Card, rating: u8, review_datetime: Option<DateTime<Utc>>,
+                       review_duration: Option<u32>) -> Result<(Card, ReviewLog), SchedulerError>;
+}
+pub enum SchedulerError { NotDue }
+```
+Pulls in `chrono` + `serde` + `serde_json`. Rating scale is 0–5. Includes a
+`needs_extra_review` same-day re-ask for ratings 3. `Card::default()` derives `card_id` from
+`SystemTime::now()` millis — a wasm/portability smell (works on wasm32 with `js-sys` time,
+but no monotonicity or collision protection). **Returns `Err(NotDue)` if you review early**,
+which is an opinionated constraint you may not want.
+
+**`srs-sm2` 0.1.1** — `MIT OR Apache-2.0` on crates.io (GitHub detects Apache-2.0 only —
+licence metadata is inconsistent), 2026-07-21, 48 downloads, 155 LOC.
+<https://github.com/suradet-ps/srs-sm2> — created **2026-07-20 (5 days before this
+research)**, 0 stars. Genuinely dependency-free, `#![no_std]`, no clock access:
+```rust
+pub struct Schedule { pub interval_days: u32, pub ease_factor: f32 }
+pub fn schedule_next(card: Schedule, quality: u8) -> Schedule;
+pub const MIN_EASE_FACTOR: f32 = 1.3;
+```
+Excellent shape (pure function, no I/O, no allocation, no time) but **zero track record**.
+Docs are unusually good for its age. Would be a fine *reference implementation to copy*.
+
+**`spaced-rs` 0.3.1** — **GPL-3.0-only**, 2022-08-28, 6,072 downloads, 109 LOC.
+"a sm2 *inspired* SR algorithm" — not faithful SM-2. Abandoned. Copyleft.
+
+**`memo_rs` 1.0.0** — MIT, 2023-04-09, 1,491 downloads, 95 LOC, single release, abandoned.
+"An implementation of supermemo2 for rust".
+
+**`sra` 0.1.0** — `MIT OR Apache-2.0`, 2021-08-23, 2,389 downloads, 139 LOC, single release,
+abandoned 5 years. "A collection of spaced repetition algorithms".
+
+**`spaced-repetition` 1.1.0** — BSD-2-Clause, 2022-04-16, 2,800 downloads, 734 LOC,
+<https://github.com/ISibboI/spaced-repetition-rs>. "based on anki and supermemo". Abandoned.
+(`spaced-repetition-rs` 0.1.0 is the same author's earlier name — superseded.)
+
+**`fitts` 0.2.1** — `MIT OR Apache-2.0`, 2025-12-28, 1,455 downloads, 1,021 LOC.
+Fitts'-Law difficulty prediction + SM-2 intervals. Idiosyncratic, low adoption.
+
+**`learnforge-core` 0.1.0** — MIT, 2026-06-19, 18 downloads, 3,199 LOC. Claims
+"BKT, SM-2, threshold, microlearning selection, signing, packs — desktop/web/WASM portable".
+Single release, one month old, part of a larger product (`agentixgarage/learnforge`) — pulls
+in far more than a scheduler (156 KB crate).
+
+### 2.2 Honest assessment: is any production-viable?
+
+**No, none of them is production-viable for a shipped client**, on the evidence:
+
+- The two with real download counts (`spaced-rs` 6,072 and `ebirsu` 4,113) are both
+  **GPL-licensed and abandoned**.
+- `sm-2` is the most credible (open-spaced-repetition org, MIT, sane API) but has **1 GitHub
+  star, 24 downloads in 90 days, and no commits in 11 months**. It is a hobby crate, not
+  infrastructure. Its `Err(NotDue)` policy and `SystemTime`-derived IDs would need working
+  around.
+- `srs-sm2` has the best *design* but is **5 days old with 0 stars** — depending on it is a
+  bet on one unknown maintainer.
+- Every one of them is 95–200 lines. There is no meaningful volume of hard-won logic to
+  inherit, and no test-suite reputation to lean on.
+
+**SM-2's actual size if implemented directly.** The entire algorithm is ~15 lines. From
+`sm-2-rs`'s `scheduler.rs` (MIT), the *complete* core is:
+
+```rust
+if rating >= 3 {                                    // correct response
+    card.ef = (card.ef + (0.1 - (5.0 - rating) * (0.08 + (5.0 - rating) * 0.02))).max(1.3);
+    card.i = match card.n { 0 => 1, 1 => 6, _ => (card.i as f32 * card.ef).ceil() as u32 };
+    card.n += 1;
+} else {                                            // incorrect response
+    card.n = 0;
+    card.i = 0;                                     // ef deliberately unchanged
+}
+```
+
+That is it: two state fields (`ease_factor`, `interval_days`) plus a repetition counter, one
+EF update formula `EF' = EF + (0.1 - (5-q)(0.08 + (5-q)·0.02))` clamped at 1.3, and the
+`1 → 6 → i·EF` interval ladder. Realistically **40–80 lines including a `Rating` enum,
+`serde` derives and a table-driven test** — the kind of test vector `sm-2-rs` already
+publishes (`ratings [4,3,3,4,5,3,0,1,3,3,4,5,3]` → intervals
+`[1,0,0,6,15,0,0,0,0,0,35,85,0]`) and which `srs-sm2` documents in its doctests. Both can be
+used as free cross-check oracles without taking a dependency.
+
+**Conclusion for the record:** taking a dependency for SM-2 buys ~50 lines of arithmetic and
+costs a supply-chain edge, a licence to audit, and (for `sm-2`) a forced `chrono` +
+`serde_json` dependency and an opinionated "not due" error. Writing it directly is the
+lower-risk option on the facts. The interesting design questions in SM-2 (same-day
+relearning steps, fuzz, leech handling, timezone/day-boundary policy, capping) are **not**
+answered by any of these crates anyway — every one of them punts on them.
+
+---
+
+## 3. Other relevant crates
+
+### 3.1 FSRS alternatives
+
+**`rs-fsrs` 1.2.1** — <https://github.com/open-spaced-repetition/rs-fsrs>
+(48 stars, 3 open issues, `pushed_at` 2026-07-20, default branch **`master`**).
+Licence: `license-file = "LICENSE"` in `Cargo.toml`, so crates.io reports `non-standard`;
+the file itself is **MIT ("Copyright (c) 2023 Open Spaced Repetition")** and GitHub detects
+MIT. 13,663 downloads (6,622 in 90d), 1,271 LOC.
+
+**Scheduler only — no optimiser/training.** Dependencies are just `chrono` (+ optional
+`serde`/`serde_json`) — much lighter than `fsrs`, but you cannot compute personalised
+parameters with it. API:
+```rust
+pub use algo::FSRS;
+pub use scheduler::{ImplScheduler, Scheduler};
+pub use scheduler_basic::BasicScheduler;
+pub use scheduler_longterm::LongtermScheduler;
+pub use models::{Card, Rating, RecordLog, ReviewLog, SchedulingInfo, State};
+pub use parameters::{Parameters, Seed};
+pub use alea::{Alea, AleaState, Prng, alea};
+pub use fractional_days::FractionalDays;
+
+pub struct Card { pub due: DateTime<Utc>, pub stability: f64, pub difficulty: f64,
+                  pub elapsed_days: i64, pub scheduled_days: i64, pub reps: i32,
+                  pub lapses: i32, pub state: State, pub last_review: DateTime<Utc> }
+impl Card { pub fn get_retrievability(&self, now: DateTime<Utc>) -> f64 }
+pub enum State { .. }  pub enum Rating { .. }
+```
+Note the different shape from `fsrs`: a *stateful, date-carrying* `Card` (f64 stability /
+difficulty) versus `fsrs`'s stateless `FSRS` + `MemoryState` (f32). It has `Alea`/`Prng` for
+interval fuzz, which `fsrs` does not expose.
+⚠️ **The crate is 21 months stale on crates.io (1.2.1, 2024-10-28) despite an active repo** —
+recent repo commits (e.g. #61 "Add FractionalDays trait", 2026-01-04) are **unpublished**.
+Also: `#![deny(warnings)]` at crate root, which can break your build on a new compiler.
+
+**`fsrsrs` 1.1.0** — 2025-01-05, 3,884 downloads (27 in 90d), 152 LOC, `non-standard`
+licence, **no repository field on crates.io**. Unverifiable provenance; do not use.
+
+### 3.2 Other scheduler families — largely absent from Rust
+
+- **Leitner boxes:** **no crate named `leitner` exists** (crates.io 404), and no crate in any
+  of my searches implements a Leitner box scheduler as a library. The only search hit for
+  "leitner" was `reps`, a TUI app. **You would be implementing Leitner from scratch.**
+- **SM-17 / SM-18:** **no Rust crate found.** These are SuperMemo's proprietary, unpublished
+  algorithms — no open specification exists, so this is expected.
+- **Ebisu (Bayesian half-life):** the crate name `ebisu` is **squatted by an empty
+  placeholder** — v0.0.0, 2022-01-24, **0 lines of code**, 828-byte crate, `Unlicense`,
+  <https://github.com/xorshift/ebisu>. No usable Rust Ebisu implementation exists.
+  (Upstream Ebisu is Python: `fasiha/ebisu`.)
+- **Half-life regression (Duolingo's HLR):** **no Rust crate found.** My "half-life
+  regression" search returned only unrelated finance/agent-memory crates.
+- **Memory models generally:** `ebirsu` 0.2.0 (GPL-3.0-or-later, abandoned 2023, 478 LOC,
+  <https://gitlab.com/antnm/ebirsu/>) is a generic "flashcard quiz scheduling" crate;
+  `learnforge-core` includes Bayesian Knowledge Tracing (BKT). Neither is credible
+  infrastructure. Most `q=memory model` hits are LLM-agent memory crates
+  (`engram-lib`, `alaya`, `pensyve-core`, `kleos-lib`, `mnemo-engine`, `zeph-memory`) —
+  unrelated to SRS despite keyword collisions.
+- **`anki` on crates.io is a 0-LOC placeholder** (v0.0.1, 2019-12-31, AGPL-3.0-or-later,
+  description: "This crate is currently only available through the GitHub repo"). You cannot
+  depend on Anki's `rslib` from crates.io — and you would not want to (see §4).
+
+### 3.3 FSRS parameter optimisation outside `fsrs-rs`
+
+- **`fsrs-optimizer` (PyPI) 6.5.0** — <https://github.com/open-spaced-repetition/fsrs-optimizer>.
+  `requires_dist`: **`torch`**, `numpy`, `pandas>=3.0.0`, `matplotlib`, `scikit-learn`,
+  `scipy`, `statsmodels`, `pytz`, `tqdm`. `license` field is **`None`** and there are **no
+  License classifiers** on the PyPI metadata — licence must be read from the repo, not the
+  package index. Using this would force a **Python + PyTorch** runtime on your build or
+  server — categorically unshippable in a wasm/Android client, and a heavy server dependency.
+- **`fsrs` (PyPI, "py-fsrs") 6.3.1** — MIT, © 2022 Open Spaced Repetition. A pure-Python
+  scheduler. Same problem: non-Rust runtime.
+- **`fsrs-browser` (npm) 6.6.0** — BSD-3-Clause, 2026-06-13. *Not* a non-Rust dependency:
+  it is `fsrs` compiled to wasm by the same org, and it **does** expose
+  `compute_parameters` + `TrainingConfig` to JS. Relevant as a packaging precedent, or as an
+  off-the-shelf answer if your web client is JS-first rather than Rust-first.
+
+**Bottom line:** `fsrs` the Rust crate is the *only* way to optimise FSRS parameters without
+introducing a non-Rust runtime. Nothing else in the Rust ecosystem trains FSRS parameters.
+
+---
+
+## 4. Licence implications
+
+| Licence | Crates | Character | Implication for an Android/web client |
+|---|---|---|---|
+| **`BSD-3-Clause`** | **`fsrs` 6.6.1** (all versions), `fsrs-browser` | Permissive | ✅ No copyleft. Requires retaining the copyright notice + disclaimer in distributed documentation/binaries, and the "no endorsement" clause forbids using "Open Spaced Repetition" or contributor names to promote your app without permission. **No source-disclosure obligation.** Fine for a closed-source Play Store / web app; just ship an attribution/licences screen. |
+| **`MIT`** | `sm-2`, `memo_rs`, `rs-fsrs` (via `license-file`), `learnforge-core` | Permissive | ✅ Attribution only. |
+| **`MIT OR Apache-2.0`** | `srs-sm2`, `sra`, `fitts` | Permissive, dual | ✅ Rust-ecosystem standard; pick either. |
+| **`BSD-2-Clause`** | `spaced-repetition`, `spaced-repetition-rs` | Permissive | ✅ Attribution only. |
+| **`GPL-3.0-only`** | **`spaced-rs`** | **Strong copyleft** | ⚠️ **Avoid.** Linking it into your client would oblige you to license the whole app GPL-3.0 and offer corresponding source. Also creates friction with Apple's App Store terms (less so Google Play). |
+| **`GPL-3.0-or-later`** | **`ebirsu`** | **Strong copyleft** | ⚠️ **Avoid.** Same as above. |
+| **`AGPL-3.0-or-later`** | **`anki`** (0-LOC placeholder) | **Network copyleft** | ⚠️ **Avoid.** Anki's real `rslib` is AGPL-3.0. Do **not** vendor or link Anki's Rust library — AGPL §13 extends the source obligation to users interacting over a network, which is fatal for a hosted/sync web client. The `fsrs` crate is deliberately BSD-3-Clause precisely so it can be reused independently; use `fsrs`, never `rslib`. |
+| **`Unlicense`** | `ebisu` (empty) | Public-domain dedication | Irrelevant — 0 LOC. |
+| **`non-standard`** | `rs-fsrs`, `fsrsrs`, `flashy` | Unresolved metadata | ⚠️ `rs-fsrs` verified MIT by reading its `LICENSE` file. **`fsrsrs` has no repository and no readable licence — treat as unlicensed / do not use.** Automated licence scanners (`cargo-deny`, `cargo-about`) will flag `non-standard`; you may need an explicit allow-entry if you use `rs-fsrs`. |
+
+**Transitive licences of `fsrs`'s 10 runtime deps** — `itertools`, `log`, `ndarray`,
+`priority-queue`, `rand`, `rayon`, `serde`, `snafu`, `strum` are all MIT/Apache-2.0 or
+BSD-family by long-standing convention. **I did not individually verify each transitive
+licence** — run `cargo deny check licenses` or `cargo about` on the real dependency graph
+before shipping. Nothing in the tree looked copyleft during the build.
+
+**Net conclusion on licensing:** the FSRS path is clean. `fsrs` (BSD-3-Clause) has no
+copyleft obligation and is safe for a proprietary, distributed Android/web client with a
+standard attribution screen. The only copyleft traps in this space are `spaced-rs`,
+`ebirsu` (GPL) and Anki's own `rslib` (AGPL) — all avoidable.
+
+---
+
+## 5. Unverified / open questions
+
+1. **Runtime behaviour of `rayon` on `wasm32-unknown-unknown`.** I proved the code
+   *compiles* and showed by static call-site analysis that the scheduling and
+   `compute_parameters` paths contain no `rayon` calls. I did **not execute** the wasm binary,
+   so I cannot certify that `compute_parameters` runs without a thread pool, nor confirm that
+   `simulate` / `optimal_retention` / `evaluate_with_time_series_splits` panic or hang on wasm
+   without `wasm-bindgen-rayon`. That `fsrs-browser` bundles `wasm-bindgen-rayon` and
+   re-exports `init_thread_pool` is strong circumstantial evidence that at least *some* path
+   needs real threads. **Worth a 30-minute spike: run `compute_parameters` in
+   `wasm32-unknown-unknown` under `wasm-bindgen-test`/node without a thread pool.**
+2. **Android link step.** `cargo check --target aarch64-linux-android` passed, which proves
+   source compatibility but not final `.so` linking (no NDK installed here). The AnkiDroid
+   backend shipping `fsrs` inside `anki/rslib` is strong evidence linking works, but I did not
+   produce an Android artifact myself. Other Android ABIs (`armv7-linux-androideabi`,
+   `x86_64-linux-android`, `i686-linux-android`) were not tested at all.
+3. **`compute_parameters` wall-clock cost on real client hardware.** `fsrs-browser`'s README
+   gives one anecdote (24,394 revlogs, 3.5 s in an optimised browser build; "days" in a debug
+   build). I have no measurement for a mid-range Android device, and no measurement at all for
+   the `--release` vs `opt-level="z"` trade-off I used for the size figure. The debug/release
+   gap is enormous — any in-app training must be release-built.
+4. **Serde asymmetry.** `MemoryState`, `NextStates` and `ItemState` derive `Serialize` but
+   **not `Deserialize`** (`FSRSItem`/`FSRSReview` derive both). If you persist `MemoryState`
+   you must define your own local struct or a `Deserialize` shim. I confirmed this from the
+   derive attributes but did not check whether it is intentional or an upstream oversight
+   worth filing.
+5. **fsrs 6.x semver churn.** Nine minor/major versions shipped in the eleven days
+   2026-05-29 → 2026-06-09 (6.0.0 … 6.6.1), and `main` already sits at an unpublished 6.6.2.
+   The 6.x line is moving fast and 6.0→6.6 included breaking API changes. I did **not**
+   enumerate the breaking changes or check for a CHANGELOG. Pin exactly and read release
+   notes before bumping. `experimental_cost_adr` is explicitly documented as exempt from
+   semver.
+6. **`fsrs`'s `priority-queue = "=2.7.0"` is an exact pin.** This will hard-conflict if
+   anything else in your graph needs a different `priority-queue` version. Not hit in my test
+   build (which had almost no other deps).
+7. **Transitive licence audit** not performed per-crate (see §4).
+8. **`rs-fsrs`'s unpublished repo state.** Whether the maintainers intend to publish 1.3.x, or
+   whether `rs-fsrs` is being wound down now that `fsrs` is dependency-light, is unknown — I
+   found no statement either way.
+9. **FSRS algorithm-version alignment.** `fsrs` 6.6.1 exposes both `FSRS5_DEFAULT_DECAY` and
+   `FSRS6_DEFAULT_DECAY`, and `DEFAULT_PARAMETERS` is 21 values (FSRS-6). I did not verify
+   which FSRS spec revision `rs-fsrs` 1.2.1 implements, so the two crates may not be
+   parameter-compatible with each other.
+10. **crates.io `recent_downloads` semantics** assumed to be a 90-day window (the documented
+    convention). Not independently confirmed against the API docs.
+
+---
+
+## Appendix: primary sources
+
+- fsrs crate API: <https://crates.io/api/v1/crates/fsrs> · versions · `/6.6.1/dependencies`
+- fsrs-rs repo: <https://github.com/open-spaced-repetition/fsrs-rs> ·
+  `main/Cargo.toml` · `main/src/lib.rs` · `main/src/{dataset,inference,model,training}.rs` ·
+  `main/README.md` · `.github/workflows/`
+- burn removal: <https://github.com/open-spaced-repetition/fsrs-rs/pull/411> (commit `ca31a0d`)
+- wasm issue/PR: <https://github.com/open-spaced-repetition/fsrs-rs/issues/99> ·
+  <https://github.com/open-spaced-repetition/fsrs-rs/pull/89>
+- docs.rs: <https://docs.rs/crate/fsrs/latest> (HTTP 200)
+- Anki: <https://github.com/ankitects/anki/blob/main/Cargo.toml> (workspace dep, `version = "6.6.1"`) ·
+  `rslib/Cargo.toml:66` · `Cargo.lock:1404`
+- AnkiDroid backend: <https://github.com/ankidroid/Anki-Android-Backend> ·
+  `rslib-bridge/Cargo.toml`
+- fsrs-browser: <https://github.com/open-spaced-repetition/fsrs-browser> ·
+  `main/Cargo.toml` · `main/src/lib.rs` · <https://www.npmjs.com/package/fsrs-browser>
+- rs-fsrs: <https://github.com/open-spaced-repetition/rs-fsrs> (`master` branch) ·
+  `master/Cargo.toml` · `master/LICENSE` · `master/src/{lib,models}.rs`
+- sm-2-rs: <https://github.com/open-spaced-repetition/sm-2-rs> · `main/src/{scheduler,card}.rs`
+- srs-sm2: <https://github.com/suradet-ps/srs-sm2> · `main/src/lib.rs`
+- PyPI: <https://pypi.org/pypi/fsrs-optimizer/json> · <https://pypi.org/pypi/fsrs/json>
+- crates.io search: `https://crates.io/api/v1/crates?q=<term>&per_page=20` for
+  `spaced repetition`, `flashcard`, `srs`, `fsrs`, `supermemo`, `leitner`,
+  `half-life regression`, `memory model`


### PR DESCRIPTION
Findings for [Research: scheduling algorithms — SM-2, FSRS, graded Leitner](https://github.com/amin-bf/leitner/issues/2), a ticket on [Map: local-first Leitner app spec](https://github.com/amin-bf/leitner/issues/1).

Adds `docs/research/scheduling-algorithms/` — a synthesis plus the three raw source-note sets as appendices, every claim carrying a primary-source URL and verified live on 2026-07-26.

This is a **throwaway research branch**, per the map's convention: it exists as a context pointer from the ticket. Merge it only if these notes should live on `master`.

## What it settles

- **FSRS has no minimum-review threshold** since Anki 24.06.3, and default parameters (fitted on ~727M reviews from ~10k users) work from zero history and degrade gracefully. This removes the main practical argument for shipping SM-2 first and migrating later.
- **"Ease hell" is Anki's additive-ease variant, not published SM-2** — SM-2's own ease update is a bounded quadratic with `q=4` as a fixed point.
- **There is no published mapping of a 4-point grade scale onto box movement.** Both academic treatments of Leitner deliberately collapse grades to binary; the reference implementation is binary and makes even demotion a config flag; the two graded implementations found in the wild contradict each other on both Hard and Easy.
- **The box-display-is-a-lie failure mode is documented by Duolingo in a peer-reviewed paper** (ACL 2016) — MAE 0.235 under Leitner vs 0.128 for their replacement, and users gaming the meter. Direct evidence for the map's standing constraint 4.
- **`fsrs` 6.6.1 (BSD-3-Clause) dropped `burn`** and builds for `wasm32-unknown-unknown` and `aarch64-linux-android` with the training path included — 164 KB of wasm, verified by building, not inferred.
- **No production-viable SM-2 crate and no Leitner crate exist in Rust.** SM-2 is ~50 lines written directly.
- **Replay analysis for standing constraint 1**: both algorithm cores are pure and replayable; load balancing, calendar shaping and sibling avoidance are not, and the enumerated breakers are listed with what each implies for the event log.

Open questions are carried forward explicitly rather than papered over — notably runtime `rayon` behaviour on wasm and `compute_parameters` cost on real Android hardware, which is now its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)