### PR TITLE
Point ADR-0003's prototype links at the archival tag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ platform, no webview, no IPC. Setup and commands are in [`README.md`](./README.m
 8. **Android text input is ASCII-only, and cannot be fixed here.** winit's Android backend handles
    only motion and key events — it has no IME path, so composed text never reaches the app. This is
    not the activity backend: GameActivity was tried and reverted (see
-   [`prototypes/egui-slice/android/README.md`](https://github.com/amin-bf/leitner/blob/worktree-worktree-client-stack-8/prototypes/egui-slice/android/README.md)). Never design a feature that requires typing non-Latin
+   [`prototypes/egui-slice/android/README.md`](https://github.com/amin-bf/leitner/blob/prototypes/issue-8/prototypes/egui-slice/android/README.md)). Never design a feature that requires typing non-Latin
    text on Android.
 9. **Verify Android on the real handset.** The emulator is x86_64; the Pixel 8 Pro is arm64-v8a only.
 

--- a/docs/adr/0003-client-stack.md
+++ b/docs/adr/0003-client-stack.md
@@ -5,8 +5,7 @@
 - **Resolves**: [Prototype: pick the client stack](https://github.com/amin-bf/leitner/issues/8)
 - **Map**: [Map: local-first Leitner app spec](https://github.com/amin-bf/leitner/issues/1)
 - **Evidence**: [`docs/research/client-stacks/`](../research/client-stacks/README.md) and the four
-  prototypes measured in [`prototypes/COMPARISON.md`](https://github.com/amin-bf/leitner/blob/worktree-worktree-client-stack-8/prototypes/COMPARISON.md) (branch `worktree-worktree-client-stack-8`,
-  PR [#29](https://github.com/amin-bf/leitner/pull/29))
+  prototypes measured in [`prototypes/COMPARISON.md`](https://github.com/amin-bf/leitner/blob/prototypes/issue-8/prototypes/COMPARISON.md) (tag [`prototypes/issue-8`](https://github.com/amin-bf/leitner/tree/prototypes/issue-8))
 - **Related**: [ADR-0001](0001-scheduling-algorithm-and-grade-scale.md),
   [ADR-0002](0002-the-card-model.md)
 
@@ -98,7 +97,7 @@ run"*, and that sections are laid out in the order given:
   not.
 
 **~60 lines, no fork of epaint**, verified on Persian sentences, mixed Latin/Persian, and digits, and
-confirmed by a Persian reader. See [`prototypes/egui-slice/src/bidi.rs`](https://github.com/amin-bf/leitner/blob/worktree-worktree-client-stack-8/prototypes/egui-slice/src/bidi.rs).
+confirmed by a Persian reader. See [`prototypes/egui-slice/src/bidi.rs`](https://github.com/amin-bf/leitner/blob/prototypes/issue-8/prototypes/egui-slice/src/bidi.rs).
 
 **All card and UI text must be rendered through this helper.** Text rendered with a plain
 `RichText`/`&str` bypasses it and will be wrong for RTL content. This is the single most important
@@ -163,7 +162,7 @@ basic ascii input"*, which it calls adequate *"for prototyping"* but *"unlikely 
 production applications."* Persian is delivered via `InputConnection.commitText` and never reaches us.
 
 `GameActivity` looked like the answer — real IME through GameTextInput. **It was built and tested,
-and it does not help.** The Gradle project is kept at [`prototypes/egui-slice/android/`](https://github.com/amin-bf/leitner/blob/worktree-worktree-client-stack-8/prototypes/egui-slice/android) so nobody
+and it does not help.** The Gradle project is kept at [`prototypes/egui-slice/android/`](https://github.com/amin-bf/leitner/blob/prototypes/issue-8/prototypes/egui-slice/android) so nobody
 repeats the experiment.
 
 **winit is the break, not the activity backend.**
@@ -201,8 +200,9 @@ for free.
 
 ### 7. What is carried forward, and what is not
 
-The prototypes are throwaway and **do not land on `main`** — they live on the branch named above,
-which is the evidence asset for this decision. What lands is this ADR, `README.md` and the rules in
+The prototypes are throwaway and **do not land on `main`** — they live under the tag
+[`prototypes/issue-8`](https://github.com/amin-bf/leitner/tree/prototypes/issue-8), which is the
+evidence asset for this decision. What lands is this ADR, `README.md` and the rules in
 `AGENTS.md`.
 
 One exception is worth naming: **the bidi helper is a validated decision, not a prototype artefact.**


### PR DESCRIPTION
Follow-up to [#30](https://github.com/amin-bf/leitner/pull/30). **2 files, 7 lines.**

ADR-0003 and `AGENTS.md` reference the prototypes by branch. This repo has `delete_branch_on_merge` enabled and the prototype branch ([#29](https://github.com/amin-bf/leitner/pull/29)) is closed and due for cleanup — so those links are one deletion away from being dead.

Repointed all four at the tag [`prototypes/issue-8`](https://github.com/amin-bf/leitner/tree/prototypes/issue-8) (`ea8764c`), which holds the identical tree.

**After this merges, `worktree-worktree-client-stack-8` is safe to delete.** The tag preserves the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)