### PR TITLE
Research / Sync Transport Over Storage We Do Not Own

### DIFF
--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -9,5 +9,6 @@ Each report was produced by a `/research` subagent resolving one `wayfinder:rese
 | [`scheduling-algorithms/`](./scheduling-algorithms/README.md) | [#2](https://github.com/amin-bf/leitner/issues/2) | SM-2 vs FSRS vs graded Leitner; cold-start behaviour, the box-metaphor failure mode, and the `fsrs` crate's licence and platform reach |
 | [`client-stacks/`](./client-stacks/README.md) | [#3](https://github.com/amin-bf/leitner/issues/3) | Dioxus vs Leptos + Tauri for desktop/web/Android, and the cross-platform storage layer underneath both |
 | [`local-first-event-log/`](./local-first-event-log/README.md) | [#4](https://github.com/amin-bf/leitner/issues/4) | Append-only review logs, cross-device merge, and how a device tells whether it is ahead of or behind another |
+| [`sync-transport/`](./sync-transport/README.md) | [#33](https://github.com/amin-bf/leitner/issues/33) | What can carry the log between devices with no server of our own — a git remote, a rented object store, rented WebDAV, a personal cloud drive, or a folder another application syncs; whether conditional writes are needed at all, what segment granularity costs, and what Android permits unattended |
 
 Each report's own README carries its sources and confidence levels. The one-line gist of what each one settled lives in the map's Decisions-so-far.

--- a/docs/research/sync-transport/README.md
+++ b/docs/research/sync-transport/README.md
@@ -1,0 +1,253 @@
+# Sync transport over storage we do not own
+
+**Research ticket:** [#33](https://github.com/amin-bf/leitner/issues/33) (under wayfinder map
+[#1](https://github.com/amin-bf/leitner/issues/1)) · **Date of research:** 2026-07-30
+
+**Question:** with no server of our own, what can carry the review event log between a user's desktop
+and Android devices?
+
+This is a **research** note. It gathers facts and sharpens trade-offs; it decides nothing. The
+decision is a later ticket's job.
+
+Three slices were investigated in parallel, each against primary sources, each testing load-bearing
+claims rather than asserting them. This README is the synthesis — **what the three slices say
+together that none of them says alone**. Each slice's own note carries its sources, its measurement
+commands, and its confidence levels:
+
+| Slice | What it covers |
+| --- | --- |
+| [`git-as-transport.md`](./git-as-transport.md) | A git remote as the store: Rust git libraries on Android, hosting terms and limits, pack behaviour measured over a synthetic decade, `ls-remote` as the handshake |
+| [`synced-folders-and-webdav.md`](./synced-folders-and-webdav.md) | A folder another application keeps in step, and WebDAV against rented storage: Android's scoped-storage limits, conditional writes and appends tested against three servers, measured handshake and segment costs |
+| [`object-stores-and-drives.md`](./object-stores-and-drives.md) | A rented object store, and a personal cloud drive through its own API: conditional-write support and necessity, segment-versus-snapshot pricing, OAuth with no server, change-detection cursors |
+
+**Scope note.** This ticket's body made the web target load-bearing — it argued the deciding finding
+would be that a browser cannot reach a git remote without a proxy, and a proxy is a server we do not
+have. That question was moot before the reading started: the map records the web target as **out of
+scope**, ruled out while resolving [Decide: the local
+store](https://github.com/amin-bf/leitner/issues/12). The budget went to Android depth instead, which
+is now half the client surface and the harder half.
+
+---
+
+## The seven findings that matter
+
+### 1. Conditional writes are not needed — and declining to need them is worth more than having them
+
+The ticket asked whether anything needs compare-and-swap at all, given each writer owns its own
+keyspace. **It does not**, and two slices established this independently, arriving at the same
+proviso.
+
+A conditional write solves *lost updates to a shared key*. Under a per-writer keyspace no key ever
+has two writers, so the failure it prevents cannot occur. What an unconditional write already
+guarantees is sufficient — including that a newly written object appears in a subsequent listing, the
+property the whole design leans on. Worse, a conditional write makes one realistic case *worse*: a
+client retrying after an ambiguous timeout, re-uploading byte-identical content, is rejected rather
+than succeeding harmlessly.
+
+The proviso, stated the same way in both slices: this holds **provided ADR-0004 §7's mutable surface
+is also published per writer** rather than as one shared document. If the mutable surface becomes a
+single shared object, its writers race and the conclusion reverses. That makes "how the mutable store
+moves" — the item ADR-0004 explicitly handed onward — a question about *concurrency control*, not
+just about bytes.
+
+And this is not merely a saving. Conditional writes were tested against three WebDAV servers and
+**two of them silently ignored the precondition, in the data-losing direction** — returning `201
+Created` and overwriting the file for both a stale `If-Match` and an `If-None-Match: *`, despite the
+governing specification making evaluation a MUST. A client cannot tell from a `2xx` that the
+condition was ever evaluated. A design that does not need conditional writes is not just cheaper; it
+is immune to a silent-corruption hazard that a design depending on them would have to detect and work
+around per server.
+
+### 2. Segment granularity is the real dial, and three independent measurements bound it from both sides
+
+The ticket framed this as a binary — per-writer segments merged at read time, or whole-snapshot
+republish. **It is neither: it is a continuous dial, and the three slices measured three different
+penalties that pull in opposite directions.**
+
+Republishing a whole per-writer log on every sync is ruled out by **uplink, not by money**. The
+monthly bill is between $0.0000 and $0.0040 either way — ingress is free everywhere and the data sits
+inside every free tier — but the bytes a device pushes are **1,800 MiB per month** at six syncs a day
+against **0.2 MiB** for segments. That is a mobile-data bill appearing on no pricing page, and it is a
+factor of roughly nine thousand.
+
+But the other end of the dial has its own penalties, and they are not obvious:
+
+- **Compression collapses.** The same rows compress **12.01×** as one file per writer-year and only
+  **5.02×** as daily 200-row segments — 2.20 MB/year instead of 0.92 MB/year — because the
+  compressor's window cannot reach across file boundaries to the repeated writer identifiers.
+- **Listing stops being the handshake.** Two devices syncing six times a day for ten years is 43,800
+  objects, against a 1,000-key listing page cap: 44 round trips and ~14 MB for a naïve full listing.
+- **Local cost explodes on a content-addressed store.** Measured over a synthetic decade, one growing
+  file per writer gives **911.8× write amplification** and a 9.14 GB unrepacked repository at the
+  five-year mark, because the whole file is re-hashed on every commit — cumulative bytes hashed is
+  quadratic in commit count, confirmed at exactly `(days+1)/2` over three run lengths.
+
+**Time-bucketed segments satisfy all three constraints, and one slice measured the optimum
+independently.** One file per writer *per month* bounds write amplification at **15.7×** and makes a
+decade of history *smaller than the text it stores* — 47.5 MB of repository for 126.3 MB of log, with
+flat one-second maintenance, against 29.8 s and climbing for the single-file layout. It also puts
+object counts in the hundreds rather than the tens of thousands, and gives the compressor a large
+enough window to work in.
+
+The residual cost is that the *current* bucket is still republished on each sync. That is bounded by
+one month of rows rather than the whole log — on the order of 10 MB per device per month at six syncs
+a day, averaged over a filling bucket [inference: arithmetic over the measured row size and
+compression ratios]. Closed buckets are immutable forever, which is what makes them cache, compress
+and pack well. **The decision ticket picks a point on this dial; the research establishes that both
+ends are penalised and the interior is not.**
+
+### 3. A synced folder is the one family with a structural disqualification, and the deepest part is not about Android
+
+Three separate problems, in increasing order of severity.
+
+**It cannot answer "am I behind?" even in principle.** A folder shows a device its own local copy;
+there is no remote to interrogate. A directory listing reports what has *arrived*, never what exists
+elsewhere. The peer-to-peer model states its delivery guarantee plainly — data moves between machines
+"as soon as they are online at the same time" — so two devices never awake together never converge,
+and **neither can tell that this is happening**. Standing constraint 3 and ADR-0004 §2 require a
+version-summary handshake; in this family that handshake has no counterparty. This is a missing
+capability, not a cost.
+
+**On Android there is exactly one directory both our app and a third-party sync application can treat
+as ordinary files, and its API was deprecated at API 30** — with its own reference stating "there is
+no security enforced with these files" in the same paragraph as the deprecation notice. App-private
+storage is unreachable by any other app, and since Android 11 nothing reaches another app's data
+directory, not even all-files access. Everything else costs a user-picked Storage Access Framework
+tree — `content://` URIs rather than paths, obtained through an activity result the Rust Android glue
+does not surface, so it also costs a hand-written `Activity` subclass in the APK. **This is the same
+`NativeActivity` limitation recorded as rule 8 in `AGENTS.md`**, the one that makes Android text input
+ASCII-only — the same missing seam, surfacing in a second place.
+
+**The sync applications themselves have retreated from Android.** The peer-to-peer client was
+archived in December 2024, its maintainer citing store publishing difficulty; the surviving fork is
+sideload-only and declares exactly the permissions that make store distribution hard. And the three
+large commercial drive clients do no local-folder sync on Android at all — one states outright that
+its app "does not sync files automatically", another that its files "aren't stored on your phone or
+tablet", and the third ships a desktop-only sync client.
+
+### 4. Android caps unattended sync identically for every candidate, so it discriminates between none of them
+
+All three slices hit the same wall independently. While dozing, network access is suspended and
+deferred work does not run; in the **Rare** and **Restricted** app-standby buckets network is listed
+as **Disabled** outright — precisely where a device that has been in a drawer lands. The periodic-work
+floor is 15 minutes. Escaping via a foreground service costs a visible notification, is capped at six
+hours in any 24, and cannot be started from boot. Asking the user for a power-management exemption is
+store-policy-restricted unless the app's core function is adversely affected, which a
+few-kilobyte sync cannot claim.
+
+Our transfers take seconds, so the caps never bite. **What binds is the once-a-day network window for
+an idle app and the visible notification** — and since this is a platform property rather than a
+transport property, it changes what the app can *promise*, not which store it should use. The honest
+promise is: sync happens when the user opens the app, and opportunistically before that.
+
+### 5. Every remote-addressable candidate has a cheap handshake, and in three of four the version summary can live in a name
+
+The ticket asked whether answering "am I behind?" means fetching everything. It does not, anywhere
+except a synced folder.
+
+| Store | Cheapest handshake | Cost |
+| --- | --- | --- |
+| Git remote | `ls-remote` — protocol v2 capability advertisement plus `ls-refs` | 2 HTTP requests, ~1.3 KB for 17 refs, **zero object transfer** |
+| Object store | One listing per writer prefix, `start-after` = highest sequence held | W requests, ~254 B envelope; a 5-writer listing ~1.8 KB in one round trip |
+| WebDAV | `PROPFIND Depth: 0` for the collection entity tag | **371 B, one round trip** — but a change *detector*, not a summary |
+| Personal drive | A delta/change cursor; one provider offers an unauthenticated long-poll push channel (30–480 s) | Cheaper than an object-store listing |
+| Synced folder | — | **Not possible** (finding 3) |
+
+**The version summary can be encoded in the store's own naming.** In a git remote it fits in the ref
+*name*, so `ls-remote` alone answers the question with no objects moved — with one caveat found by
+testing: ref names cannot nest, so the scheme must be flat. In an object store, a zero-padded sequence
+number in the key means the listing *is* the summary, with entity tag and size in the metadata so no
+fetch is needed. WebDAV is the weakest: the cheap form tells you only that *something* changed, the
+full listing costs 28 B/entry gzipped on a compressing server but 245 B/entry on one that offers no
+compression even when asked, and the standardised incremental-sync report is not available on the
+files endpoint at all.
+
+### 6. Where the families actually separate is credentials, setup and terms — not bytes and not money
+
+Money is a non-discriminator: $0.000–0.004/month for object storage, EUR 0.50–3.20/month for rented
+WebDAV, free for git hosting. One rented store is disqualified purely on **billing floors** — a 1 TB
+monthly minimum, a 90-day minimum duration and a 4 KB minimum billable object, which inflates segment
+storage 3–11× on top of charging for a terabyte to hold twenty megabytes.
+
+What differs materially:
+
+- **A git remote** uses per-device keys or tokens, individually revocable — a well-understood story.
+  Its exposure is **the hosts' terms**: one states plainly that private repositories are "explicitly
+  not [for use] as a personal cloud or media storage", which is what an append-only personal review
+  log is; another caps file requests explicitly to prevent CDN-like usage; a third has no storage
+  clause in its acceptable-use policy at all, while its own documentation warns that git is not
+  designed as a backup tool. At 47.5 MB per decade no *size* limit binds — the terms are the
+  exposure, not the bytes. The one host that unambiguously permits it has an 800 GB minimum order.
+- **A rented object store** has the worst credential story. Only one provider lets a user mint a key
+  scoped to a name prefix with an expiry from a form; another offers bucket scoping with no prefix
+  scoping and no expiry; the third can express it only through hand-written policy JSON. Setup is an
+  account signup plus roughly five steps, repeated per device, with the secret shown once — so a lost
+  phone means manual rotation everywhere.
+- **Rented WebDAV** has the cheapest and most conventional story: app-specific passwords are the norm
+  and are mandatory under two-factor authentication, so they are per-device and individually
+  revocable. No provider surveyed documents entity-tag or conditional-request behaviour — which
+  finding 1 makes a non-issue.
+- **A personal cloud drive** clears the bar everyone expects it to fail: a public OAuth client with
+  PKCE and a loopback redirect is explicitly supported, no client secret is required, and the
+  app-private folder scope is **non-sensitive**, so no app verification and **no verification-time
+  endpoint** — which would have been a server. The costs are elsewhere and they are real: refresh
+  tokens die after six months unused (exactly the drawer-device case) and after seven days while the
+  project remains in testing status, are capped at 100 per account per client, and one provider
+  freezes new user links two weeks after the fiftieth user pending review.
+
+### 7. A structural correction to this ticket's own premise: per-writer *files* do not prevent push conflicts
+
+The ticket asserted that because each device appends only to its own rows, "there are no cross-device
+write conflicts to resolve at all". For content-addressed transport this is **true of file content
+and false of publishing**, because git's compare-and-swap is on the **ref**, not the file. Two devices
+committing entirely disjoint per-writer files to one branch: the second push is rejected. The same two
+pushes to per-writer **branches** both succeed with no interaction.
+
+The premise is recoverable, but it costs a design commitment — per-writer refs — that the ticket did
+not know it was making. The analogous commitment in the other families is per-writer key prefixes,
+which finding 1 already shows is load-bearing for a different reason. **"One writer, one namespace" is
+the invariant the whole transport design rests on**, whichever store wins.
+
+---
+
+## Two knock-ons for ADR-0004
+
+Findings that bear on the map's own text rather than on transport.
+
+1. **The interchange row size and decade projection are confirmed.** Two slices independently
+   generated rows in [ADR-0004](../../adr/0004-the-review-event-log.md) §11's exact shape and measured
+   **151.4 B** and **152.5 B** per row against the ADR's "roughly 150 bytes", reproducing §10's "around
+   110 MB raw" per decade to within 1%.
+
+2. **§10's "compresses about ten to one" is conditional on two things §11 does not fix — the
+   compressor's window and the segment size.** A decade of rows compresses **11.76×** with `zstd -19`
+   and **12.01×** as one file per writer-year, but only **3.99×** with `gzip -9`, because gzip's 32 KiB
+   window cannot reach back to the repeated writer identifiers — and only **5.02×** as daily segments
+   even with a large-window compressor, because the window cannot span files. So §10's "15 MB
+   compressed per decade" holds for a large-window compressor over large segments, and becomes roughly
+   27 MB under gzip or roughly 22 MB under daily segmentation. **The interchange form should name the
+   compressor, or the size figure should carry the condition** — and note that this couples §10 to a
+   transport decision the ADR deliberately deferred.
+
+---
+
+## What this does not settle
+
+- **Which store to use.** That is the decision ticket's job, and this note deliberately leaves it
+  open. What it establishes is that four families remain live (git remote, rented object store,
+  rented WebDAV, personal cloud drive) and one is structurally disqualified (a folder another
+  application syncs).
+- **Where on the segment dial to land**, and how the ADR-0004 §7 mutable surface moves — snapshot or
+  change stream — which finding 1 shows is also a concurrency-control question.
+- **Whether git runs on the real handset.** Nothing here was verified on the Pixel 8 Pro, and
+  `AGENTS.md` rule 9 requires that before anything is designed on it. The same applies to Storage
+  Access Framework throughput.
+- **Eight open items in the git slice** (§8 there), notably whether the hosted forges accept pushes to
+  non-branch refs — which finding 7 makes load-bearing — and whether classic token types expire, which
+  decides whether a year-offline device can still authenticate.
+- **Conditional-write support on one object store** was not verifiable from its documentation and
+  needs testing against a real bucket.
+
+The decade-scale figures in the git slice are extrapolated from three measured points and labelled as
+such; all workload numbers throughout come from synthetic logs generated to ADR-0004 §11's shape, not
+from real user data.

--- a/docs/research/sync-transport/git-as-transport.md
+++ b/docs/research/sync-transport/git-as-transport.md
@@ -1,0 +1,489 @@
+# Git as the sync transport
+
+**Research ticket:** [#33](https://github.com/amin-bf/leitner/issues/33) (under wayfinder map [#1](https://github.com/amin-bf/leitner/issues/1)) · **Date of research:** 2026-07-30
+**Question:** Can a git remote carry the review event log between a user's desktop and Android devices, with no server of our own?
+
+This is a **research** note. It gathers facts and sharpens trade-offs; it does not pick a design. Every non-obvious claim carries an inline source; claims I reasoned rather than sourced are marked **[inference]**; claims I could not settle are collected in §8.
+
+Context assumed throughout, from [ADR-0004](../../adr/0004-the-review-event-log.md) and the ticket: Rust, egui/eframe, **desktop and Android only** (the web target was ruled out while resolving [#12](https://github.com/amin-bf/leitner/issues/12), so browser constraints are out of scope). No server of our own, ever. An append-only JSON Lines review log where every row carries `(writer id, sequence number)` and **each device appends only to its own rows**, so two devices never write the same file and merging is set union — there are no cross-device write conflicts. One user, 2–5 devices. Worst case ~200 reviews/day.
+
+Where a claim is load-bearing I tested it with the `git` CLI (2.55.0) or the Rust toolchain (rustc 1.97.0, Android NDK 29.0.13846066) on this machine and reported the command and output. **The workload numbers in §4 come from a synthetic log I generated; they are not measurements of real user data.** The generator is in the appendix.
+
+---
+
+## Summary of findings
+
+Ordered by how much each one constrains the decision.
+
+1. **Nothing here disqualifies git.** The ticket's stated killer — a browser cannot reach a git remote without a proxy — was moot before this research started, because the web target is out of scope. On desktop and Android there was never a proxy problem. Everything below is cost and operational risk, not impossibility.
+
+2. **The single biggest lever is file layout, and it is not the one the ticket assumed.** "One file per writer" and "one file per writer *per month*" differ by **two orders of magnitude in local cost**. Measured over a synthetic decade (126.3 MB of log text, 3 writers, 3,650 daily commits, git 2.55.0):
+
+   | layout | write amplification | `.git` before repack | `.git` after `git gc` | `git gc` time |
+   |---|---|---|---|---|
+   | one file per writer (5 yr, **half** the decade) | **911.8×** | **9.14 GB** | 109.9 MB | 29.8 s |
+   | one file per writer per month (full decade) | **15.7×** | 133.5 MB | **47.5 MB** | **1.0 s** |
+
+   With one growing file, `git add` re-hashes the *entire* file on every commit, so cumulative bytes hashed is quadratic in the number of commits — measured at exactly `(days+1)/2 ×` the log's own size, over three run lengths. A decade means **~225 GB of hashing and ~36 GB of loose objects between repacks** [inference: quadratic extrapolation from three measured points]. Monthly segments bound the amplification at half a month and make the whole decade's history *smaller than the plain text it stores* (47.5 MB for 126.3 MB, ratio 0.376). §4.
+
+3. **A decade of history is nearly free; the current content is the whole cost.** Full clone of the decade repo moved **45.2 MB** on the wire; `--depth 1` moved **36.4 MB**. Ten years of history costs **8.8 MB more than the tip alone**. Shallow clone is not a meaningful optimisation for this shape of data — but `--filter=tree:0` moves only **2.4 MB** for all 3,650 commits, and `--filter=blob:none` **3.4 MB**, which is what makes a cheap "what do you have?" probe possible without cloning. §5.
+
+4. **"Am I behind?" costs two HTTP requests and about 1.3 KB, measured against a real host.** Protocol v2's capability advertisement is **191 bytes**; the `ls-refs` request is **108 bytes**; the reply is **~1,083 bytes for 17 refs** (~55–64 bytes per ref). With one ref per writer that is a few hundred bytes and one kept-alive TLS connection. **The version summary can be carried in the ref *name*** — `refs/heads/w1-seq-0000000134` — so `ls-remote` alone answers the question with no object transfer at all. One caveat found by testing: ref names may not nest, so `refs/heads/w/1` and `refs/heads/w/1/seq/…` cannot coexist. §5.
+
+5. **Git's unit of concurrency control is the ref, not the file — so per-writer *files* do not prevent push conflicts; per-writer *branches* do.** Two devices editing entirely disjoint files on one branch: the second push is rejected `! [rejected] main -> main (fetch first)`. The same two pushes to `refs/heads/w/1` and `refs/heads/w/2` both succeed with no interaction. This is the single most important structural finding for a design where "there are no conflicts to resolve". §7.
+
+6. **`git2` (libgit2) cross-compiles for `aarch64-linux-android` with HTTPS and SSH, verified by building it here** — it produced `libgit2.a`, `libssl.a` (vendored OpenSSL 3.6.3) and `libssh2.a`. It costs three vendored C libraries and an OpenSSL build in CI. `gix` is pure Rust plus `ring`, cross-compiles cleanly, and needs no OpenSSL — **but its SSH transport works by spawning an external `ssh` program**, and Android forbids `execve()` from the app's home directory. So on Android the practical choices are `gix` over **HTTPS only**, or `git2` with the C dependencies. §1.
+   Separately: **`gix` 0.86.0 does not compile on rustc 1.97.0 at all** — 16 errors in `gix-hash` 0.26.0 — and this is *not* Android-specific; it fails on the host too. `gix` 0.72.1 compiles everywhere I tried. §1.
+
+7. **`libgit2` is GPLv2 with a linking exception** — "the authors give you unlimited permission to link the compiled version of this library into combinations with other programs, and to distribute those combinations without any restriction coming from the use of this file" ([libgit2 `COPYING`](https://github.com/libgit2/libgit2/blob/main/COPYING)). Not a blocker, but it is the only copyleft licence in either stack. `gix` is MIT OR Apache-2.0 with no copyleft anywhere. §1.
+
+8. **The hosting terms are the sharpest external risk, and they differ.** One host states plainly that private repositories are "explicitly not [for use] as a personal cloud or media storage" ([Codeberg Terms of Use](https://codeberg.org/Codeberg/org/src/branch/main/TermsOfUse.md)) — which is what an append-only personal review log is. Another caps file requests at 5,000/hour explicitly "to prevent CDN-like usage" and hard-blocks pushes past 4 GB ([Bitbucket](https://confluence.atlassian.com/bbkb/what-are-the-repository-and-file-size-limits-1167700604.html)). GitHub's Acceptable Use Policies contain **no clause prohibiting data storage** — only §9 excessive bandwidth and §4 "excessive automated bulk activity" ([AUP](https://docs.github.com/en/site-policy/acceptable-use-policies/github-acceptable-use-policies)) — while its own docs warn "Git is not designed to serve as a backup tool" and recommend repos stay "less than 1 GB" ([large files](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github)). At 47.5 MB per decade none of the size limits bite; the *terms* are the exposure, not the bytes. §3.
+
+9. **Unattended operation on Android is the hardest constraint, and it is not specific to git.** While the device is dozing, "network access is suspended", "JobScheduler doesn't run", and sync adapters don't run ([Doze and App Standby](https://developer.android.com/training/monitoring-device-state/doze-standby)). A rarely-used app gets network "about once a day". Background work over 10 minutes needs a foreground service with a visible notification, and on Android 15 a `dataSync` foreground service is capped at **6 hours in any 24** before the system throws `RemoteServiceException` ([Android 15 behaviour changes](https://developer.android.com/about/versions/15/behavior-changes-15)). Our transfers are seconds, so the caps are irrelevant; the *notification* and the once-a-day network window are the real design constraints. App-private internal storage is a normal filesystem directory with no permissions required and no other app able to read it ([app-specific storage](https://developer.android.com/training/data-storage/app-specific)) — adequate for a git working directory. §6.
+
+10. **Two recovery paths are worse than expected, both verified by testing.** A killed `git clone` **deletes the target directory entirely** — no partial progress is kept, and git's smart protocol has no resume, so a device on a bad link retries the whole transfer from zero. And a repository with one missing object **is not repaired by re-fetching**: negotiation is ref-based, the remote believes the client already has the object, and `git fsck` still reports the broken link afterwards. Recovery from corruption is re-clone. §7.
+
+---
+
+## 1. Rust git implementations that work on Android
+
+### 1.1 What I built, and how
+
+All builds used the toolchain on this machine: `rustc 1.97.0 (2d8144b78 2026-07-07)`, `cargo-ndk`, NDK `29.0.13846066`, target `aarch64-linux-android`. Each probe was a bare `lib.rs` with a single dependency, so nothing but the crate under test and its tree was compiled.
+
+```
+cargo ndk -t arm64-v8a check  --target aarch64-linux-android    # dependency resolution + build scripts
+cargo ndk -t arm64-v8a build  --target aarch64-linux-android    # full compile and archive production
+```
+
+### 1.2 `git2` / libgit2 — builds, at the cost of three C libraries
+
+`git2` 0.21.0 with `features = ["https", "ssh", "vendored-libgit2", "vendored-openssl"]` **compiles and links for `aarch64-linux-android`**. The archives it produced under `target/aarch64-linux-android/debug/build/`:
+
+```
+libgit2-sys-…/out/build/libgit2.a
+openssl-sys-…/out/openssl-build/install/lib/libssl.a
+libssh2-sys-…/out/build/libssh2.a
+```
+
+Resolved versions: `git2` 0.21.0, `libgit2-sys` 0.18.7+**1.9.6**, `libssh2-sys` 0.3.2, `openssl-sys` 0.9.117, `openssl-src` 300.6.1+**3.6.3**.
+
+Three facts about that build worth carrying:
+
+- **Nothing is on by default.** `git2`'s manifest is `default = []`; `https = ["libgit2-sys/https", "openssl-sys", "openssl-probe", "cred"]` and `ssh = ["libgit2-sys/ssh", "cred"]` ([`Cargo.toml`](https://github.com/rust-lang/git2-rs/blob/master/Cargo.toml)). Network support is entirely opt-in.
+- **OpenSSL is not optional on Android.** `libgit2-sys`'s build script picks the TLS backend by target: `GIT_WINHTTP` on Windows, `GIT_SECURE_TRANSPORT` on Apple, and otherwise `#define GIT_OPENSSL 1` ([`libgit2-sys/build.rs`](https://github.com/rust-lang/git2-rs/blob/master/libgit2-sys/build.rs)). Android falls in the `else`, so HTTPS means shipping OpenSSL — 3.6.3, compiled from source, in every CI run and for every ABI.
+- **libgit2 has an explicit Android carve-out.** The same build script contains `if !target.contains("android") { features.push_str("#define GIT_USE_NSEC 1\n"); }` — nanosecond stat timestamps are disabled on Android. The consequence is coarser index-staleness detection, i.e. git may need to re-hash a file it would otherwise skip [inference: that is what `GIT_USE_NSEC` controls; I did not measure the effect].
+
+### 1.3 `gix` — pure Rust, but SSH is a subprocess
+
+`gix` 0.72.1 with `default-features = false, features = ["blocking-network-client"]` and again with `"blocking-http-transport-reqwest-rust-tls"` added **both check clean for `aarch64-linux-android`**. The only build-script/C crate anywhere in the 262-package lock is `ring` 0.17.14 (pulled in by `rustls` 0.23.43 via `reqwest` 0.12.28). No OpenSSL, no libssh2, no libgit2.
+
+Two caveats, both material:
+
+- **`gix` 0.86.0 (current) does not compile on rustc 1.97.0.** `cargo check` fails with 16 errors in `gix-hash` 0.26.0 (`E0004` non-exhaustive match, `E0308`, `E0665`). I re-ran the same check for the **host** target (`x86_64-unknown-linux-gnu`) and it fails identically, so **this is a crate/toolchain incompatibility, not an Android problem**. Pinning to `=0.72` compiles. Anyone re-checking this should re-test current `gix` before concluding anything about it.
+- **`gix`'s SSH transport shells out.** The blocking SSH client "connect[s] to `host` using the ssh program", and its `ProgramKind` enum — "The kind of SSH programs we have built-in support for" — is `Ssh`, `Plink`, `Putty`, `TortoisePlink`, `Simple` ([`gix-transport` ssh module](https://docs.rs/gix-transport/latest/gix_transport/client/blocking_io/ssh/index.html), [`ProgramKind`](https://docs.rs/gix-transport/latest/gix_transport/client/blocking_io/ssh/enum.ProgramKind.html)). Every one of those is an external executable. That collides head-on with Android's sandbox: "Untrusted apps that target Android 10 cannot invoke `execve()` directly on files within the app's home directory", because "Execution of files from the writable app home directory is a W^X violation" and "Apps should load only the binary code that's embedded within an app's APK file" ([Android 10 behaviour changes](https://developer.android.com/about/versions/10/behavior-changes-10)).
+
+  So `gix` + SSH on Android requires either shipping an `ssh` binary inside the APK where it is executable, or writing a custom transport over a Rust SSH client. The latter is available: `russh` 0.62.4 — "Low-level Tokio SSH2 client and server implementation", supporting public-key auth with `ssh-ed25519`, `rsa-sha2-256/512` and ECDSA ([README](https://github.com/Eugeny/russh)) — **checks clean for `aarch64-linux-android`** in the same harness.
+
+### 1.4 Licences (read from the manifests and bundled sources on disk)
+
+| Component | Licence |
+|---|---|
+| `git2` 0.21.0, `libgit2-sys`, `libssh2-sys` (the Rust wrappers) | `MIT OR Apache-2.0` |
+| **bundled libgit2 1.9.6** | **GPLv2 with a linking exception** |
+| bundled libssh2 | BSD-3-clause style (Golemon/Stenberg/Josefsson/Microsoft copyrights, "Redistribution and use in source and binary forms, with or without modification, are permitted provided…") |
+| bundled OpenSSL 3.6.3 | Apache License 2.0 |
+| `openssl-sys` 0.9.117 | `MIT` · `openssl-src` | `MIT/Apache-2.0` |
+| `gix` 0.72.1 | `MIT OR Apache-2.0` |
+| `russh` 0.62.4 | `Apache-2.0` · `ring` 0.17.14 | `Apache-2.0 AND ISC` · `rustls` 0.23.43 | `Apache-2.0 OR ISC OR MIT` |
+
+The libgit2 exception is the only copyleft in play and it is written to permit exactly this use: "In addition to the permissions in the GNU General Public License, the authors give you unlimited permission to link the compiled version of this library into combinations with other programs, and to distribute those combinations without any restriction coming from the use of this file" ([`COPYING`](https://github.com/libgit2/libgit2/blob/main/COPYING)). The same file insists "the only valid version of the GPL as far as this project is concerned is _this_ particular version of the license (ie v2, not v2.2 or v3.x or whatever)".
+
+---
+
+## 2. Auth without a server
+
+The constraint is that we can register a client identifier but cannot keep a secret and cannot run a redirect endpoint. Three mechanisms clear that bar.
+
+### 2.1 SSH keypair generated on the device
+
+The user-facing cost is stated by the host: "you will need to generate a new private SSH key and add it to the SSH agent. You must also add the public SSH key to your account on GitHub before you use the key to authenticate" ([about SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh)). Translated into our setting: **one enrolment per device** — generate a keypair on-device, get the public half onto the host once. Nothing expires, nothing needs refreshing, and the private key never leaves the device.
+
+The friction is the transfer of the public key. On Android that means the user pasting a public key into a web form on the phone, which is bearable, but note the standing constraint that **Android text input in this app is ASCII-only** (`AGENTS.md` rule 8) — a base64 public key is ASCII, so copy-out works; typing anything non-Latin does not. On Android the keypair itself would be generated in-process by a Rust SSH library, not by an `ssh-keygen` binary (§1.3).
+
+### 2.2 A token typed or pasted once
+
+Fine-grained personal access tokens take an expiry "Integer between 1 and 366" days or `none`, and "Infinite lifetimes are allowed but may be blocked by a maximum lifetime policy set by your organization or enterprise owner" ([managing PATs](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)). Classic tokens can be non-expiring, but "GitHub automatically removes personal access tokens that haven't been used in a year" (same source) — which is precisely the device-in-a-drawer case this app has to survive.
+
+**Decision-relevant shape:** a token with an expiry turns unattended sync into a chore that recurs at most annually and silently breaks sync when it lapses; a non-expiring token is the only variant that is genuinely fire-and-forget, and it is exactly the variant the host discourages and an organisation policy can forbid.
+
+### 2.3 OAuth device flow — the only one that needs no typing and no secret
+
+For the device flow "you must pass your app's client ID… The `client_secret` is not needed", the device shows a short user code, the user enters it at a verification URL in any browser, and the app polls; codes expire after "900 seconds or 15 minutes". It exists "for apps that don't have access to a web browser" ([authorizing OAuth apps](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps)).
+
+This is the mechanism that fits an Android app with no server: the client ID is public by design, there is no redirect URI to host, and enrolment is "type six characters on any device you like". The cost is token lifetime — a GitHub App's "user access token expires after eight hours, and the refresh token expires after six months" ([refreshing user access tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens)). **A six-month refresh-token horizon is shorter than "device left in a drawer for a year", so device flow alone does not survive the offline case that §7 has to handle.** Classic OAuth App tokens do not expire unless the app opts in — but the linked doc does not state that positively, so I am marking it unverified (§8).
+
+### 2.4 Where the credential lives
+
+**Android.** App-specific internal storage needs no permission, "other apps cannot access files stored within internal storage", "On Android 10 (API level 29) and higher, these locations are encrypted", and files are removed on uninstall ([app-specific storage](https://developer.android.com/training/data-storage/app-specific)). For the secret itself, the keystore is a key container, not a secret store: "Key material never enters the application process… key material remaining non-exportable", bound to the TEE or a StrongBox secure element ([Android Keystore](https://developer.android.com/privacy-and-security/keystore)). The idiomatic arrangement is therefore a keystore-held key that encrypts a token at rest in app-private storage — the keystore cannot hold the token, only protect it.
+
+An SSH private key has the same problem in a sharper form: it must be usable by the SSH library in-process, so it cannot be a non-exportable keystore key unless the SSH implementation delegates signing to the keystore. **Whether `russh` can be driven from an externally-held signer is not something I established** (§8).
+
+**Desktop.** Git's own mechanism is credential helpers — "programs executed by Git to fetch or save credentials from and to long-term storage", invoked with `get`/`store`/`erase`, resolved by prefixing `git credential-` to the configured name ([`gitcredentials`](https://git-scm.com/docs/gitcredentials)). The two built-ins are `cache` (in memory, short-lived) and `store`, which stores credentials **unencrypted on disk indefinitely**. Since we would be embedding a git library rather than driving the CLI, the helper protocol is available to reuse but not automatic; the equivalent choice on desktop is the platform keyring.
+
+---
+
+## 3. Hosting reality
+
+### 3.1 Size and bandwidth, with real numbers
+
+| Host | Per-file | Per-repo | Per-push | Other |
+|---|---|---|---|---|
+| GitHub | warning >50 MiB, **blocked >100 MiB** | recommended "<1 GB", "less than 5 GB is strongly recommended" | not published | Git LFS free tier 10 GiB storage + 10 GiB bandwidth/month; at $0 budget "Git LFS usage is blocked for the rest of the calendar month" |
+| GitLab.com Free | "100 MiB per-file limit… when pushing new files" | **10 GiB per project**; beyond it "the project is set to a read-only state" and "you cannot push changes" | — | — |
+| Bitbucket Cloud | 1 GB file upload | warning at 2 GB, **hard block at 4 GB** ("ability to push new commits… will be disabled"); Free workspaces get **1 GB total** | 3.5 GB ("pack exceeds maximum allowed size") | **5,000 file requests/hour "to prevent CDN-like usage"** |
+| Codeberg | not published | not published; "unreasonable storage requirements" may trigger warnings or suspension | — | — |
+
+Sources: [GitHub large files](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github), [GitHub LFS billing](https://docs.github.com/en/billing/concepts/product-billing/git-lfs), [GitLab push limit](https://docs.gitlab.com/user/free_push_limit/), [GitLab storage quotas](https://docs.gitlab.com/user/storage_usage_quotas/), [Bitbucket limits](https://confluence.atlassian.com/bbkb/what-are-the-repository-and-file-size-limits-1167700604.html), [Codeberg Terms of Use](https://codeberg.org/Codeberg/org/src/branch/main/TermsOfUse.md).
+
+**Against §4's measured 47.5 MB for a synthetic decade, every one of these limits has three orders of magnitude of headroom.** Size is not the risk.
+
+### 3.2 What the terms actually say about using a repo as a data store
+
+This is where the hosts diverge, and it is worth quoting rather than summarising.
+
+**A host that says no, in as many words.** Codeberg scopes the whole service to "projects covered by a licence for free and open source software, free and open source hardware, or free cultural works", and permits private repositories for "really small & personal stuff like your journal, config files, ideas or notes, **but explicitly not as a personal cloud or media storage**" ([Terms of Use](https://codeberg.org/Codeberg/org/src/branch/main/TermsOfUse.md)). A machine-written append-only review log, growing daily and pushed unattended, is closer to the prohibited side of that line than to "notes". Codeberg is a poor default here — not because it would break, but because the terms say not to.
+
+**A host that says nothing, and warns technically instead.** GitHub's Acceptable Use Policies have no clause about storage or non-code data. The nearest are §9 Excessive Bandwidth Use — "If we determine your bandwidth usage to be significantly excessive in relation to other users of similar features, we reserve the right to suspend your Account, throttle your file hosting, or otherwise limit your activity" — and §4, which prohibits "using our servers for any form of excessive automated bulk activity, to place undue burden on our servers through automated means" ([AUP](https://docs.github.com/en/site-policy/acceptable-use-policies/github-acceptable-use-policies)). The Terms of Service add only an API-abuse clause under §H ([ToS](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service)). Its *technical* documentation is discouraging without being prohibitive: "**Git is not designed to serve as a backup tool**" and "Git is not designed to handle large SQL files" ([large files](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github)).
+
+  A once-or-twice-daily push of tens of kilobytes from a handful of a single user's devices is hard to construe as "excessive automated bulk activity" [inference — this is my reading of the clause, not a statement by the host].
+
+**A host that enforces against it mechanically.** Bitbucket's 5,000-file-requests-per-hour cap is documented as existing "to prevent CDN-like usage" — a host that has thought about this pattern and priced it.
+
+**A host where storing arbitrary data *is* the product.** A generic SSH storage account sidesteps the terms question entirely, because there is no "this is for code" premise to violate. rsync.net documents running git over its SSH accounts, including `ssh user@rsync.net "git clone --mirror …"` and using credential helpers or tokens for private upstreams ([rsync.net git howto](https://www.rsync.net/resources/howto/git.html)). The catch is the price floor: "1.5 Cents Per GB Per Month" with an "800 GB Minimum Order" ([pricing](https://www.rsync.net/pricing.html)) — roughly $12/month to store 47.5 MB. **That is not a storage cost, it is an entry fee**, and it is the honest answer to "is there a host that unambiguously permits this?": yes, and it is priced for backups, not for a flashcard app.
+
+---
+
+## 4. Behaviour under this workload
+
+### 4.1 What I generated, and the disclaimer
+
+**These numbers come from a synthetic log, not from real user data.** The generator emits JSON Lines rows shaped like the ADR-0004 log, averaging **169.1 bytes**:
+
+```
+{"w":1,"s":1,"ts":"2026-01-01T04:53:31.582Z","card":"d8f16adf-cd61-4c38-1027-1e2f414c343c","kind":"review","grade":4,"ivl":3117,"last_ivl":921,"factor":2267,"ms":21951}
+```
+
+Card ids are random UUID-shaped hex, so the data has genuine entropy and does not compress unrealistically well. Three writers share 200 rows/day (67/67/66). A decade is **3,650 daily commits and 126.3 MB of text** — about 15% above the ticket's ~110 MB estimate, because JSON key names cost more than the raw field widths.
+
+Harness settings, all disclosed because two of them are not defaults: `gc.auto=0` so that repacks happen at points I control and can time; an explicit `git gc` every 365 commits plus a final one; and `core.looseCompression=1`, which speeds only the loose-object write path and leaves pack compression at its default — without it the single-file runs would not finish in reasonable time, which is itself a finding.
+
+### 4.2 One growing file per writer: the cost is quadratic
+
+Three run lengths, same generator, same settings:
+
+| days | log text | bytes re-hashed by `git add` | amplification | `.git` before final gc | `.git` after gc | ratio to text | ms/commit | final `gc` |
+|---|---|---|---|---|---|---|---|---|
+| 200 | 6.9 MB | 0.69 GB | **100.3×** | 303.8 MB | 6.3 MB | 0.92 | 138 | 1.3 s |
+| 730 | 25.1 MB | 9.18 GB | **365.1×** | 3,036 MB | 45.2 MB | 1.80 | 259 | 10.4 s |
+| 1,825 | 63.0 MB | 57.4 GB | **911.8×** | 9,142 MB | 109.9 MB | 1.75 | 375 | 29.8 s |
+
+The amplification figures are `100.3`, `365.1`, `911.8` against `(days+1)/2` = `100.5`, `365.5`, `913` — **the amplification is exactly half the commit count**, because `git add` re-hashes and re-compresses the whole file every time one line is appended. Extrapolating the same law to a decade: **1,825× amplification, ~225 GB hashed, and ~36 GB of loose objects accumulated between repacks** [inference: quadratic extrapolation, not measured — the 5-year run took 744 s and the decade would take roughly four times that].
+
+The intermediate `git gc` times from the 5-year run show the repack cost climbing too: **3.9 s → 10.2 s → 19.3 s → 23.1 s** at years 1–4, and 29.8 s for the final one. On a phone, on battery, that is the number that matters, not the megabytes.
+
+Default git also would not have repacked when I did. With ~9 objects per daily commit (3 blobs, 5 trees, 1 commit) and `gc.auto` defaulting to 6,700 loose objects, the first automatic repack lands around **day 744** [inference: arithmetic over the default and the observed object count] — by which point the 730-day run had **3.0 GB** of loose objects sitting in `.git`.
+
+### 4.3 Monthly segments per writer: the cost is linear and small
+
+Same decade, same rows, one file per writer per calendar month, still one commit per day:
+
+```
+layout=monthly days=3650 writers=3
+worktree log bytes      : 126277860 (126.3 MB)
+bytes re-hashed by add  : 1985011910 (2.0 GB)  amplification x15.7
+.git before final gc    : 133467172 (133.5 MB)
+.git after  final gc    :  47520964 ( 47.5 MB)  ratio to worktree 0.376
+build wall time         : 613.3 s (git add+commit 600.5 s, 165 ms/commit)
+intermediate gc runs    : [(365,0.7),(730,0.7),(1095,0.9),(1460,1.5),(1825,1.1),(2190,1.0),(2555,1.1),(2920,0.9),(3285,0.9)]
+final git gc            : 1.0 s
+```
+
+Every number that mattered above collapses: amplification bounded at half a month (**15.7×**), `.git` never exceeding 133 MB even unrepacked, repacks flat at **~1 second for the whole decade**, and per-commit cost flat at 165 ms instead of climbing past 375 ms. And the entire decade of history — 3,650 commits — occupies **less space than the plain text it stores** (0.376×).
+
+### 4.4 Does an append-only text file delta-compress? Yes, but the default depth cap fights it
+
+A control repository containing only the *final* 730-day content in a single commit, with no history at all, packs to **7.27 MB** for 25.1 MB of text — so git's own compression on this data is **0.29×**. The 730-day repo with full history packs to 45.2 MB, meaning **37.9 MB of history overhead across 730 commits, ≈52 KB per daily commit** for 34.5 KB of new raw text.
+
+That is worse than it needs to be, and the cause is a default. Repacking the same repository with a deeper delta chain:
+
+```
+$ git repack -adfq --depth=1000 --window=50
+real 0m22,374s   user 2m24,767s
+.git: 45,227,334 → 25,500,099 bytes
+```
+
+**`pack.depth` defaults to 50**, so with one file revised 730 times git must store a full copy roughly every 50 revisions; lifting the cap recovers 19.7 MB (44%) at the cost of a 22-second repack. This is a real lever, but it only mitigates a layout problem that monthly segments avoid outright.
+
+A separate micro-test settles that thin-pack deltas do work on this data in principle: a single 449 KB file built by 120 daily commits produces a **2,357-byte** thin pack for one day's fetch, against **1,605 bytes** for the same day's new rows piped through `gzip -6`. Delta compression of an append is near-optimal when the pack layout cooperates.
+
+---
+
+## 5. The "am I behind?" handshake
+
+### 5.1 What asking a real remote costs, measured
+
+Against a real public repository over HTTPS with git 2.55.0 (`GIT_TRACE_CURL=1`, and `curl` for the first leg):
+
+| Leg | Bytes | Note |
+|---|---|---|
+| `GET /info/refs?service=git-upload-pack` with `Git-Protocol: version=2` | **191 down** | capability advertisement only |
+| the same GET **without** the v2 header (protocol v0) | **1,441 down** | v0 advertises every ref up front |
+| `POST /git-upload-pack` carrying `command=ls-refs` | **108 up** | |
+| its response, 17 refs | **983–1,083 down** | ≈55–64 bytes per ref |
+
+Two HTTP requests over one kept-alive TLS connection; ~0.23 s and ~0.20 s from this machine. This is exactly what protocol v2 was designed for: "Reference advertisement will be omitted unless explicitly requested", and `ls-refs` "takes in arguments which can be used to limit the refs sent from the server", including `ref-prefix <prefix>` ([protocol-v2](https://git-scm.com/docs/protocol-v2)).
+
+**One correction to the obvious assumption:** `git ls-remote` does *not* use `ref-prefix`. Tracing the packets with a pattern argument shows the request is byte-identical to the unfiltered one and contains zero `ref-prefix` lines:
+
+```
+$ GIT_TRACE_PACKET=1 git -c protocol.version=2 ls-remote <url> 'refs/heads/*' 2>&1 | grep -c ref-prefix
+0
+=> Send data: 0014command=ls-refs.001aagent=git/2.55.0-Linux0016object-format=sha100010009peel.000csymrefs.000bunborn.0000
+```
+
+`ls-remote` asks for everything and filters locally. At 5 writer refs that is irrelevant; it would matter only if the ref namespace grew large.
+
+### 5.2 The summary can live in the ref name — with one hard constraint
+
+Because a ref is just a name pointing at a hash, the `{writer id → highest sequence}` summary can be encoded in the names themselves, making `ls-remote` a complete answer with **zero object transfer**. Verified locally:
+
+```
+$ git ls-remote /…/o.git
+0a5ee340…  refs/heads/w/1
+1ebb903b…  refs/heads/w1-seq-0000000134
+1ebb903b…  refs/leitner/w1
+```
+
+Two findings from building that:
+
+- **Ref names cannot nest.** Trying to keep both `refs/heads/w/1` and a sequence-bearing child fails at the server:
+  ```
+  remote: error: cannot lock ref 'refs/heads/w/1/seq/0000000067': 'refs/heads/w/1' exists;
+                 cannot create 'refs/heads/w/1/seq/0000000067'
+   ! [remote rejected] HEAD -> w/1/seq/0000000067 (refname conflict)
+  ```
+  So a sequence-in-the-name scheme needs **flat** names (`w1-seq-0000000134`), and advancing the counter is a create-new-then-delete-old pair rather than an update.
+- **A non-branch namespace works** on a plain git server: pushing `HEAD:refs/leitner/w1` succeeded and `ls-remote` returns it. Whether the hosted forges accept pushes outside `refs/heads/` and `refs/tags/` I did **not** verify (§8) — and per-writer *branches* avoid the question entirely.
+
+### 5.3 Clone and fetch costs at decade scale
+
+Against the 126.3 MB / 47.5 MB / 32,850-object decade repository, cloned over `file://` (which uses the same pack protocol as the network, so the wire figures transfer; the wall-clock figures do not):
+
+| clone mode | wire | objects | `.git` | wall |
+|---|---|---|---|---|
+| full | **45.2 MB** | 32,850 | 46.3 MB | 1.44 s |
+| `--depth 1` | 36.4 MB | 366 | 36.4 MB | 0.74 s |
+| `--depth 30` | 36.4 MB | 624 | 36.5 MB | 0.79 s |
+| `--filter=blob:none` | **3.4 MB** | 21,900 | 40.7 MB after checkout faults blobs in | 0.73 s |
+| `--filter=tree:0` | **2.4 MB** | 3,650 | 39.2 MB | 0.68 s |
+
+**A decade of history costs 8.8 MB more than the tip alone (45.2 vs 36.4).** Shallow clone buys almost nothing here, because this repository is not deep-history-heavy — it is content-heavy, and the content is all live. The partial-clone filters are the interesting ones: `tree:0` fetches all 3,650 commits for 2.4 MB, which is enough to *read the log's shape* — commit messages, dates, which segments exist — before deciding what to download. Git's own caveat applies: missing objects are "faulted in" on demand and "Dynamic object fetching tends to be slow as objects are fetched one at a time" ([partial-clone](https://git-scm.com/docs/partial-clone)), and the server must opt in via `uploadpack.allowFilter`.
+
+### 5.4 Incremental fetch: what "behind by N days" actually transfers
+
+Measured by building the exact thin pack the server would send (`git pack-objects --stdout --thin --revs --delta-base-offset`):
+
+| device is behind | monthly segments (decade repo) | one file per writer (2-year repo) |
+|---|---|---|
+| 1 day | 101 KiB | **13 KiB** |
+| 7 days | 150 KiB | 91 KiB |
+| 30 days | 457 KiB | 389 KiB |
+| 90 days | 1,113 KiB | 1,159 KiB |
+| 365 days | 4.63 MiB | 12.4 MiB |
+| 1,825 days | 22.2 MiB | — |
+
+**The daily-sync cost of the monthly layout depends on where in the month you are.** Stepping one commit at a time across a month boundary:
+
+```
+reviews 2035-11-29 : 104268 B      reviews 2035-12-01 :  11360 B
+reviews 2035-11-30 : 107552 B      reviews 2035-12-02 :  21420 B
+                                   …
+                                   reviews 2035-12-29 : 104033 B
+```
+
+The cost fits `≈ 8.0 KB + 3.31 KB × day-of-month` and resets on the 1st — mean **≈59 KB/day, ≈21 MB/year of download for 12.6 MB/year of new text**, a wire overhead of about 1.7×. **I could not fully account for that shape** (§8): `--no-reuse-delta` changes nothing for the one-day case, and the micro-test in §4.4 shows thin-pack deltas working near-optimally on an equivalent single file, so it is a property of how `git gc` laid out this pack rather than a limit of the protocol. The practical reading is that **shorter segments make each fetch cheaper**, and daily segment files would make the one-day fetch approach the ~10 KB floor of the data itself [inference].
+
+The single-file layout is *better* on the wire for a daily sync (13 KiB) and *far worse* for a year-behind catch-up (12.4 MiB vs 4.63 MiB) — and, per §4.2, catastrophically worse locally. That is the whole trade-off in two columns.
+
+---
+
+## 6. Unattended operation on Android
+
+### 6.1 The device will not let you sync whenever you like
+
+While the device is idle, the system suspends network access, ignores wake locks, defers `AlarmManager` alarms including `setExact()`, and does not run `JobScheduler` jobs or sync adapters — the last of which "affects WorkManager tasks as well". It emerges only periodically: "the system exits Doze for a brief time to let apps complete their deferred activities. During this *maintenance window*, the system runs all pending syncs, jobs, and alarms, and lets apps access the network", and it "schedules maintenance windows less frequently over time". For an app the user has not opened recently, App Standby defers network to **about once a day**, and the escape hatches `setAndAllowWhileIdle()` / `setExactAndAllowWhileIdle()` "cannot fire alarms more than once per nine minutes, per app" ([Doze and App Standby](https://developer.android.com/training/monitoring-device-state/doze-standby)).
+
+**Read against this app's requirements, that is workable.** A review log does not need minute-level freshness; "sync at least daily, and immediately when the user opens the app" is inside what Doze permits without any exemption. What is *not* available is "push my reviews the moment I grade a card while the phone is in my pocket".
+
+### 6.2 Long transfers need a visible notification, and are capped
+
+Work that exceeds WorkManager's ordinary window must be promoted: `setForeground()`/`setForegroundAsync()` mean "WorkManager manages and runs a foreground service on your behalf to execute the `WorkRequest`, while also showing a configurable notification", and "These Workers can run longer than 10 minutes". Targeting Android 14+, "you must specify a foreground service type for all long-running workers" ([long-running workers](https://developer.android.com/develop/background-work/background-tasks/persistent/how-to/long-running)).
+
+The matching type is `dataSync`, requiring `FOREGROUND_SERVICE_DATA_SYNC` and intended for "data upload or download", "backup-and-restore operations", "transfer data between a device and the cloud over a network" ([service types](https://developer.android.com/develop/background-work/services/fgs/service-types)). Its Android 15 limits:
+
+> "Apps targeting Android 15 can run `dataSync` foreground services for a total of **6 hours in a 24-hour period**." After that the system calls `Service.onTimeout()`, the service has "a few seconds to call `Service.stopSelf()`", and otherwise the system throws `android.app.RemoteServiceException: "A foreground service of type dataSync did not stop within its timeout"`. "The 6-hour limit is shared across all an app's `dataSync` foreground services", but "if the user brings the app to the foreground, the timer resets". Separately, `BOOT_COMPLETED` receivers "are not allowed to launch" a `dataSync` foreground service, raising `ForegroundServiceStartNotAllowedException`.
+> — [Android 15 behaviour changes](https://developer.android.com/about/versions/15/behavior-changes-15)
+
+**Our transfers are seconds** — §5.4 puts a daily fetch at ~59 KB and a year-behind catch-up at 4.63 MB — so the 6-hour cap is irrelevant and the 10-minute worker window is ample even for a first clone. The binding costs are the **user-visible notification** for anything promoted to the foreground, and the fact that **sync cannot be started from boot**.
+
+The one case that could exceed the window is a *first* clone on a slow link: 45.2 MB full, or 36.4 MB shallow. At a poor 200 kbit/s that is 25–30 minutes — beyond 10 minutes, so a first sync would need the foreground-service path, and per §7.3 it is not resumable.
+
+### 6.3 Does git-on-Android get a real filesystem? Yes
+
+App-specific internal storage "doesn't require any system permissions to read and write", "other apps cannot access files stored within internal storage", is "encrypted" on Android 10+, and is used through ordinary `File` APIs and streams ([app-specific storage](https://developer.android.com/training/data-storage/app-specific)). Scoped-storage restrictions target shared external storage, not this directory. For git's needs — atomic `rename()` for ref updates, `O_EXCL` lock files, ordinary read/write — that is sufficient [inference: the doc establishes it is a normal writable filesystem directory; I did not run a git repository on a handset to confirm every syscall git relies on behaves, and §8 records that gap].
+
+The one capability it does **not** grant is execution: `execve()` on files in the app home directory is refused for apps targeting Android 10+ ([Android 10 behaviour changes](https://developer.android.com/about/versions/10/behavior-changes-10)). So anything in the git stack that works by spawning a helper program — `gix`'s SSH transport (§1.3), git's own credential helpers (§2.4) — has no home there. **Everything must be in-process.**
+
+---
+
+## 7. What goes wrong
+
+### 7.1 Two devices pushing at once — the file layout does not save you
+
+The premise "per-writer files mean git never has to merge anything" is true about *content* and false about *pushes*. Git's compare-and-swap is on the ref. Two clones, each committing a file the other never touches, both pushing `main`:
+
+```
+--- A pushes:
+   9e7205a..4200cb2  main -> main
+--- B pushes (different file, no textual conflict):
+ ! [rejected]        main -> main (fetch first)
+error: failed to push some refs to '…/origin.git'
+hint: Updates were rejected because the remote contains work that you do not
+hint: have locally. This is usually caused by another repository pushing to
+hint: the same ref.
+--- B recovers by rebase, then pushes:
+   4200cb2..673daa3  main -> main
+```
+
+**Per-writer files on one branch do not remove the conflict; they only guarantee the automatic resolution is trivial.** Every concurrent push still costs a fetch-and-replay round trip, and the recovery has to be implemented and tested because two devices syncing on the same schedule will collide.
+
+**Per-writer branches remove it entirely.** The identical pair of pushes, retargeted:
+
+```
+--- A2 -> refs/heads/w/1:   * [new branch]      HEAD -> w/1
+--- B2 -> refs/heads/w/2:   * [new branch]      HEAD -> w/2
+```
+
+Both succeed; the devices never contend. The cost is that no single ref names "the whole log" — a reader must enumerate refs (which §5.1 shows costs ~55 bytes each) and merge at read time. That is the same shape as ADR-0004's read-time merge, so it is not a new burden.
+
+When a shared ref *is* unavoidable — the mutable surface of deck names, tags and scheduler config — git offers a real compare-and-swap rather than blind force:
+
+```
+$ git push --force-with-lease=refs/heads/shared origin HEAD:refs/heads/shared
+ ! [rejected]        HEAD -> shared (stale info)
+```
+
+The lease is checked against the client's last-known value, so a device that has not seen the newest state cannot clobber it. That is exactly the `ETag` + `If-Match` primitive the ticket asks about, available on any git remote with no server support beyond ordinary `receive-pack`.
+
+### 7.2 A device offline for a year
+
+Nothing structural breaks: the catch-up is a single fetch of **4.63 MiB** (monthly segments, §5.4) and completes in well under a second locally. The failure modes are elsewhere and are all credential-shaped (§2): a fine-grained token past its ≤366-day expiry, a classic token auto-removed after a year of disuse, or a device-flow refresh token past its six-month life. **A year in a drawer is survivable for the data and not survivable for most of the auth options.** SSH keys are the exception — they do not expire.
+
+### 7.3 Interrupted transfers are not resumable, and a killed clone loses everything
+
+Killing `git clone` mid-transfer:
+
+```
+$ timeout 0.6 git clone -q file://…/single2y part
+exit=124 ; bytes kept in part/:      # the directory is gone
+```
+
+Git removes the target directory on failure. A killed `git fetch` into an existing repository is only slightly better: it leaves an orphan temp pack that the retry does not use.
+
+```
+timeout=0.5s exit=124 .git bytes=25041771 objects=1   pack dir: tmp_pack_roOm19
+timeout=1.0s exit=124 .git bytes=25041771 objects=1   pack dir: tmp_pack_W6i2d7
+timeout=2.0s exit=124 .git bytes=25041771 objects=1   pack dir: tmp_pack_3VqgVG
+```
+
+Each attempt writes a fresh `tmp_pack_*` and starts over. On a phone that drops off Wi-Fi mid-clone, **the first sync restarts from zero every time**, and each failed attempt leaves ~25 MB of garbage until something prunes it. This is the strongest argument for `--filter=tree:0` or `--depth 1` on the *first* sync (§5.3): a 2.4 MB transfer succeeds on links where a 45 MB one does not.
+
+### 7.4 Corruption is not repaired by refetching
+
+Delete one object from a healthy clone and ask git to fix itself:
+
+```
+$ rm C2/.git/objects/75/f31e7f2832a06039604f49cfce0286dcce17f1
+$ git fsck
+broken link from  commit 97083a87696e794656eb2fee068671f33fafdb81
+              to    tree 75f31e7f2832a06039604f49cfce0286dcce17f1
+missing tree 75f31e7f2832a06039604f49cfce0286dcce17f1
+$ git fetch --all && git fsck
+broken link from  commit 97083a87696e794656eb2fee068671f33fafdb81
+              to    tree 75f31e7f2832a06039604f49cfce0286dcce17f1
+```
+
+**A refetch does not heal it.** Negotiation is driven by refs: the client's ref still points at a commit the server also has, so the server concludes there is nothing to send. Recovery from local corruption means re-cloning — 45.2 MB, or 36.4 MB shallow — which loops back into §7.3's non-resumability. The compensation is that corruption is *detectable*: git object names are content hashes, so `git fsck` gives a definitive integrity answer that a plain file sync cannot.
+
+---
+
+## 8. What I could not establish
+
+Each of these is load-bearing enough that a decision should not silently assume an answer.
+
+1. **Whether the hosted forges accept pushes outside `refs/heads/` and `refs/tags/`.** It works on a plain git server (§5.2); I did not test it against a host, because doing so means writing to a real repository. Per-writer branches avoid needing the answer.
+2. **Whether classic OAuth App tokens expire.** The GitHub App document states 8-hour user tokens with 6-month refresh tokens; it does not positively state the OAuth App case, and I did not find a doc that does. This decides whether device-flow enrolment survives §7.2's year-offline device.
+3. **Why a one-day fetch in the monthly-segment layout costs the month-to-date rather than the day** (§5.4). The measurement is reproducible and linear; the mechanism is not accounted for, and `--no-reuse-delta` does not change it.
+4. **Whether a Rust SSH client can sign with an Android-keystore-held, non-exportable key.** If not, the SSH private key must sit encrypted-at-rest in app-private storage rather than in the TEE (§2.4).
+5. **Whether git actually runs correctly against Android app-private storage on a real handset.** The documentation establishes a normal writable filesystem directory; the repo's own rule ("Verify Android on the real handset", `AGENTS.md` rule 9) means this stays open until someone runs a clone and a push on the Pixel.
+6. **Whether an `ssh` binary shipped in the APK's native library directory is executable**, which is the only route to `gix` + SSH on Android. The Android 10 rule prohibits `execve()` from the *app home directory*; whether the extracted native-library directory is exempt I did not verify.
+7. **Real-network timings.** Every clone and fetch figure in §5 was measured over `file://`. The *wire byte counts* transfer directly (same pack protocol); the wall-clock numbers do not, and no mobile-network measurement was taken.
+8. **The decade-scale single-file numbers in §4.2** are extrapolated from three measured points on an exact quadratic, not measured. The 5-year point is real; the 10-year point is arithmetic.
+
+---
+
+## Appendix: reproducing the workload measurements
+
+Environment: git 2.55.0, rustc 1.97.0, NDK 29.0.13846066, Linux, `GIT_CONFIG_NOSYSTEM=1` throughout.
+
+**Row generator** — 169.1 bytes/row average, three writers sharing 200 rows/day:
+
+```python
+def rows(w, s0, day, n, rng):
+    base = datetime.datetime(2026, 1, 1) + datetime.timedelta(days=day)
+    out = []
+    for i in range(n):
+        t = base + datetime.timedelta(seconds=rng.randint(0, 86399),
+                                      milliseconds=rng.randint(0, 999))
+        card = "%08x-%04x-4%03x-%04x-%012x" % (rng.getrandbits(32), rng.getrandbits(16),
+                 rng.getrandbits(12), rng.getrandbits(16), rng.getrandbits(48))
+        ts = t.strftime("%Y-%m-%dT%H:%M:%S.") + ("%03d" % (t.microsecond // 1000))
+        out.append('{"w":%d,"s":%d,"ts":"%sZ","card":"%s","kind":"review",'
+                   '"grade":%d,"ivl":%d,"last_ivl":%d,"factor":%d,"ms":%d}'
+                   % (w, s0 + i, ts, card, rng.randint(1, 4), rng.randint(1, 3650),
+                      rng.randint(1, 1200), rng.randint(1300, 3200), rng.randint(600, 30000)))
+    return "\n".join(out) + "\n"
+```
+
+**Build loop** — per day, append each writer's rows to `log/w<N>/log.jsonl` (single) or `log/w<N>/<YYYY>-<MM>.jsonl` (monthly), then `git add <paths>` and `git commit -q --no-verify`. Repo configured `gc.auto=0` and `core.looseCompression=1`; `git gc -q` every 365 commits, timed; one final `git gc`, timed. Write amplification is the running sum of `os.path.getsize()` on each file at the moment it is staged, divided by the total new content written.
+
+**Exact wire cost of "behind N commits"** — build the thin pack the server would send:
+
+```bash
+{ echo HEAD; echo "^$(git rev-parse HEAD~N)"; } \
+  | git pack-objects --stdout --thin --revs --delta-base-offset | wc -c
+```
+
+**Clone shapes** — `git clone --progress [--depth 1|--depth 30|--filter=blob:none|--filter=tree:0] file://$REPO`, with `uploadpack.allowFilter=true` set on the source; wire bytes read from git's own `Receiving objects: 100% (N/N), X MiB` line.
+
+**Handshake bytes against a live host** —
+
+```bash
+curl -s -o /dev/null -w '%{size_download}\n' -H 'Git-Protocol: version=2' \
+  "https://<host>/<repo>.git/info/refs?service=git-upload-pack"
+GIT_TRACE_CURL=1 git -c protocol.version=2 ls-remote <url> 2>&1 | grep -E 'Send data, |Recv data, '
+GIT_TRACE_PACKET=1 git -c protocol.version=2 ls-remote <url> 'refs/heads/*' 2>&1 | grep -c ref-prefix
+```
+
+**Android cross-compilation** — a bare `lib.rs` crate per dependency set, then `cargo ndk -t arm64-v8a check --target aarch64-linux-android` (and `build` for `git2`, to force the C archives to be produced and linked). Licences read from `~/.cargo/registry/src/*/<crate>/Cargo.toml` and from the bundled `COPYING`/`LICENSE.txt` inside `libgit2-sys`, `libssh2-sys` and `openssl-src`.

--- a/docs/research/sync-transport/object-stores-and-drives.md
+++ b/docs/research/sync-transport/object-stores-and-drives.md
@@ -1,0 +1,563 @@
+# Sync transport: key-value stores and personal cloud drives, reached directly from the client
+
+**Research ticket:** [#33](https://github.com/amin-bf/leitner/issues/33) (under wayfinder map #1) · **Date of research:** 2026-07-30
+**Question:** Can a rented object store, or a consumer cloud drive reached through its own API, carry the review log between a user's devices with **no server of our own** — and what does each actually cost in bytes, requests, money, credentials and setup steps?
+
+This is a **research** note. It gathers facts and sharpens trade-offs; it decides nothing. Every non-obvious claim carries an inline primary source. Claims I reasoned rather than sourced are marked **[inference]**. Claims I measured are marked **[measured]** and the command is in §10.
+
+**Scope.** Clients are **desktop and Android only** — the web target was ruled out while resolving [#12](https://github.com/amin-bf/leitner/issues/12), so browser and cross-origin constraints are out of scope here. One user, 2–5 devices, no sharing between users. Two data shapes, per [ADR-0004](../../adr/0004-the-review-event-log.md): an append-only review log where every row carries `(writer id, sequence number)` and **each device appends only to its own rows**, plus a small mutable surface (deck names, tags, scheduler config, deletion flags) that settles per key by a counter that jumps above any counter it sees.
+
+Sibling notes under this ticket cover the other candidate families. This one covers **(A) object storage the user rents** and **(B) personal cloud drives via their own APIs**.
+
+---
+
+## Summary of findings
+
+Disqualifying or near-disqualifying first, then the numbers.
+
+1. **Conditional writes are not needed for the log, and are mildly harmful there.** The mechanism the ticket names — compare the stored entity tag before overwriting, `412` if it moved — exists and is well specified: "PUT and DELETE requests MAY have an 'If-Match' request header, and MUST fail with a 412 response code if that does not match the document's current version" ([remoteStorage protocol draft-22, §6](https://datatracker.ietf.org/doc/html/draft-dejong-remotestorage-22)). But it solves *lost updates to a shared key*, and under a per-writer keyspace **no key ever has two writers**. What a plain unconditional `PUT` already guarantees is enough: "Any read (GET or LIST request) that is initiated following the receipt of a successful PUT response will return the data written by the PUT request", including "A process writes a new object to Amazon S3 and immediately lists keys within its bucket. The new object appears in the list." ([Amazon S3 data consistency model](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)). Worse, a conditional `If-None-Match: *` turns the *harmless* case — a client retrying after an ambiguous timeout and re-uploading byte-identical content — into a spurious `412`, because "If multiple conditional writes or copies occur for the same object name, the first write operation to finish succeeds. Amazon S3 then fails subsequent writes with a `412 Precondition Failed` response" ([conditional writes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html)). **This widens the candidate set exactly as the ticket suspected.** Details and the two places a race *does* survive in §1.
+
+2. **Storage cost is not a discriminator; the user's uplink is.** At the ticket's worst case the monthly *bill* for two devices syncing six times a day is **$0.0040 on one metered store, $0.0032 on another, and $0.0000 on a third** [inference: my arithmetic over published prices, §3]. What differs by four orders of magnitude is bytes pushed: republishing a whole 10 MB per-writer log on every sync is **1,800 MiB per device per month** at six syncs a day and **7,200 MiB** at twenty-four, against **0.2 MiB** for segment objects. On a metered mobile connection that is the entire decision.
+
+3. **A finding for ADR-0004 rather than for transport: its "compresses about ten to one" claim holds for `zstd` and fails for `gzip`.** A decade of rows in the ADR's own interchange form measures 111,295,393 B raw — reproducing ADR-0004 §10's "around 110 MB raw" to within 1% — compressing to **9,462,142 B with `zstd -19` (11.76×)** but only **27,907,906 B with `gzip -9` (3.99×)** [measured, §3.1]. Every row repeats a 36-character UUID and the same nine keys, and `gzip`'s 32 KiB window cannot reach far enough back to exploit it. **The compressor choice changes the decade-scale per-writer object by 3×.**
+
+4. **Segment objects break "listing is the handshake" within a decade, and the fix is a key-name convention.** A listing page returns at most 1,000 keys — "By default, the action returns up to 1,000 key names. The response might contain fewer keys but will never contain more" ([ListObjectsV2](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html)). Two devices × six syncs/day × ten years is **43,800 live objects**, so a naïve full listing costs **44 round trips and ~14 MB** [inference, §2]. Issuing one listing *per writer prefix* with `start-after` set to the highest sequence that device already holds collapses this to **W requests of ~254 bytes each** [measured envelope, §2].
+
+5. **Object metadata alone answers "am I behind?" — no `GET` needed.** A listing entry carries `Key`, `LastModified`, `ETag`, `Size` and `StorageClass` ([ListObjectsV2](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html), and [measured] against a live public bucket in §10). If the sequence number is zero-padded into the key name, the listing *is* the version summary. A five-writer snapshot listing measures **~1.8 KB in one round trip** [inference over the measured 254-byte envelope and 287-byte-plus-key-length per-entry cost].
+
+6. **The credential problem is real and the three metered stores differ sharply.** Only one of them lets a user mint a key restricted to a *name prefix*, with an expiry: `namePrefix` "limits access to file names that begin with a specific prefix", `bucketIds` means "the new key can only access the specified buckets", and `validDurationInSeconds` "must be less than 1000 days (in seconds)" ([Backblaze b2_create_key](https://www.backblaze.com/apidocs/b2-create-key), [application keys](https://www.backblaze.com/docs/cloud-storage-application-keys)). Another supports bucket scoping but its token documentation describes no prefix scoping and no TTL — "you can scope your token to a set of buckets" and account tokens "remain valid until manually revoked" ([Cloudflare R2 API tokens](https://developers.cloudflare.com/r2/api/tokens/)). The third can express prefix restrictions but only through hand-written policy JSON with an explicit `Deny` on `s3:prefix` ([S3 bucket policy examples](https://docs.aws.amazon.com/AmazonS3/latest/userguide/amazon-s3-policy-keys.html)) — not something a user does unaided. **A leaked key on a lost phone costs, in the best case, write access to that device's own prefix until the expiry; in the worst case, full read/write/delete over the whole bucket, indefinitely.**
+
+7. **One rented store is disqualified by its billing floors, not its API.** A 1 TB monthly minimum, a 90-day minimum storage duration and a 4 KB minimum billable object size ([Wasabi minimum storage duration policy](https://docs.wasabi.com/docs/how-does-wasabis-minimum-storage-duration-policy-work), [monthly minimum storage charge](https://docs.wasabi.com/docs/how-does-wasabis-monthly-minimum-storage-charge-work), [minimum object size](https://knowledgebase.wasabi.com/hc/en-us/articles/115001684511-What-are-the-minimum-and-maximum-object-sizes-that-can-be-stored-in-Wasabi)) mean a user storing 20 MB of review log pays for 1 TB. Segment objects of 389–1,190 bytes would each be billed as 4 KB — a **3–11× storage-billing inflation** on top of that [inference].
+
+8. **The Rust story is clean on Android, but every candidate drags in a C toolchain.** Four crates `cargo check` clean for `aarch64-linux-android` [measured, §5] — but only once the NDK's `clang` is exported, because the default cryptographic backend compiles C: `error occurred in cc-rs: failed to find tool "aarch64-linux-android-clang"` from `aws-lc-sys v0.43.0`. The repo already installs that NDK for `cargo apk`, so this is a build-environment fact, not a blocker.
+
+9. **The drive-API disqualifier is not OAuth itself — a public client with PKCE is explicitly supported everywhere — it is what surrounds it.** Native apps are public clients: "Native apps are classified as public clients…they MUST be registered with the authorization server as such" and "it is NOT RECOMMENDED for authorization servers to require client authentication of public native apps clients using a shared secret" ([RFC 8252 §8.4, §8.5](https://datatracker.ietf.org/doc/html/rfc8252)). The providers agree: the client secret is marked "(Optional)" for installed apps and "is not applicable to requests from clients registered as Android, iOS, or Chrome applications" ([Google, OAuth for iOS & desktop](https://developers.google.com/identity/protocols/oauth2/native-app)); "Public clients, which include native applications and single page apps, must not use secrets or certificates when redeeming an authorization code" ([Microsoft identity platform auth code flow](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow)). **The costs are elsewhere:** one provider freezes new user links two weeks after the 50th user unless a review is passed ([Dropbox developer guide](https://www.dropbox.com/developers/reference/developer-guide)); another expires refresh tokens after **7 days** while the project sits in "Testing" publishing status, and caps live refresh tokens at **100 per Google Account per client ID** ([Google OAuth 2.0](https://developers.google.com/identity/protocols/oauth2)).
+
+10. **The one genuinely good news on drives: the app-private folder scope is *non-sensitive*, so verification is not mandatory.** "Before you can access the application data folder, you must request access to the `https://www.googleapis.com/auth/drive.appdata` **non-sensitive** scope" ([Drive application data folder](https://developers.google.com/workspace/drive/api/guides/appdata)), and "If your app utilizes only *non-sensitive* scopes, it is not mandatory for your app to complete the app verification process" ([Google OAuth verification](https://support.google.com/cloud/answer/13463073)). No app review, no verification-time endpoint (which would have been a server).
+
+11. **Change detection on drives is cheaper than listing an object store, and one of them has a free push channel.** A long-poll endpoint blocks up to 480 s, needs **no authentication**, runs on a separate host, and works for app-folder apps: `timeout UInt64(min_value=30, max_value=480) = 30`, `host = "notify"`, `auth = "noauth"`, `allow_app_folder_app = true` ([Dropbox API spec, `files.stone`](https://github.com/dropbox/dropbox-api-spec/blob/master/files.stone)) [measured — I read the spec file directly, §10].
+
+12. **Unattended background sync on Android is capped by the platform regardless of transport, and in two app-standby buckets it is impossible.** Doze "Suspends network access", "Doesn't let `JobScheduler` run" and "Defers standard `AlarmManager` alarms […] to the next maintenance window" ([Doze and App Standby](https://developer.android.com/training/monitoring-device-state/doze-standby)). Worse, in the **Rare** and **Restricted** app-standby buckets **network is listed as "Disabled"** ([power management restrictions](https://developer.android.com/topic/performance/power/power-details)) — precisely the buckets a device that has been in a drawer lands in. The deferrable-work API's floor is **15 minutes** between periodic runs ([define work](https://developer.android.com/develop/background-work/background-tasks/persistent/getting-started/define-work)), and escaping Doze with a foreground service now costs a hard cap: "The system permits an app's `dataSync` services to run for a total of 6 hours in a 24-hour period" and such a service **cannot be started from boot** ([Android 15 behaviour changes](https://developer.android.com/about/versions/15/behavior-changes-15)).
+
+---
+
+## Part A — Object storage the user rents
+
+### 1. Conditional writes: what exists, and whether we need any
+
+#### 1.1 The model the ticket names
+
+The cleanest primary statement of the entity-tag-plus-precondition model is the remoteStorage protocol, which makes it normative rather than advisory:
+
+> "All successful GET, HEAD, PUT and DELETE requests MUST return an 'ETag' header with, in the case of GET and HEAD the current version, in the case of PUT, the new version, and in case of DELETE, the version that was deleted."
+>
+> "PUT and DELETE requests MAY have an 'If-Match' request header, and MUST fail with a 412 response code if that does not match the document's current version."
+>
+> "A PUT request MAY have an 'If-None-Match: *' header, in which case it MUST fail with a 412 response code if the document already exists."
+>
+> — [remoteStorage protocol, draft-dejong-remotestorage-22, §6](https://datatracker.ietf.org/doc/html/draft-dejong-remotestorage-22)
+
+The same draft makes folder listings carry versions, so a client can diff a directory without downloading it: a folder GET returns per-item descriptions each containing "a string-valued 'ETag' field…representing the document's current version" (same source, §4). That is the shape of a cheap "am I behind?" handshake, and it is worth noting the protocol got there in 2016 without inventing anything — it is plain HTTP conditional requests, [RFC 7232](https://datatracker.ietf.org/doc/html/rfc7232).
+
+#### 1.2 What object stores actually support, and when it arrived
+
+| Store | `If-None-Match: *` on write | `If-Match: <etag>` on write | Arrived | Source |
+|---|---|---|---|---|
+| Amazon S3 | Yes, on `PutObject`, `CompleteMultipartUpload`, `CopyObject` | Yes, same three | `If-None-Match` **2024-08-20**, `If-Match` **2024-11-25** | [conditional writes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html); [announcement, Aug 2024](https://aws.amazon.com/about-aws/whats-new/2024/08/amazon-s3-conditional-writes/); [announcement, Nov 2024](https://aws.amazon.com/about-aws/whats-new/2024/11/amazon-s3-functionality-conditional-writes/) |
+| Cloudflare R2 | Yes | Yes (also `If-Modified-Since`, `If-Unmodified-Since`) | not dated in the doc | [R2 S3 API compatibility](https://developers.cloudflare.com/r2/api/s3/api/) |
+| Backblaze B2 (S3-compatible) | **Not documented** | **Not documented** | — | [B2 S3-compatible API](https://www.backblaze.com/docs/cloud-storage-s3-compatible-api) lists unsupported features as "ACLs, IAM Roles, Object Tagging, Website Configuration, Browser-based uploads to pre-signed URLs using `POST`" and says nothing about conditional write headers |
+
+The exact semantics, which matter if we ever *do* want them:
+
+> "Conditional writes with the `If-None-Match` header evaluate against existing objects in a bucket. If there's no existing object with the same key name in the bucket, the write operation succeeds, resulting in a `200 OK` response. If there's an existing object, the write operation fails, resulting in a `412 Precondition Failed` response."
+>
+> "If multiple conditional writes or copies occur for the same object name, the first write operation to finish succeeds. Amazon S3 then fails subsequent writes with a `412 Precondition Failed` response."
+>
+> "You can also receive a `409 Conflict` response in the case of concurrent requests if a delete request to an object succeeds before a conditional write operation on that object completes."
+>
+> — [How to prevent object overwrites with conditional writes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html)
+
+Two operational constraints from the same page: `If-Match` needs both `s3:PutObject` **and** `s3:GetObject` permission ("This enables the caller to check the ETag"), and "To use conditional writes, you must use AWS Signature Version 4 to sign the request."
+
+**Confidence on B2:** *low-to-medium* that conditional writes are unsupported. Backblaze's own documentation does not mention them either way, and third-party comparisons claim support. **This must be tested against a real bucket before it is load-bearing** — it is exactly the kind of claim that silently changes.
+
+#### 1.3 The sharper question: is a conditional write needed at all?
+
+**For the review log, no — and it is actively counterproductive.**
+
+The argument, stated as a chain so it can be attacked:
+
+1. Every log row carries `(writer id, sequence number)` and each device appends only to its own rows, gap-free (ADR-0004). So a layout of `log/<writer id>/<sequence>` — whether one object per writer or one per segment — has the property that **each key has exactly one possible author**.
+2. A plain `PUT` to a key nobody else writes cannot lose an update. There is no second writer to lose it to.
+3. The store already guarantees the reader sees it: "Amazon S3 provides strong read-after-write consistency for PUT and DELETE requests of objects in your Amazon S3 bucket in all AWS Regions. This behavior applies to both writes to new objects as well as PUT requests that overwrite existing objects and DELETE requests" ([data consistency model](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)).
+4. Listing is covered too, which is what makes the handshake in §2 sound: "A process writes a new object to Amazon S3 and immediately lists keys within its bucket. The new object appears in the list" (same source). **List-after-write is strongly consistent, not eventually consistent** — this is the 2020 change that makes the whole design viable, and it is why prior-generation object-store sync designs needed conditional writes and ours does not [inference].
+5. The one behaviour that *would* bite a shared key is documented and does not apply to us: "Amazon S3 does not support object locking for concurrent writers. If two PUT requests are simultaneously made to the same key, the request with the latest timestamp wins. If this is an issue, you must build an object-locking mechanism into your application" (same source).
+6. Adding `If-None-Match: *` on top makes retries unsafe rather than safe. The realistic failure is *not* two devices racing; it is one device losing its connection after the store committed the write but before the response arrived, then retrying with identical bytes. Unconditionally that retry is idempotent and free. Conditionally it returns `412`, which the client cannot distinguish from "someone else got there first" without an extra `HEAD` **[inference]**.
+
+**Where the races actually are.** Three, none of them in the log:
+
+- **The mutable surface, only if it is a single shared object.** If deck names, tags and scheduler config live in one `config.json` that every device overwrites, that *is* a shared key and it *does* lose updates — the "latest timestamp wins" rule above applies literally. **But ADR-0004 §7 already settles values by a per-key counter that jumps above any counter it sees, which is a merge function, not an overwrite.** Sharding the mutable surface per writer (`state/<writer id>.json`, merged at read time by that counter rule) removes the shared key and therefore removes the need for a conditional write. The trade is one small `GET` per writer instead of one, and slightly more read-side code. **This is the real decision the mutable-store bullet in the ticket is pointing at, and it is a design choice, not a constraint imposed by the store** [inference].
+- **Compaction and roll-up.** Deleting segments after merging them into a larger object is the one place where a stale actor can destroy data another actor still needs. The lock-free discipline for this is already recorded in the sibling note: keep track of every change loaded from storage and "when compacting *only delete those changes*" ([Automerge storage under-the-hood](https://github.com/automerge/automerge.github.io/blob/main/content/docs/reference/under-the-hood/storage.md), quoted in [`../local-first-event-log/README.md`](../local-first-event-log/README.md) §1). A conditional delete would also work here — "Conditional deletes evaluate if your object exists or is unchanged before deleting it. You can perform conditional deletes using the `DeleteObject` or `DeleteObjects` APIs" ([conditional requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html)) — but the read-set discipline needs nothing from the store.
+- **Torn publication, which is a liveness bug not a correctness bug.** A reader can see writer A's new segment before A's head pointer, or the pointer before the segment. Writing data before pointers, and treating a dangling pointer as "not yet there, retry", makes this benign. If the sequence number lives in the key name (§2) there is no separate pointer at all and the window closes entirely **[inference]**.
+
+**Consequence for the candidate set.** Any store that offers unconditional `PUT`, `GET`, `DELETE` and a prefix listing is sufficient. Conditional-write support becomes a *nice-to-have for compaction*, not an entry requirement — which is exactly the widening the ticket asked us to test rather than assume.
+
+### 2. The handshake: what a listing costs
+
+#### 2.1 The API's own limits
+
+- **Page size:** "By default, the action returns up to 1,000 key names. The response might contain fewer keys but will never contain more." Pagination is by opaque `NextContinuationToken`, which "is obfuscated and is not a real key".
+- **Ordering:** "For general purpose buckets, `ListObjectsV2` returns objects in lexicographical order based on their key names." (Directory buckets do **not** — worth knowing if anyone reaches for the low-latency bucket type.)
+- **Prefix:** "Limits the response to keys that begin with the specified prefix."
+- **Delimiter:** rolls keys up into `CommonPrefixes`, and "All of the keys that roll up into a common prefix count as a single return when calculating the number of returns."
+- **`start-after`:** "StartAfter is where you want Amazon S3 to start listing from. Amazon S3 starts listing after this specified key."
+- **Fields per entry:** `Key`, `LastModified`, `ETag`, `Size`, `StorageClass` (plus checksum fields in practice); `Owner` is omitted unless `fetch-owner=true`.
+
+All from [ListObjectsV2](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html).
+
+The equivalent on the native B2 API: `maxFileCount` defaults to 100 with a maximum of 10,000, but "the maximum number of files returned per transaction is 1000", entries carry `fileName`, `contentLength`, `contentSha1`, `uploadTimestamp` and `fileId`, and `prefix`, `delimiter` and `startFileName` all exist ([b2_list_file_names](https://www.backblaze.com/apidocs/b2-list-file-names)).
+
+#### 2.2 Measured wire cost
+
+Against a live public bucket (§10 has the commands):
+
+| Request | Response bytes |
+|---|---|
+| `?list-type=2&prefix=zzzznonexistent&max-keys=5` (empty result) | **254** |
+| `?list-type=2&max-keys=1` | 865 |
+| `?list-type=2&max-keys=2` | 1,260 |
+| `?list-type=2&max-keys=5` | 2,445 |
+
+Per-entry cost is `(2445 − 865) / 4 = 395` bytes for a **108-character** key, so the fixed XML per entry is **287 bytes plus the key length** [measured + inference]. The 254-byte envelope grows only by the prefix string; the 865-byte single-entry response also carries a ~228-byte continuation token that a complete listing does not.
+
+Applying that to a realistic key, `log/3f9a2b1c/0000000000000731.zst` (33 characters):
+
+| Layout | Live objects | Requests | Bytes on the wire |
+|---|---|---|---|
+| One object per writer, sequence in the key, 5 writers | 5 | **1** | 254 + 5 × 320 = **~1.85 KB** |
+| Segments, 2 devices × 6 syncs/day × 10 years, listed whole | 43,800 | **44** | ~14.1 MB |
+| Segments, same, one listing per writer prefix with `start-after` = highest sequence held | 43,800 | **W** (2) | **~254 B each** when up to date |
+
+[inference: arithmetic over the measured per-entry cost.] The third row is the one that matters: **the version summary the device already holds is exactly the `start-after` key**, so "am I behind?" is `KeyCount == 0`.
+
+#### 2.3 Can metadata alone answer it — and can the key name *be* the handshake?
+
+Yes to both.
+
+- The listing returns `ETag` and `Size` without any `GET`. Verified live: `HEAD` on a public object returns `ETag: "7fb98fdd354afbd9f6ac81fe9a511279"`, the same value that appeared in the listing [measured].
+- Conditional reads work as specified and cost nothing when nothing changed: `GET` with `If-None-Match` on the current tag returned **`304`, 0 bytes downloaded**; `GET` with a wrong `If-Match` returned **`412`, 348 bytes** [measured]. So even a content fetch can be made free-when-unchanged. There is no charge for the conditionality itself: "There is no additional charge for conditional reads, conditional writes or conditional deletes. You are only charged existing rates for the applicable requests, including for failed requests" ([conditional requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html)).
+- **Encoding the sequence number in the key name makes the listing the handshake.** Keys sort lexicographically (sourced above), so a zero-padded fixed-width sequence sorts numerically. `prefix=log/&delimiter=/` returns one `CommonPrefixes` entry per writer for discovery; `prefix=log/<writer>/&start-after=<highest held>` returns exactly the rows we lack. No `GET`, no separate manifest object, no pointer that can be torn.
+
+**Caveat.** Under the *snapshot* shape this requires publishing to a **new** key each time (the sequence changes) and deleting the old one, which is two operations and a transient window with two objects for that writer. Under the *segment* shape each key is written once and never rewritten, which is strictly simpler. [inference]
+
+### 3. Appending: nobody supports it, so segments versus snapshots
+
+**No candidate supports true append.** Object stores replace whole objects; the S3 documentation's own framing is that "Updates to a single key are atomic" and that a PUT to an existing key overwrites it ([data consistency model](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)). Multipart upload is not an append either — parts must be assembled into one `CompleteMultipartUpload`, and "Uploading to the same part number replaces the previous part" ([R2 S3 API](https://developers.cloudflare.com/r2/api/s3/api/)). So the choice is segments or republish.
+
+#### 3.1 Measured payload sizes
+
+Synthetic rows in **exactly** the interchange form ADR-0004 §11 pins — `{"k","w","s","n","o","g","t","d","ms"}` with a 16-hex writer id and an RFC 9562 canonical note UUID — as JSON Lines [measured, §10]:
+
+| Rows | Raw | zstd-19 | gzip-9 | zstd ratio |
+|---|---|---|---|---|
+| 730,000 (a decade at 200/day) | **111,295,393 B (106.1 MiB)** | **9,462,142 B (9.02 MiB)** | 27,907,906 B | **11.76×** |
+| 73,000 (one year) | 11,056,472 B | 1,036,927 B | 2,791,194 B | 10.66× |
+| 200 (one day) | 29,816 B | 6,330 B | 7,875 B | 4.71× |
+| 33 (one sync at 6/day) | 4,899 B | **1,190 B** | 1,352 B | 4.12× |
+| 8 (one sync at 24/day) | 1,181 B | **389 B** | 402 B | 3.04× |
+
+Three things this settles:
+
+- **Rows are ~152 bytes, not 38–58.** The brief for this ticket quoted 38–58 bytes/row, which is the *packed* figure ADR-0004 §11 explicitly contrasts against ("roughly 150 bytes against 56"). The 150-byte figure is the one that matters for transport, because §11 also requires that "A row is relayed byte for byte and never re-encoded" — **the interchange form is what crosses the wire, so transport must be costed against 152 bytes.** At 152.5 B/row the decade total is 111.3 MB raw, which reproduces ADR-0004 §10's "around 110 MB raw" to within 1%.
+- **ADR-0004's "compresses about ten to one" is true for `zstd`, and false for `gzip`.** At decade scale `zstd -19` gives **11.76×** but `gzip -9` gives only **3.99×** — 9.0 MiB against 26.6 MiB for the same bytes. The cause is window size: every row repeats a 36-character UUID and the same nine keys, and `gzip`'s 32 KiB window cannot reach back far enough to exploit it. **The compressor choice changes a decade-scale per-writer object by 3×**, which is not a detail if snapshots are on the table [inference]. ADR-0004 §10's "15 MB compressed" sits between the two and is conservative for `zstd`.
+- **Small segments compress badly** — 3.04× at eight rows against 11.76× at a decade — so per-sync overhead is worse than the annual ratio suggests, though still trivial in absolute terms (389 bytes).
+
+For the cost table below I use the ticket's round **10 MB per-writer snapshot**, which the measurement supports as the worst case: 9.02 MiB if a single writer produced the whole decade at 200/day.
+
+#### 3.2 Published prices, from the providers
+
+Amazon S3, US East (N. Virginia), read out of AWS's own machine-readable price list rather than the marketing page [measured, §10]:
+
+- Storage, S3 Standard: **`$0.023` per GB-month** for the first 50 TB (`TimedStorage-ByteHrs`, General Purpose).
+- `PUT`, `COPY`, `POST`, `LIST`: **`$0.005` per 1,000** (`Requests-Tier1`).
+- `GET` and all others: **`$0.0004` per 1,000** (`Requests-Tier2`, listed as `$0.004 per 10,000`).
+- Data transfer out to the internet: **`$0.090` per GB** for the first 10 TB/month "beyond the global free tier", then `$0.085`, `$0.070`, `$0.050`. The [pricing page](https://aws.amazon.com/s3/pricing/) puts that free tier at "the first 100GB per month, aggregated across all AWS Services and Regions".
+- **Minimums:** S3 Standard states none. "S3 Standard-IA and S3 One Zone-IA storage have a minimum billable object size of 128 KB" and "are charged for a minimum storage duration of 30 days" (same page) — so the cheaper tiers are *not* usable for small segment objects.
+
+Cloudflare R2 ([pricing](https://developers.cloudflare.com/r2/pricing/)):
+
+- Storage: **`$0.015` / GB-month** (Standard).
+- **Class A `$4.50` / million** — includes `PutObject`, `ListObjects`, `CopyObject`, `CreateMultipartUpload`, `CompleteMultipartUpload`, `UploadPart`.
+- **Class B `$0.36` / million** — includes `GetObject`, `HeadObject`.
+- **Free operations:** `DeleteObject`, `DeleteBucket`, `AbortMultipartUpload`.
+- **Egress: free.**
+- **Free tier:** 10 GB-month storage, 1 million Class A, 10 million Class B per month.
+- Minimum storage duration of 30 days applies only to Infrequent Access; Standard has none.
+
+Backblaze B2 ([pricing](https://www.backblaze.com/cloud-storage/pricing), [transaction pricing](https://www.backblaze.com/cloud-storage/transaction-pricing)):
+
+- Storage: **`$6.95` per TB/month** (= `$0.00679` / GB-month), and "First 10GB storage is always free".
+- Egress: **`$0.01`/GB** beyond "up to 3x of average monthly data stored", which is free.
+- **Class A (uploads: `b2_upload_file` / `PutObject`), Class B (downloads: `GetObject`, `HeadObject`) and Class C (listing: `b2_list_file_names` / `ListObjectsV2`) are all listed as free** for pay-as-you-go. Only Class D (event notifications) is charged, at "$0.004 per 10,000" with the first 2,500/day free.
+- No minimum object size or minimum storage duration is stated.
+
+Wasabi ([pricing](https://wasabi.com/pricing)): "Starting at $7.99 TB/month", "No fees for egress or API requests" — but see finding 7: a **1 TB monthly minimum**, a **90-day minimum storage duration** and a **4 KB minimum billable object size**. **Disqualified for this workload on billing floors alone.**
+
+#### 3.3 The actual monthly numbers
+
+Steady state at the ticket's worst case: 10 MB compressed per-writer log, `W` devices, `N` syncs/day, 30 days, one publish and one listing per device per sync [inference: my arithmetic over the prices above; AWS's 100 GB/month egress free tier ignored, which only makes the S3 column pessimistic].
+
+| Devices | Syncs/day | Shape | Uploaded/month | Class-A-equivalent ops | S3 | R2 | B2 | Live objects after 10 yrs |
+|---|---|---|---|---|---|---|---|---|
+| 2 | 6 | snapshot | **3,600 MiB** | 720 | $0.0040 | $0.0032 | $0.0000 | 2 |
+| 2 | 6 | segment | **0.4 MiB** | 720 | $0.0040 | $0.0032 | $0.0000 | 43,800 |
+| 2 | 24 | snapshot | **14,400 MiB** | 2,880 | $0.0148 | $0.0130 | $0.0000 | 2 |
+| 2 | 24 | segment | **0.5 MiB** | 2,880 | $0.0148 | $0.0130 | $0.0000 | 175,200 |
+| 5 | 6 | snapshot | **9,000 MiB** | 1,800 | $0.0101 | $0.0081 | $0.0000 | 5 |
+| 5 | 6 | segment | **1.0 MiB** | 1,800 | $0.0101 | $0.0081 | $0.0000 | 109,500 |
+| 5 | 24 | snapshot | **36,000 MiB** | 7,200 | $0.0371 | $0.0324 | $0.0000 | 5 |
+| 5 | 24 | segment | **1.3 MiB** | 7,200 | $0.0371 | $0.0324 | $0.0000 | 438,000 |
+
+**Per-device upload per month: 1,800 MiB (snapshot, 6 syncs/day), 7,200 MiB (snapshot, 24 syncs/day), 0.2–0.3 MiB (segments, either).**
+
+Three things fall out:
+
+1. **The bill does not distinguish the shapes at all**, because ingress is free everywhere and 10 MB of storage is inside every free tier. Snapshot and segment rows are identical to the cent. Anyone arguing the shapes on cost is arguing about a rounding error.
+2. **The uplink distinguishes them by a factor of ~9,000.** Republishing costs the *user's* bandwidth, battery and time — 1.8–7.2 GB per device per month, much of it plausibly cellular. That is the whole case against snapshots, and it is not visible in any provider's pricing page.
+3. **Segments trade that for object-count growth** that breaks naïve listing (finding 4) and would be catastrophic under a 4 KB minimum billable object size (finding 7, on the store where that applies: 438,000 objects × 4 KB = 1.7 GB billed for ~50 MB of data [inference]).
+
+**A third shape worth naming, since neither of the ticket's two is obviously right: segments plus periodic roll-up.** Write a segment per sync; once a writer accumulates, say, 512 segments, merge them into one object and delete the merged ones under the read-set discipline from §1.3. That bounds live objects to roughly `W × 512` while keeping per-sync upload at segment size. Cost: one 10 MB republish per writer per ~85 days at six syncs/day, i.e. **~0.12 MiB/day amortised** against 60 MiB/day for republish-every-sync [inference].
+
+### 4. The credential problem
+
+With no server, the client holds long-lived storage credentials. There is no way around this: every one of these stores authenticates with a static key pair signed per request (AWS Signature Version 4 or the provider's equivalent). What differs is how narrowly the key can be cut and how long it lives.
+
+| | Scope to one bucket | Scope to a key prefix | Expiry | User can create it unaided |
+|---|---|---|---|---|
+| Backblaze B2 | Yes (`bucketIds`) | **Yes (`namePrefix`)** | **Yes, `validDurationInSeconds` < 1000 days** | Yes — the console exposes bucket, capability and prefix as form fields |
+| Cloudflare R2 | Yes | **Not documented** | **Not documented** | Yes — but only at bucket granularity |
+| Amazon S3 | Yes | Yes, via IAM policy JSON with `s3:prefix` and an explicit `Deny` | Only via STS (which needs something to call it) | **Realistically no** |
+
+Sources: [b2_create_key](https://www.backblaze.com/apidocs/b2-create-key) ("When provided, the new key can only access the specified buckets"; `namePrefix` "limits access to file names that begin with a specific prefix"; `validDurationInSeconds` "must be less than 1000 days (in seconds)"), [B2 application keys](https://www.backblaze.com/docs/cloud-storage-application-keys) (capabilities are "Read and Write - Read Only - Write Only"), [R2 API tokens](https://developers.cloudflare.com/r2/api/tokens/) ("you can scope your token to a set of buckets"; account tokens "remain valid until manually revoked"), [S3 bucket policy examples](https://docs.aws.amazon.com/AmazonS3/latest/userguide/amazon-s3-policy-keys.html).
+
+The S3 prefix pattern, for the record, is not one statement but two — an `Allow` on `s3:ListBucket` conditioned on `"s3:prefix": "projects"` **plus** an explicit `Deny` for any other prefix, because "explicit `Deny` statements always override `Allow` statements" (same source). Anyone who writes only the `Allow` has an ineffective policy, since a broader grant elsewhere silently wins. That is a footgun, not a user-facing feature.
+
+**What a leaked key on a lost phone costs.** All three key types are bearer credentials with no device binding and no proof-of-possession.
+
+- Best case (prefix-scoped, write-only, expiring): the attacker can write objects under that one device's prefix until the expiry. They cannot read the other devices' rows, cannot delete, and the damage self-heals when the key expires.
+- Realistic case (bucket-scoped, read-write, no expiry): the attacker reads the user's entire review history — which cards they study, when, and how badly — and can delete all of it. Review logs are not neutral data; study history discloses what someone is learning and when they are awake.
+- All three providers show the secret exactly once. "Your master app key is shown only when you generate it, and it is not shown again" and "This is the only time it will be returned, so you need to keep it" ([application keys](https://www.backblaze.com/docs/cloud-storage-application-keys), [b2_create_key](https://www.backblaze.com/apidocs/b2-create-key)). So recovery from a lost phone means *rotating* the key on every remaining device, by hand.
+- **There is no revocation channel we control.** Revocation happens in the provider's console, by the user, if they think of it.
+
+**Setup burden, counted honestly.** Steps between "user installs the app" and "sync works", for the most favourable of the three:
+
+1. Create an account with the storage provider (email, password, payment card — even on a free tier).
+2. Create a bucket, choosing a globally-or-account-unique name and a region.
+3. Open the application-keys page, create a key, choose the bucket, choose read-and-write, type a name prefix, optionally set a duration.
+4. Copy a key ID and a secret shown once.
+5. Type or paste both into the app — **on each of 2–5 devices**, including the phone.
+
+That is five steps and an account signup before the first review syncs, repeated in part per device. On Android step 5 means entering a ~25-character key ID and a ~31-character secret into a text field; both are ASCII, so the repo's ASCII-only Android IME limitation (`AGENTS.md` rule 8) does not block it, but it is still a miserable first-run experience and a strong argument for a device-to-device transfer of the credential (QR code, or a paired-device handoff) rather than retyping [inference].
+
+**This is the finding most likely to disqualify the whole family.** Not any single technical gap — the API surface is genuinely sufficient — but that the design asks a language-learner to become an object-storage administrator, and hands them a bearer secret whose loss is unrecoverable without manual rotation.
+
+### 5. Rust client support on Android
+
+All four candidates `cargo check` clean for `aarch64-linux-android` with `rustc 1.97.0` on 2026-07-30 [measured, §10]:
+
+| Crate | Version checked | Licence | Repo last release | Notes |
+|---|---|---|---|---|
+| `object_store` | 0.14.1, feature `aws` | MIT/Apache-2.0 | 2026-07-15 | Apache Arrow project; 75.6M downloads |
+| `aws-sdk-s3` + `aws-config` | 1.140.0 / 1.10.1 | Apache-2.0 | 2026-07-24 | AWS's own SDK; 74.2M downloads |
+| `rust-s3` | 0.36.0 (`default-features = false`, `tokio-rustls-tls`) | MIT | 0.37.2, 2026-05-04 | community-maintained, single maintainer |
+| `opendal` | 0.57.0, features `services-s3`, `services-gdrive`, `services-dropbox`, `services-onedrive` | Apache-2.0 | 2026-07-27 | Apache project; **also covers all three consumer drives in Part B behind one interface** |
+
+Metadata from the crates.io API [measured, §10].
+
+**The one real friction: the cryptographic backend needs a C toolchain.** With no `CC` exported, the `object_store` check fails:
+
+```
+Compiling aws-lc-sys v0.43.0
+error: failed to run custom build command for `aws-lc-sys v0.43.0`
+  cargo:warning=Compiler family detection failed due to error: ToolNotFound:
+    failed to find tool "aarch64-linux-android-clang"
+  error occurred in cc-rs: failed to find tool "aarch64-linux-android-clang"
+```
+
+`cargo tree -i aws-lc-sys` shows it arriving by two independent routes — `object_store` depends on `aws-lc-rs` directly (request signing), and `rustls 0.23` pulls it as the default cryptographic provider through `reqwest`/`hyper-rustls`/`rustls-platform-verifier`. Exporting `CC_aarch64_linux_android` to the NDK's `aarch64-linux-android24-clang` makes all four check clean in 7–17 s. The repo already pins exactly one NDK for `cargo apk` (`scripts/android-env.sh`, NDK 29.0.13846066), so this is satisfied by the existing toolchain.
+
+The alternative backend, `ring`, is not obviously better: it also builds C and assembly, and its last release was **2025-03-11**, sixteen months before this note, against `aws-lc-rs`'s 2026-07-17 [measured from crates.io]. Licences: `aws-lc-rs` is `ISC AND (Apache-2.0 OR ISC)`, `ring` is `Apache-2.0 AND ISC` — both permissive, neither copyleft.
+
+**No OpenSSL anywhere** in the checked configurations, which matters because a Rust `openssl-sys` build for Android is the classic source of NDK pain. Every candidate defaults to rustls.
+
+---
+
+## Part B — Personal cloud drives via their own APIs
+
+### 6. App-scoped folders
+
+| Provider | Name | What the app sees | What the user sees | Quota | Source |
+|---|---|---|---|---|---|
+| Google Drive | application data folder (`appDataFolder` space) | "a special hidden folder that your app can use to store application-specific data"; "Only the application that created the data in the `appDataFolder` can access it" | "its contents are hidden from the user and from other Google Drive apps"; the folder "is deleted when a user uninstalls your app from their My Drive. Users can also delete your app's data folder manually" | Counts as "other storage", which "often includes device backups and hidden data from apps connected to your Drive"; user removes it via Drive settings → **Manage apps** | [appdata guide](https://developers.google.com/workspace/drive/api/guides/appdata), [about files](https://developers.google.com/workspace/drive/api/guides/about-files), [Drive storage help](https://support.google.com/drive/answer/6374270) |
+| Dropbox | App folder | "A dedicated folder named after your app is created within the Apps folder of a user's Dropbox"; the app "gets read and write access to this folder only" | **Fully visible.** "users can contribute by moving files into it" | user's Dropbox quota [inference] | [developer guide](https://www.dropbox.com/developers/reference/developer-guide) |
+| OneDrive | App Root special folder (`approot`) | "The application's personal folder. Usually in `/Apps/{Application Name}`"; "Special folders are automatically created the first time an application attempts to write to one, if it doesn't already exist. If a user deletes one, it is recreated when written to again." | Visible at that path | user's OneDrive quota [inference] | [get special folder](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/drive_get_specialfolder) |
+
+Two consequences worth flagging for the decision:
+
+- **The hidden folder is a backup hazard, not a backup.** Content the user cannot see is content the user cannot copy out, and the app's own uninstall deletes it. The two visible app folders are the opposite: the user can inspect the JSON Lines, copy them, and — inconveniently — also move or delete them mid-sync. A design that tolerates a file vanishing is required either way [inference].
+- **Google's folder has operations that simply fail**: apps "cannot share files within this folder, move files between storage locations, or trash files", which returns `notSupportedForAppDataFolderFiles` ([appdata guide](https://developers.google.com/workspace/drive/api/guides/appdata)). Deletion must be permanent rather than to trash — fine for segment roll-up, but it removes the safety net.
+
+### 7. OAuth for a native app with no server
+
+#### 7.1 What the standard requires
+
+[RFC 8252, *OAuth 2.0 for Native Apps*](https://datatracker.ietf.org/doc/html/rfc8252) is unusually prescriptive, and every requirement it imposes is satisfiable without a server:
+
+- §5: "native apps MUST use an external user-agent to perform OAuth authorization requests", and §8.12: "This best current practice requires that native apps MUST NOT use embedded user-agents to perform authorization requests." The rationale is that an embedded webview lets the host app "access the user's full authentication credential, not just the OAuth authorization grant."
+- §6: "Public native app clients MUST implement the Proof Key for Code Exchange (PKCE) extension to OAuth, and authorization servers MUST support PKCE for such clients." §8.1: "An app that intercepted the authorization code would not be in possession of this secret, rendering the code useless."
+- §7: three redirect options — private-use URI schemes (§7.1), claimed `https` URIs (§7.2), loopback interface redirection (§7.3).
+- §8.4: "Native apps are classified as public clients…they MUST be registered with the authorization server as such." §8.5: "Secrets that are statically included as part of an app distributed to multiple users should not be treated as confidential secrets…it is NOT RECOMMENDED for authorization servers to require client authentication of public native apps clients using a shared secret."
+
+**None of this needs a server.** A loopback redirect means a listener on `127.0.0.1:<random port>` inside our own process; an external user-agent means launching the system browser. Both are ordinary desktop and Android capabilities.
+
+#### 7.2 Is a client secret required, and can a public client be registered?
+
+**No, and yes, on all three.**
+
+- Google marks the client secret "(Optional)" in the installed-app token exchange, and states "The `client_secret` is not applicable to requests from clients registered as Android, iOS, or Chrome applications." For desktop, the redirect is the loopback address: "http://127.0.0.1:port or http://[::1]:port". PKCE is supported: "Google supports the Proof Key for Code Exchange (PKCE) protocol to make the installed app flow more secure" — though Google labels it "Recommended" rather than "Required", which is weaker than RFC 8252's MUST. Two removals to note: "Custom URI schemes are no longer supported due to the risk of app impersonation" (for the iOS/desktop client types), and "The manual copy/paste option, also referred to as an out of band (OOB) redirect method, is no longer supported." ([OAuth for iOS & desktop](https://developers.google.com/identity/protocols/oauth2/native-app))
+- Microsoft is blunt: "Public clients, which include native applications and single page apps, must not use secrets or certificates when redeeming an authorization code", and the client secret is "required for confidential web apps" only, with the note "Don't use the application secret in a native app or single page app because a `client_secret` can't be reliably stored on devices or web pages." Recommended native redirect values are `https://login.microsoftonline.com/common/oauth2/nativeclient` for embedded browsers or **`http://localhost` for apps that use system browsers**. PKCE is "recommended for all application types, both public and confidential clients". ([auth code flow](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow))
+- Dropbox recommends PKCE precisely for this case: "PKCE is an open extension to OAuth 2.0, and solves this problem using dynamic codes instead of the static client_secret", and directs "desktop apps, mobile apps, single-page applications, and open source applications" to "the OAuth code flow with PKCE, with refresh tokens". Refresh tokens require `token_access_type=offline` on the authorization URL. ([OAuth guide](https://developers.dropbox.com/oauth-guide))
+
+#### 7.3 App review, and what the scopes cost
+
+This is where the family gets expensive, and the three diverge completely.
+
+- **Google: no review needed for the folder we want.** The application-data-folder scope is explicitly categorised **non-sensitive** ([appdata guide](https://developers.google.com/workspace/drive/api/guides/appdata)), and "Apps that request access to scopes categorized as *sensitive* or *restricted* must complete Google's OAuth app verification" while "If your app utilizes only *non-sensitive* scopes, it is not mandatory for your app to complete the app verification process" ([verification requirements](https://support.google.com/cloud/answer/13463073)). **Crucially, nothing here requires the developer to run a verification-time endpoint** — no domain ownership proof, no hosted privacy policy check, no callback the reviewer hits. That would have been a server. *Confidence: medium-high.* Google's verification policy has moved before, and brand verification is still required if the consent screen is to show a logo (same source).
+- **Dropbox: a review gate at 50 users.** Apps start in development status and can link only the creator's account; then "you will have two weeks to apply for and receive production status approval before your app's ability to link additional Dropbox users will be frozen", triggered at 50 linked users. Review checks "that your app doesn't request an unnecessarily broad permission based on the functionality provided" ([developer guide](https://www.dropbox.com/developers/reference/developer-guide)). App-folder access is the least-privileged option, which helps, but **the ceiling is hard: the 51st user cannot connect until a human at Dropbox approves.**
+- **Microsoft:** the app-folder permission `Files.ReadWrite.AppFolder` is listed as the **least privileged** delegated permission for personal Microsoft accounts on the special-folder API ([get special folder](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/drive_get_specialfolder)). I did not find a consumer-account review gate equivalent to the other two. *Confidence: low* — absence of evidence, and I did not exhaust Microsoft's publisher-verification documentation.
+
+#### 7.4 Refresh tokens: the quiet disqualifier for unattended sync
+
+Unattended sync means the token must survive months of not being used. It does not, uniformly.
+
+Google states the failure conditions outright ([OAuth 2.0](https://developers.google.com/identity/protocols/oauth2)):
+
+- "The refresh token has not been used for six months" — **a device in a drawer for seven months needs the user to sign in again.** This is exactly the offline-device case the whole design is meant to survive.
+- "There is currently a limit of 100 refresh tokens per Google Account per OAuth 2.0 client ID." With 2–5 devices this is not binding, but each re-authorisation consumes one and the oldest is invalidated when the limit is hit.
+- "A Google Cloud Platform project with an OAuth consent screen configured for an external user type and a publishing status of 'Testing' is issued a refresh token expiring in **7 days**, unless the only OAuth scopes requested are a subset of name, email address, and user profile." **A project left in Testing forces re-login weekly.** Since the scope we need is non-sensitive and therefore needs no verification, moving to production status should be available — but this is the single most likely thing to be got wrong.
+- Also: "The user has revoked your app's access", "The user account has exceeded a maximum number of granted (live) refresh tokens".
+
+Microsoft: "Refresh tokens for web apps and native apps don't have specified lifetimes. Typically, the lifetimes of refresh tokens are relatively long", with rolling replacement — "Refresh tokens aren't revoked when used to acquire new access tokens. You're expected to discard the old refresh token." Access tokens come back with `"expires_in": 3599`, i.e. **one hour**. The 24-hour cap applies only to `spa`-typed redirect URIs, which a native app does not use. ([auth code flow](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow))
+
+Dropbox: refresh tokens are described as "long-lived" with no stated expiry, and access-token lifetime is deliberately not published — "The exact expiry time of a token is returned by the token endpoint" ([OAuth guide](https://developers.dropbox.com/oauth-guide)). *Confidence: low* on any specific number here; the honest statement is "read `expires_in` and do not hard-code."
+
+### 8. Change detection
+
+All three offer a cursor, so "am I behind?" is one call rather than a listing. This is materially better than the object-store handshake in §2.
+
+| Provider | Mechanism | Cost of "nothing changed" | Push? | Source |
+|---|---|---|---|---|
+| Google Drive | `changes.getStartPageToken` once, then `changes.list` with `pageToken`; the last page returns `newStartPageToken` to store. "If the `nextPageToken` is listed, it can be used to gather the next page of changes. If it's not listed, the client application should store the `newStartPageToken`." A `spaces` parameter selects the storage space, so it can be scoped to the application data folder. | one `changes.list` (100 quota units) | no client-side push without a webhook endpoint (which is a server) | [manage changes](https://developers.google.com/workspace/drive/api/guides/manage-changes) |
+| Dropbox | `list_folder` → cursor → `list_folder/continue`; or `list_folder/get_latest_cursor`, "A way to quickly get a cursor for the folder's state. Unlike `list_folder`, `list_folder/get_latest_cursor` doesn't return any entries." Cursors are "long-lived, but may expire if unused for an extend time", and expiry surfaces as a `reset` error meaning "Call `list_folder` to obtain a new cursor." | one `list_folder/continue`, or **zero while long-polling** | **Yes.** `list_folder/longpoll` blocks up to 480 s, "plus up to 90 seconds of random jitter added to avoid the thundering herd problem", on `host = "notify"` with **`auth = "noauth"`** and `allow_app_folder_app = true`. Its result carries an optional `backoff` telling the client how long to wait. | [`files.stone`](https://github.com/dropbox/dropbox-api-spec/blob/master/files.stone) [measured — read directly, §10], [detecting changes](https://developers.dropbox.com/detecting-changes-guide) |
+| OneDrive | `delta` returning `@odata.nextLink` then `@odata.deltaLink`; `?token=latest` returns "empty response with latest delta token" for establishing a baseline without enumerating. Deletions arrive with a `deleted` facet. | one `delta` call with the stored `deltaLink` | no | [driveItem: delta](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_delta) |
+
+Three details that will bite an implementation:
+
+- **Cursors expire and the recovery is a full resync.** OneDrive: "There may be cases when the service can't provide a list of changes for a given token…In these cases the service returns an `HTTP 410 Gone` error…and a `Location` header containing a new nextLink that starts a fresh delta enumeration from scratch", with `resyncChangesApplyDifferences` / `resyncChangesUploadDifferences` telling the client which way to reconcile. Dropbox has the same failure as a `reset` error. **A device offline long enough loses its cursor**, which is the same drawer case as the refresh-token expiry — and for us it is cheap to recover from, because the log is a set and re-listing is idempotent [inference].
+- **The delta feed is a state feed, not a change feed.** "The delta feed shows the latest state for each item, not each change. If an item were renamed twice, it would only show up once, with its latest name", "The same item may appear more than once in a delta feed…You should use the last occurrence you see", and "**When using delta you should always track items by id**" (same source). Since our objects are immutable once written this is mostly moot, but it forbids treating file names as stable identity.
+- **The long-poll endpoint is unauthenticated.** That is a genuine architectural gift for a serverless client: a device can hold a cheap blocking connection open with no credential in flight, and it works for app-folder apps. It is also the only push-shaped mechanism in this entire note; everything else is polling.
+
+### 9. Rate limits, quotas, and unattended operation on Android
+
+#### 9.1 Published limits
+
+- **Google Drive**: "Per minute per project: 1,000,000 quota units", "Per minute per user per project: 325,000 quota units", "Per day per project: 400,000,000 quota units", with read operations costing 5 units, list operations 100, downloads 200 ([usage limits](https://developers.google.com/workspace/drive/api/guides/limits)). At 325,000 units/minute per user and 100 units per `changes.list`, a single user could poll **3,250 times a minute** before throttling — irrelevantly far above anything we would do [inference]. Also: "Google Workspace users can only upload 750 GB per day", "The maximum file size that users can upload is 5 TB".
+- **Dropbox**: **no published numbers.** "While Dropbox does not publish exact rate limits, these limits are *not* designed to inhibit normal applications." The contract is behavioural: "the API call will return an HTTP 429 error, returning the reason of too_many_requests", "Rate limited responses always include a Retry-After header", limits "apply per user who has linked your app", and — the trap — "Rate limited requests themselves *also* count towards rate limits, and thus rapid retry loops without pause or respecting this header will be counter-productive." ([performance guide](https://developers.dropbox.com/dbx-performance-guide))
+- **Microsoft Graph**: the general throttling page does not carry Files/OneDrive numbers; it redirects to the SharePoint guidance ([throttling limits](https://learn.microsoft.com/en-us/graph/throttling-limits)). *Confidence: low* — I did not pin a number, and anyone relying on a specific OneDrive rate should chase it in the SharePoint documentation.
+
+**Assessment:** rate limits do not discriminate between these three for a single user syncing a few times an hour. The interesting number is the *absence* of one at Dropbox, which means back-off must be implemented against `Retry-After` rather than against a budget.
+
+#### 9.2 Unattended on Android — the platform, not the provider, is the constraint
+
+This applies identically to Part A and Part B; it is a property of the phone.
+
+**Doze** ([Doze and App Standby](https://developer.android.com/training/monitoring-device-state/doze-standby)) applies, verbatim:
+
+> - "Suspends network access."
+> - "Ignores wake locks."
+> - "Defers standard `AlarmManager` alarms, including `setExact()` and `setWindow()`, to the next maintenance window."
+> - "Doesn't perform Wi-Fi scans."
+> - "Doesn't let sync adapters run."
+> - "Doesn't let `JobScheduler` run."
+
+Relief comes in bursts: "Periodically, the system exits Doze for a brief time to let apps complete their deferred activities. During this *maintenance window*, the system runs all pending syncs, jobs, and alarms, and lets apps access the network." And they get rarer: "Over time, the system schedules maintenance windows less frequently."
+
+**App Standby buckets are the harder limit**, and the table is worth reproducing because two rows say *Disabled* under Network ([power management restrictions](https://developer.android.com/topic/performance/power/power-details)):
+
+| Bucket | Regular jobs | Network |
+|---|---|---|
+| Active | up to 20 min in a rolling 60 min | No restrictions |
+| Working set | up to 10 min in a rolling 4 h | No restrictions |
+| Frequent | up to 10 min in a rolling 12 h | No restrictions |
+| Rare | up to 10 min in a rolling 24 h | **Disabled** |
+| Restricted | once per day for up to 10 min | **Disabled** |
+
+Also: "App Standby defers background network activity for apps with no recent user activity" and "If the device is idle for long periods of time, the system allows idle apps network access about once a day" ([Doze and App Standby](https://developer.android.com/training/monitoring-device-state/doze-standby)).
+
+**So a phone that has not been opened in weeks — the exact case the sync design exists to handle — is in Rare or Restricted, where background network is off.** The realistic guarantee is: *sync happens when the user opens the app, and opportunistically before that.* Any design that promises "your phone quietly catches up in the background" is overpromising [inference].
+
+**Does a network sync need a foreground service?** Android's own answer is no, and it discourages one:
+
+> "In most cases, your best option for running background tasks is to use WorkManager."
+> "If a task is not critical and can be deferred, you should use WorkManager instead of a foreground service, as foreground services can potentially put a heavy load on the device."
+> "If a background work task takes longer than 10 minutes to complete, it's highly likely to be interrupted."
+>
+> — [background tasks overview](https://developer.android.com/develop/background-work/background-tasks)
+
+The deferrable-work API's floor is coarse: "The minimum repeat interval that can be defined is 15 minutes (same as the JobScheduler API)", with constraints available for `NetworkType`, `BatteryNotLow`, `RequiresCharging`, `DeviceIdle` and `StorageNotLow` ([define work](https://developer.android.com/develop/background-work/background-tasks/persistent/getting-started/define-work)). **Fifteen minutes is finer than we need**, since the whole point is offline-first reconciliation.
+
+If a foreground service is used anyway, the cost is now explicit ([Android 15 behaviour changes](https://developer.android.com/about/versions/15/behavior-changes-15)):
+
+> "The system permits an app's `dataSync` services to run for a total of 6 hours in a 24-hour period, after which the system calls the running service's `Service.onTimeout(int, int)` method"
+> "Fatal Exception: android.app.RemoteServiceException: 'A foreground service of type dataSync did not stop within its timeout: [component name]'"
+> "`BOOT_COMPLETED` receivers are *not* allowed to launch the following types of foreground services: `dataSync`, `camera`, `mediaPlayback`, `phoneCall`, `mediaProjection`, `microphone`"
+> — and if one tries, "the system throws `ForegroundServiceStartNotAllowedException`".
+
+The `dataSync` type itself is exactly our use case ("Data upload or download… Transfer data between a device and the cloud over a network") and needs `FOREGROUND_SERVICE_DATA_SYNC` in the manifest with `android:foregroundServiceType="dataSync"`, with **no runtime prerequisites** ([foreground service types](https://developer.android.com/develop/background-work/services/fgs/service-types)). But Android 15 pushes away from it, and **it cannot be started at boot**, so it cannot be the mechanism that catches a device up after a restart [inference].
+
+#### 9.3 Provider SDKs assume Java/Kotlin — what that means for a pure-Rust client
+
+Every one of these providers ships an Android SDK written for the JVM. That has three concrete consequences for an egui/eframe binary:
+
+1. **We do not use their SDKs.** All three APIs are plain HTTPS+JSON (or XML for object storage), reachable from `reqwest`. §5 shows one crate that already implements the S3, Google Drive, Dropbox and OneDrive protocols in Rust behind a single interface and checks clean for `aarch64-linux-android`. So the SDKs' language is a non-issue for the *data path*.
+2. **The auth path is the part that touches the platform.** RFC 8252 requires an external user-agent, which on Android means launching a browser — a Custom Tab, or at minimum an `ACTION_VIEW` intent — and receiving the redirect back. Both are Java API calls, so the pure-Rust client needs a JNI hop, which the repo already does for filesystem paths (`AGENTS.md`, storage table). The custom-scheme redirect must also be declared in the manifest as an intent filter. **This is the single largest piece of Android-specific plumbing the drive family imposes, and the object-store family does not impose it at all** — a key and secret need no browser [inference].
+3. A silver lining worth recording against `AGENTS.md` rule 8 (Android text input is ASCII-only, and cannot be fixed): **an OAuth flow types the password into the system browser, not into our app**, so it sidesteps the IME limitation entirely. Pasting a storage secret does too, but *typing* one does not. Neither family is blocked, but OAuth is the one that never asks our text field to handle anything [inference].
+
+---
+
+## 10. Method: commands run and outputs
+
+Everything marked [measured] came from one of these. Run 2026-07-30 on Linux, `rustc 1.97.0`, `cargo 1.97.0`.
+
+**Listing wire cost, against a live anonymously-listable bucket:**
+
+```
+$ curl -s -o /dev/null -w "%{size_download}\n" \
+    "https://noaa-goes16.s3.amazonaws.com/?list-type=2&prefix=zzzznonexistent&max-keys=5"
+254
+$ curl -s -o /dev/null -w "%{size_download}\n" "https://noaa-goes16.s3.amazonaws.com/?list-type=2&max-keys=1"
+865
+$ curl -s -o /dev/null -w "%{size_download}\n" "https://noaa-goes16.s3.amazonaws.com/?list-type=2&max-keys=2"
+1260
+$ curl -s -o /dev/null -w "%{size_download}\n" "https://noaa-goes16.s3.amazonaws.com/?list-type=2&max-keys=5"
+2445
+```
+
+The empty listing in full, which is the whole envelope:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>noaa-goes16</Name><Prefix>zzzznonexistent</Prefix><KeyCount>0</KeyCount><MaxKeys>5</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>
+```
+
+A populated entry, showing the metadata available without a `GET`:
+
+```xml
+<Contents><Key>ABI-L1b-RadC-Reproc/2017/351/00/RP_ABI-L1b-RadC-M3C01_G16_s20173510002228_e20173510004599_c20250632343546.nc</Key><LastModified>2025-05-20T18:07:12.000Z</LastModified><ETag>&quot;7fb98fdd354afbd9f6ac81fe9a511279&quot;</ETag><ChecksumAlgorithm>CRC64NVME</ChecksumAlgorithm><ChecksumType>FULL_OBJECT</ChecksumType><Size>2159575</Size><StorageClass>STANDARD</StorageClass></Contents>
+```
+
+**Conditional reads, live:**
+
+```
+$ curl -s -o /dev/null -w "status=%{http_code} bytes=%{size_download}\n" \
+    -H 'If-None-Match: "7fb98fdd354afbd9f6ac81fe9a511279"' "https://noaa-goes16.s3.amazonaws.com/<key>"
+status=304 bytes=0
+$ curl -s -o /dev/null -w "status=%{http_code} bytes=%{size_download}\n" \
+    -H 'If-Match: "deadbeefdeadbeefdeadbeefdeadbeef"' -r 0-0 "https://noaa-goes16.s3.amazonaws.com/<key>"
+status=412 bytes=348
+```
+
+**Conditional *writes* were not tested** — that needs an authenticated bucket on each provider. Everything in §1.2 is from documentation, and the B2 row is the one to verify before relying on it.
+
+**Prices, from AWS's own unauthenticated price list rather than the marketing page:**
+
+```
+$ curl -s --compressed -o /tmp/s3us.json \
+    "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonS3/current/us-east-1/index.json"
+$ python3 -c "..."   # filter products by usagetype, join to terms.OnDemand.priceDimensions
+Requests-Tier2 | GET and all other requests | $0.004 per 10,000 | 0.0000004 per Requests
+Requests-Tier1 | PUT/COPY/POST or LIST      | $0.005 per 1,000  | 0.0000050 per Requests
+TimedStorage-ByteHrs | General Purpose | $0.023 per GB - first 50 TB / month | 0.023 per GB-Mo
+```
+
+```
+$ curl -s --compressed -o /tmp/dt.json \
+    "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AWSDataTransfer/current/index.json"
+$0.090 per GB - first 10 TB / month data transfer out beyond the global free tier
+$0.085 per GB - next 40 TB   |  $0.070 per GB - next 100 TB  |  $0.050 per GB - over 150 TB
+```
+
+**Payload sizes** — rows in ADR-0004 §11's exact interchange form (16-hex writer id, RFC 9562 canonical note UUID, nine keys) as JSON Lines, `zstd -19` and `gzip -9`:
+
+```
+ 730000 rows | raw  111295393 B (152.5 B/row) | zstd-19 9462142 B | gzip-9 27907906 B | zstd ratio 11.76
+  73000 rows | raw   11056472 B (151.5 B/row) | zstd-19 1036927 B | gzip-9  2791194 B | zstd ratio 10.66
+    200 rows | raw      29816 B (149.1 B/row) | zstd-19    6330 B | gzip-9     7875 B | zstd ratio  4.71
+     33 rows | raw       4899 B (148.5 B/row) | zstd-19    1190 B | gzip-9     1352 B | zstd ratio  4.12
+      8 rows | raw       1181 B (147.6 B/row) | zstd-19     389 B | gzip-9      402 B | zstd ratio  3.04
+```
+
+The decade row reproduces ADR-0004 §10's "around 110 MB raw" independently, which is a useful cross-check that the synthetic rows are the right shape.
+
+**Rust builds for Android**, each in its own scratch crate to avoid feature unification:
+
+```
+$ CC_aarch64_linux_android=$NDK/.../aarch64-linux-android24-clang \
+  AR_aarch64_linux_android=$NDK/.../llvm-ar \
+  cargo check --target aarch64-linux-android
+object_store 0.14.1 (feature "aws")                              Finished in 10.75s
+aws-sdk-s3 1.140.0 + aws-config 1.10.1                           Finished in 17.22s
+rust-s3 0.36.0 (default-features=false, "tokio-rustls-tls")      Finished in  6.52s
+opendal 0.57.0 (services-s3, -gdrive, -dropbox, -onedrive)       Finished in 16.58s
+```
+
+Without `CC_aarch64_linux_android` the first of these fails in `aws-lc-sys v0.43.0` with `failed to find tool "aarch64-linux-android-clang"`. `cargo tree -i aws-lc-sys` shows it arriving both directly from `object_store` and transitively through `rustls 0.23`.
+
+**Crate metadata** from the crates.io API (licence, newest version, last update) is quoted in §5.
+
+**Dropbox long-poll parameters** were read from the provider's own interface-definition file rather than the rendered docs, which are client-rendered and not fetchable:
+
+```
+$ curl -s https://raw.githubusercontent.com/dropbox/dropbox-api-spec/master/files.stone
+struct ListFolderLongpollArg
+    timeout UInt64(min_value=30, max_value=480) = 30
+route list_folder/longpoll (...)
+    attrs
+        host = "notify"
+        auth = "noauth"
+        allow_app_folder_app = true
+        scope = "files.metadata.read"
+```
+
+---
+
+## 11. Confidence and what to re-check
+
+| Claim | Confidence | Why |
+|---|---|---|
+| Conditional writes unnecessary for a per-writer keyspace | **High** | Follows from quoted strong read-after-write and list-after-write guarantees plus the single-author property; the reasoning chain is in §1.3 and is attackable step by step |
+| Listing byte costs and the 1,000-key page limit | **High** | Measured live and stated in the API reference |
+| Published prices and the cost table | **High** for the prices (read from AWS's own price-list JSON and the providers' pricing pages), **medium** for my arithmetic — marked [inference], and prices move |
+| B2 does not support conditional writes | **Low-medium** | Absence in their documentation, contradicted by third-party comparisons. **Test against a real bucket before relying on it either way.** |
+| R2 tokens cannot be prefix-scoped or given a TTL | **Medium** | Absence in the token documentation. Absence of evidence, not evidence of absence |
+| Google's application-data-folder scope is non-sensitive and needs no verification | **Medium-high** | Stated directly in two Google sources, but verification policy has changed before |
+| Google refresh tokens die after six months unused, 7 days in Testing status | **High** | Stated verbatim by Google |
+| Dropbox freezes new links after 50 users pending review | **High** | Stated verbatim |
+| Microsoft has no equivalent consumer review gate | **Low** | I did not exhaust publisher-verification documentation |
+| Microsoft Graph OneDrive rate limits | **Not established** | The Graph page redirects elsewhere; no number pinned |
+| Android network is disabled in Rare and Restricted standby buckets | **High** | Stated in Android's own power-management table |
+| All four Rust crates build for `aarch64-linux-android` | **High** | Measured today, `cargo check` only — not `cargo build`, so linking is unverified |
+
+**Not covered here, by design:** synced folders, WebDAV and a git remote (sibling notes under this ticket); conflict UX and the plane case (out of scope per the ticket); the web target (ruled out in [#12](https://github.com/amin-bf/leitner/issues/12)).
+
+**The two things a decision session should test before committing**, because they are cheap to test and expensive to be wrong about: (1) whether conditional writes work on the chosen store, with a real key and two racing clients; (2) how long a real Android handset, left alone for a fortnight, actually goes between successful background syncs.

--- a/docs/research/sync-transport/synced-folders-and-webdav.md
+++ b/docs/research/sync-transport/synced-folders-and-webdav.md
@@ -1,0 +1,424 @@
+# Sync transport, part 1: a folder someone else syncs, and WebDAV
+
+**Research ticket:** [#33](https://github.com/amin-bf/leitner/issues/33) (under wayfinder map [#1](https://github.com/amin-bf/leitner/issues/1)) · **Date of research:** 2026-07-30
+**Question:** Can the review log ride on a directory that a sync application the user already runs keeps in step, or on WebDAV against rented storage — on **desktop and Android**, unattended, with no server of ours?
+
+This is a **research** note. It gathers facts and sharpens trade-offs; it decides nothing. Every non-obvious claim carries an inline source. Claims I reasoned rather than sourced are marked **[inference]**. Claims I tested are marked **[tested]** and the command and output are in §5.
+
+Context assumed throughout, from [ADR-0004](../../adr/0004-the-review-event-log.md): an append-only log of JSON Lines rows, each carrying `(writer id, sequence number)`; **every device appends only to its own rows**, so one file or one run of segments per writer, no two devices ever writing the same file, and merge is set union. Rows are relayed byte for byte and never re-encoded (§11). Clients are desktop and Android only — the web target was ruled out while resolving [#12](https://github.com/amin-bf/leitner/issues/12), so browser constraints are out of scope. ~200 reviews/day worst case ≈ 73,000 rows/year; the log is never compacted (ADR-0004 §10). One user, two to five devices.
+
+---
+
+## Summary of findings
+
+The facts that most constrain the decision, disqualifying ones first:
+
+1. **On Android there is exactly one directory that both our app and a third-party sync app can treat as ordinary files, and its API has been deprecated since API 30.** App-private storage is unreachable by anyone else — "Other apps cannot access files stored within internal storage" ([app-specific storage](https://developer.android.com/training/data-storage/app-specific)) — and since Android 11 no app, not even one holding all-files access, can read another app's `Android/data/`: that permission grants "Write access to all internal storage directories **except** `/Android/data/`, `/sdcard/Android`, and most subdirectories of `/sdcard/Android`" ([Manage all files](https://developer.android.com/training/data-storage/manage-all-files)). The exception is `Android/media/<package>`, returned by `Context.getExternalMediaDirs()`, of which Android's own reference says: "These files are scanned and made available to other apps through `MediaStore`… **There is no security enforced with these files.**" — and, in the same paragraph, "**This method was deprecated in API level 30.**" ([`Context`](https://developer.android.com/reference/android/content/Context#getExternalMediaDirs())). Everything else on Android costs a user-picked Storage Access Framework tree — a `content://` URI rather than a path, obtained through an activity result that the Rust Android glue does not expose, so it also costs a hand-written `Activity` subclass in the APK (§1.3).
+
+2. **The peer-to-peer file synchroniser's Android client was discontinued, and the stated cause was the app store.** Syncthing exchanges data directly between devices with no server in between; its Android wrapper was archived on 2024-12-03 with the notice "This app is discontinued. The last release on Github and F-Droid will happen with the December 2024 Syncthing version" ([syncthing/syncthing-android](https://github.com/syncthing/syncthing-android)), the maintainer citing "a combination of Google making Play publishing something between hard and impossible and no active maintenance" ([announcement, 2024-10-20](https://forum.syncthing.net/t/discontinuing-syncthing-android/23002)). The surviving community fork declares `MANAGE_EXTERNAL_STORAGE` and a `specialUse` foreground service in its manifest [tested — see §5.6], and its Play listing returns **HTTP 404**: it ships via F-Droid and GitHub releases only ([Catfriend1/syncthing-android](https://github.com/Catfriend1/syncthing-android)). So this family costs the user a sideload plus an all-files-access grant plus a battery-optimisation exemption, on every Android device.
+
+3. **None of the three big commercial drive clients sync a local folder on Android at all.** The strongest statement is first-party and unambiguous: "**The OneDrive app does not sync files automatically**, but you can upload updated files and edited pictures", and offline-marked files "are **read-only** — you can edit them only when you're online. If you edit a file offline, it saves as a new file, and does not change the original OneDrive file" ([Microsoft](https://support.microsoft.com/en-US/onedrive/use-onedrive-on-android)). Dropbox: "Files and folders in the Dropbox mobile app aren't stored on your phone or tablet, so they aren't available offline by default" ([Dropbox help](https://help.dropbox.com/sync/access-files-offline)), and the synced folder is a computer concept — "If you set your files to online-only, they will still appear in the Dropbox folder **on your computer**" ([Dropbox help](https://help.dropbox.com/sync/sync-overview)). Google's desktop sync client lists only "64-bit Windows 10 and up", "ARM64 Windows 11 and up" and "MacOS Ventura 13.0 or higher"; on Android, offline is a per-file toggle ([Google](https://support.google.com/drive/answer/2375082), [Google](https://support.google.com/drive/answer/2375012?co=GENIE.Platform%3DAndroid)). **These are not transports for us.**
+
+4. **A synced folder cannot answer "am I behind?" at all.** It shows a device its own local copy; there is no remote to interrogate. A directory listing tells you what has already arrived, never what exists elsewhere. The peer-to-peer synchroniser states the delivery model plainly: it "does not upload your data to the cloud but exchanges your data across your machines **as soon as they are online at the same time**" ([FAQ](https://docs.syncthing.net/users/faq.html)) — so two devices that are never awake together never converge, and neither can tell. **[inference]** from that model: the version-summary handshake of ADR-0004 §2 has no counterparty in this family; a device can only observe arrival, never absence.
+
+5. **WebDAV's conditional writes are mandatory to honour and were silently ignored by two of the three servers I tested — in the data-losing direction.** RFC 9110 is a MUST: "the origin server MUST evaluate the If-Match condition per Section 13.2 prior to performing the method", and "An origin server that evaluates an If-Match condition MUST NOT perform the requested method if the condition evaluates to false" (§13.1.1). Nextcloud 34.0.2 obeyed — `If-Match` with a stale tag returned **412** and left the file intact [tested]. `rclone serve webdav` v1.74.4 and `dufs` 0.46.0 both returned **201 Created** and **overwrote the file** for both `If-Match: "0000"` and `If-None-Match: *` [tested]. A client cannot assume the precondition was evaluated.
+
+6. **Appending to a remote file is not portable, and attempting it can destroy the file.** RFC 9110 §14.5 is explicit that partial PUT "support is inconsistent and depends on private agreements with user agents", and — the sharp part — "**Partial PUT is not backwards compatible with the original definition of PUT. It may result in the content being written as a complete replacement for the current representation.**" That is not hypothetical: a `PUT` with `Content-Range: bytes 8-12/13` against both `rclone serve webdav` and `dufs` returned 201 and left the file containing **only the fragment** [tested]; Nextcloud correctly returned **400** and left the file untouched [tested]. The out-of-band extension that does support appending — `PATCH` with `Content-Type: application/x-sabredav-partialupdate` and `X-Update-Range: append` ([sabre/dav](https://sabre.io/dav/http-patch/)) — worked on `dufs` (204), returned **400** on `rclone`, and returned **500** on Nextcloud [tested], despite Nextcloud being built on that same library. **Appending is off the table; segments are forced.**
+
+7. **Segmenting costs real compression, and I measured how much.** Over 73,000 synthetic rows in ADR-0004 §11's exact shape (measured at **151.4 bytes/row raw**, matching the ADR's "roughly 150 bytes"), `zstd -19` gives **12.01×** for one file per writer-year but only **5.02×** for daily 200-row segments — 2.20 MB/year instead of 0.92 MB/year, and 365 files instead of one [tested]. Per decade per writer: ~9.2 MB in one file, ~22 MB in 3,650 daily segments.
+
+8. **Reading only the new tail of a remote file works; that is the one thing that survives.** `Range: bytes=5-` returned **206 Partial Content** with a correct `Content-Range` on all three servers tested. So a large per-writer file can be *read* incrementally even though it cannot be *written* incrementally — a device that knows it holds 8.4 MB of a 9.2 MB file fetches 800 KB, not 9.2 MB. **[inference]**: this makes "few big files, rewritten whole on publish, read by range" a real shape, distinct from "many small segments".
+
+9. **The cheap handshake exists on WebDAV, and its price is one request.** A `PROPFIND` with `Depth: 0` for `getetag` on a collection returned **371 bytes** on Nextcloud, and the value changed both when a file was added and when an existing file was modified [tested] — one round trip answers "has anything changed?". The expensive form is the full listing: `Depth: 1` with named `getetag`+`getcontentlength` over 100 entries cost **28,577 bytes (286 B/entry)**, gzip-compressed on the wire to **2,794 bytes (28 B/entry)**; `allprop` cost **42,485 bytes (425 B/entry)** [tested]. The same listing against `rclone serve webdav` over 1,000 entries cost **245,280 bytes (245 B/entry) with no compression offered even when `Accept-Encoding: gzip` was sent**, and `allprop` cost **787,570 bytes (788 B/entry)** [tested]. RFC 6578's incremental `sync-collection` REPORT is **not** available on the files endpoint: the server answered 415 with "The {DAV:}sync-collection REPORT is not supported on this url." [tested].
+
+10. **The maintained Rust WebDAV client builds clean for `aarch64-linux-android`, and issues the most expensive PROPFIND there is.** `reqwest_dav` 0.3.3 (last published 2026-03-02, 254,184 downloads in 90 days, MIT OR Apache-2.0, [crates.io](https://crates.io/crates/reqwest_dav)) plus `reqwest` with `rustls-tls` passed `cargo ndk -t arm64-v8a check` against NDK 29.0.13846066 on rustc 1.97.0 [tested]. But its `list_raw` hard-codes `<D:allprop/>` — the 425 B/entry form — with no way to name properties through the typed API; `start_request` returns a bare `reqwest::RequestBuilder`, so conditional headers, `Range`, and named-property PROPFIND are all "build it yourself". The TLS stack it pulls in also requires Android-specific bootstrapping: `rustls-platform-verifier` needs `init_hosted()` called "before any networking has a chance to run", taking a `JNIEnv` and an Android `Context` ([docs.rs](https://docs.rs/rustls-platform-verifier/latest/rustls_platform_verifier/)).
+
+11. **Unattended background sync on Android has a hard floor of 15 minutes and a ceiling of 6 hours a day.** The minimum periodic work interval "is 15 minutes (same as the JobScheduler API)" and the actual run time "depends on the constraints that you are using… and on the optimizations performed by the system" ([WorkManager](https://developer.android.com/develop/background-work/background-tasks/persistent/getting-started/define-work)). In Doze, network access is suspended and jobs do not run until a maintenance window, and "over time, the system schedules maintenance windows less frequently" ([Doze and App Standby](https://developer.android.com/training/monitoring-device-state/doze-standby)). The escape hatch has its own cap: "The system permits an app's `dataSync` services to run for a total of **6 hours in a 24-hour period**, after which the system calls the running service's `Service.onTimeout(int, int)` method", and failing to stop yields `RemoteServiceException: "A foreground service of type dataSync did not stop within its timeout"` ([Android 15 behaviour changes](https://developer.android.com/about/versions/15/behavior-changes-15)). Asking the user to exempt us from Doze is store-policy-restricted: "**Google Play policies prohibit apps from requesting direct exemption from Power Management features** — Doze and App Standby — in Android 6.0 and above unless the core function of the app is adversely affected" ([Doze docs](https://developer.android.com/training/monitoring-device-state/doze-standby#exemption-cases)). **[inference]:** a spaced-repetition app syncing a few kilobytes has no case for the exemption; 15-minute periodic work on unmetered network is what we get.
+
+12. **Rented WebDAV is cheap and the auth story is settled, but nobody documents conditional requests.** Real prices observed 2026-07-30: 1 TB for **EUR 3.20/month** on a storage box exposing "FTP, FTPS, SFTP, SCP, Samba/CIFS, BorgBackup, Restic, Rclone, rsync via SSH, HTTPS, WebDAV" ([Hetzner](https://www.hetzner.com/storage/storage-box/)); 100 GB for **EUR 2/month** and 10 GB for **EUR 0.50/month**, yearly billing only ([Koofr](https://koofr.eu/pricing/)); 10 GB for **€1,99/month** billed annually on a hosted Nextcloud ([The Good Cloud](https://thegood.cloud/consumers/)); 3 TB for **€4,99/month** annual ([Infomaniak kDrive](https://www.infomaniak.com/en/ksuite/kdrive/prices)). App-specific passwords are the norm and sometimes mandatory: "You will not be able to set up a WebDAV connection, without using an application-specific password" ([Koofr](https://koofr.eu/help/koofr_with_webdav/which-password-to-use-when-connecting-via-webdav/)); "If you use two-factor authentication for your account, device-specific passwords are the only way to configure clients" ([Nextcloud](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html)). **`If-Match` and `If-None-Match` appear nowhere** in Nextcloud's WebDAV developer manual, which documents six custom upload headers and says only "Any existing file will be overwritten by the request" ([Nextcloud dev manual](https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/basic.html)); no other provider in the survey mentions ETag semantics either.
+
+13. **The design does not need conditional writes — the ticket's hypothesis holds.** Every log file is owned by exactly one writer, so no two devices ever `PUT` the same URL; a lost update requires two writers racing on one resource, which cannot occur. **[inference]**, but it follows directly from ADR-0004 §2. Finding 5 therefore prices a hazard we can decline to be exposed to, provided the mutable surface of ADR-0004 §7 is also published per writer rather than as one shared document. The one place conditional requests still earn their keep is the *read* side: `If-None-Match` on GET yields 304 and saves a download, and that is a pure optimisation whose failure mode is a wasted transfer, not corruption.
+
+---
+
+## 1. What Android lets one app share with another
+
+This is the load-bearing question for the whole synced-folder family: **can a third-party sync app sync a directory that our app can also read and write as ordinary files?**
+
+### 1.1 The two places our app can write without asking
+
+Android's storage overview divides the world into app-specific storage, shared storage, and media, and states the visibility rule directly. On app-specific storage: "Other apps cannot access files stored within internal storage", "The system prevents other apps from accessing these locations", and no permission is needed — "Your app doesn't require any system permissions to read and write to files in these directories" ([app-specific storage](https://developer.android.com/training/data-storage/app-specific)). Since Android 10 this is the default posture for external storage too: "Apps that target Android 10 (API level 29) and higher are given scoped access into external storage, or *scoped storage*, by default… Such apps have access only to the app-specific directory on external storage, as well as specific types of media that the app has created" ([data storage overview](https://developer.android.com/training/data-storage)).
+
+So `getFilesDir()` and `getExternalFilesDir()` are both writable by us with plain `std::fs`, and both are **invisible to any sync application**. `getExternalFilesDir()` resolves under `/sdcard/Android/data/<package>`, and Android 11 sealed that directory shut from every direction at once:
+
+- All-files access does not open it — the permission grants "Write access to all internal storage directories **except** `/Android/data/`, `/sdcard/Android`, and most subdirectories of `/sdcard/Android`" ([Manage all files](https://developer.android.com/training/data-storage/manage-all-files)).
+- The document picker does not open it — "on Android 11 (API level 30) and higher, you cannot use `ACTION_OPEN_DOCUMENT_TREE` to request individual file selection from: The `Android/data/` directory and all subdirectories. The `Android/obb/` directory and all subdirectories." ([SAF docs](https://developer.android.com/training/data-storage/shared/documents-files); the same restriction is stated for both intent actions on the [Android 11 storage page](https://developer.android.com/about/versions/11/privacy/storage)).
+
+### 1.2 The one directory that is both ours and reachable
+
+`Context.getExternalMediaDirs()` returns `/sdcard/Android/media/<package>`, and it is the sole exception. Android's own reference is unusually candid about why:
+
+> "Returns absolute paths to application-specific directories on all shared/external storage devices where the application can place media files. **These files are scanned and made available to other apps through `MediaStore`.** … **There is no security enforced with these files.** For example, any application holding `Manifest.permission.WRITE_EXTERNAL_STORAGE` can write to these files."
+> — [`Context.getExternalMediaDirs()`](https://developer.android.com/reference/android/content/Context#getExternalMediaDirs())
+
+The all-files-access page confirms it counts as shared storage: "Read and write access to all files within shared storage. (Note: The `/sdcard/Android/media` directory is part of shared storage.)" ([Manage all files](https://developer.android.com/training/data-storage/manage-all-files)). And Android 11's restriction list names `Android/data/` and `Android/obb/` — **not** `Android/media/`.
+
+Two independent applications have converged on this directory for exactly this reason. The self-hostable client stores downloads there and tags the location `PUBLIC` — its source comments the resolved path as `/storage/emulated/0/Android/media/com.nextcloud.client/nextcloud/admin@example.cloud/folder/file.txt` ([`FileStorageUtils.java`](https://github.com/nextcloud/android/blob/master/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java), [`DataStorageProvider.java`](https://github.com/nextcloud/android/blob/master/app/src/main/java/com/owncloud/android/datastorage/DataStorageProvider.java)). The peer-to-peer synchroniser's community documentation reports the same constraint from the other side: under scoped storage its folders live under `Android/media/<its own package>`.
+
+The catch is stated in the same reference paragraph: **"This method was deprecated in API level 30"**, with the migration advice being to insert into a `MediaStore` collection instead — which does not help, because a compressed JSON Lines segment is not media and `READ_MEDIA_*` permissions do not cover it.
+
+### 1.3 The alternative: a user-picked SAF tree
+
+`ACTION_OPEN_DOCUMENT_TREE` "allows users to grant your app access to an entire directory tree", after which "your app can then access any file in the selected directory and any of its sub-directories" ([SAF docs](https://developer.android.com/training/data-storage/shared/documents-files)). Three costs, all documented:
+
+**It is a URI, not a path.** Reads and writes go through `ContentResolver.openInputStream` / `openOutputStream` / `openFileDescriptor(uri, "w")`, and creation through `DocumentsContract.createDocument`. Google's own framing: "The app gains read and write access to a URI that represents the user's chosen location or document." A Rust or C dependency that wants `open(2)` on a filename gets nothing; `openFileDescriptor` yields a `ParcelFileDescriptor` whose raw fd *can* be handed to `std::fs::File::from_raw_fd`, but every open, create, rename and list is a JNI call first. **[inference]**
+
+**Listing is a cursor, and the convenience wrapper is quadratic in round trips.** AOSP's `TreeDocumentFile.listFiles()` queries the children URI for **only** `COLUMN_DOCUMENT_ID`, and every subsequent `getName()`, `length()` and `lastModified()` is its own separate `resolver.query` ([`TreeDocumentFile.java`](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/documentfile/documentfile/src/main/java/androidx/documentfile/provider/TreeDocumentFile.java), [`DocumentsContractApi19.java`](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/documentfile/documentfile/src/main/java/androidx/documentfile/provider/DocumentsContractApi19.java)) [tested — source read, §5.7]. Listing N files with sizes through that wrapper is **1 + 3N** IPC round trips; querying `buildChildDocumentsUriUsingTree` directly with all three columns is **one** cursor. Android warns about the naive path in the same document: "If you iterate through a large number of files within the directory that's accessed using `ACTION_OPEN_DOCUMENT_TREE`, your app's performance might be reduced."
+
+**It survives reboot only if you take it, and not if the folder moves.** "By default, URI permissions last only until device restart"; `takePersistableUriPermission()` fixes that, but "Even after calling `takePersistableUriPermission()`, your app doesn't retain access to the URI if the associated document is moved or deleted. In those cases, you need to ask permission again to regain access to the URI." ([SAF docs](https://developer.android.com/training/data-storage/shared/documents-files)). **[inference]:** a sync application that recreates its folder — restore, re-pair, storage change — silently revokes our access and needs a fresh picker interaction.
+
+Two directories are also excluded outright: "On Android 11 (API level 30) and higher, you cannot use `ACTION_OPEN_DOCUMENT_TREE` to request access to: The root directory of the internal storage volume. The root directory of each SD card volume… The `Download` directory."
+
+**And the picker itself needs plumbing this stack does not have.** Granting a tree means starting an activity for a result and receiving `onActivityResult` — and the Rust Android glue does not surface it. The crate that provides the entry point supports "NativeActivity or GameActivity" and can be extended to other base classes ([rust-mobile/android-activity](https://github.com/rust-mobile/android-activity)); the request that opened that line of work states the gap directly: "I'm writing a Rust library that interacts with Bluetooth on Android where I need to have my own subclass of `Activity` for being able to use `Activity::startIntentSenderForResult` and override `onActivityResult`" ([rust-mobile/ndk#266](https://github.com/rust-mobile/ndk/issues/266)). This lines up with AGENTS.md rule 8, which records that the windowing backend "handles only motion and key events". **[inference]:** a SAF tree therefore costs a hand-written `Activity` subclass in Java or Kotlin inside the APK, on a stack whose whole appeal (ADR-0003) is one crate and one binary per platform. The `getExternalMediaDirs()` route needs no picker and therefore no subclass — which is a large part of why it is the interesting one.
+
+### 1.4 All-files access is not open to us
+
+`MANAGE_EXTERNAL_STORAGE` would restore ordinary file I/O over shared storage, but the store gates it: "To limit broad access to shared storage, the Google Play store has updated its policy to evaluate apps that target Android 11 (API level 30) or higher and request all-files access… This policy is in effect as of May 2021", and "Apps that fail to meet policy requirements or do not submit a Permissions Declaration Form may be removed from Google Play" ([Manage all files](https://developer.android.com/training/data-storage/manage-all-files), [Play policy](https://support.google.com/googleplay/android-developer/answer/10467955)). The eligible list is file managers, backup/restore, anti-virus, document management, on-device search, encryption and device migration. A spaced-repetition app is none of those.
+
+### 1.5 The answer
+
+**Yes, but only in one shape.** Our app writes to its own `getExternalMediaDirs()` path with ordinary file I/O and no permission at all, and a sync application holding all-files access reads and writes it — that combination is documented from both ends. Every other shape costs a SAF tree: a picker interaction per device, a persisted URI permission that can be lost, `content://` plumbing through JNI, and one cursor query rather than `readdir`. And the deprecated status of `getExternalMediaDirs()` means the good shape is the one Android is steering away from.
+
+---
+
+## 2. What the sync applications themselves guarantee
+
+### 2.1 Peer-to-peer, no server — and no Android client from upstream
+
+The peer-to-peer synchroniser is architecturally the best fit on paper: it moves files between devices with no intermediary, which is exactly the "no server of our own" constraint. Its own FAQ states the delivery model and, in doing so, the limitation: it "does not upload your data to the cloud but exchanges your data across your machines **as soon as they are online at the same time**" ([FAQ](https://docs.syncthing.net/users/faq.html)).
+
+Upstream's Android client is gone: repository "archived by the owner on Dec 3, 2024. It is now read-only", with "This app is discontinued. The last release on Github and F-Droid will happen with the December 2024 Syncthing version" ([syncthing/syncthing-android](https://github.com/syncthing/syncthing-android)). The maintainer's stated reason names the app store: "a combination of Google making Play publishing something between hard and impossible and no active maintenance… The app saw no significant development for a long time and without Play releases I do no longer see enough benefit" ([forum announcement, 2024-10-20](https://forum.syncthing.net/t/discontinuing-syncthing-android/23002)).
+
+The community fork is maintained and distributes via "the 'releases' section or F-Droid" ([Catfriend1/syncthing-android](https://github.com/Catfriend1/syncthing-android)); its Play listing returns **HTTP 404** [tested, §5.6]. Its manifest declares `MANAGE_EXTERNAL_STORAGE`, `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`, `FOREGROUND_SERVICE_SPECIAL_USE` and `android:foregroundServiceType="specialUse"` [tested, §5.6] — i.e. it depends on precisely the two things Google Play restricts. `specialUse` itself is reviewed: developers "specify the `<property>` element within the `<service>` element. These values and corresponding use cases are reviewed when you submit your app in the Google Play Console" ([foreground service types](https://developer.android.com/develop/background-work/services/fgs/service-types)).
+
+### 2.2 A self-hostable server-backed client: two-way, but not for arbitrary folders
+
+The Android client of the self-hostable file-sync server does register a storage provider — `DocumentsStorageProvider` with `android:permission="android.permission.MANAGE_DOCUMENTS"` and a `DOCUMENTS_PROVIDER` intent filter, implementing `queryChildDocuments`, `openDocument`, `createDocument`, `renameDocument`, `deleteDocument` ([AndroidManifest.xml](https://github.com/nextcloud/android/blob/master/app/src/main/AndroidManifest.xml), [`DocumentsStorageProvider.java`](https://github.com/nextcloud/android/blob/master/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java)). It also declares `MANAGE_EXTERNAL_STORAGE` and `requestLegacyExternalStorage="true"`.
+
+But what it syncs is narrower than "a folder":
+
+- **Auto upload is one-way and media-shaped.** The store description offers "Auto Upload for photos and videos taken by your device" ([full_description.txt](https://github.com/nextcloud/android/blob/master/src/generic/fastlane/metadata/en-US/full_description.txt)), and the trigger watches `MediaStore.Images`, `MediaStore.Video` and `MediaStore.Files` content URIs ([`BackgroundJobManagerImpl.kt`](https://github.com/nextcloud/android/blob/master/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt)).
+- **Two-way sync exists, but only for files already marked available offline, and only when the server side moved first.** `OfflineSyncWork.doWork()` calls `checkETagChanged(folderName, …) ?: return` — if the remote collection ETag is unchanged the folder is skipped entirely, before any local file is examined ([`OfflineSyncWork.kt`](https://github.com/nextcloud/android/blob/master/app/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt)). The per-file operation underneath *is* bidirectional and does upload local changes ([`SynchronizeFileOperation.kt`](https://github.com/nextcloud/android/blob/master/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.kt)). **[inference]:** a purely local append by our app, with nothing having changed on the server, is not noticed until some unrelated change bumps that collection's ETag.
+- **Cadence is 15 minutes, unmetered only, and off under power saving.** `DEFAULT_PERIODIC_JOB_INTERVAL_MINUTES = 15L`, the offline-sync request sets `NetworkType.UNMETERED`, and the worker no-ops when power saving is on ([`BackgroundJobManagerImpl.kt`](https://github.com/nextcloud/android/blob/master/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt)).
+
+No first-party documentation states this client's scoped-storage position; the evidence above is source code, and a repository search for "scoped storage" returns only lint suppressions.
+
+### 2.3 Command-line sync tooling is not a background service
+
+The general-purpose cloud-storage CLI has Android binaries but disowns them: "See also Android builds… These are built as part of the official release, but haven't been adopted as first class builds yet" ([downloads.md](https://github.com/rclone/rclone/blob/master/docs/content/downloads.md)). Its install guide, FAQ and `mount` documentation contain no Android section at all. Two-way sync is a separate command carrying an explicit warning — "`bisync` is considered an **advanced command**, so use with care… or data loss can result" — and is scheduled externally: "On Linux or Mac, consider setting up a crontab entry… On Windows this can be done using a *Task Scheduler*" ([bisync docs](https://rclone.org/bisync/)). There is no watch or daemon mode.
+
+### 2.4 Change detection and latency
+
+The peer-to-peer synchroniser detects changes two ways: "By regular full scans and by notifications received from the filesystem ('watcher'). By default the watcher is enabled and full scans are done once per hour" ([Understanding Synchronization](https://docs.syncthing.net/users/syncing.html)). The configuration defaults are `fsWatcherEnabled: true`, `fsWatcherDelayS: 10` — "The duration during which changes detected are accumulated, before a scan is scheduled" — and `rescanIntervalS: 3600` ([Configuration](https://docs.syncthing.net/users/config.html)). So **write-to-scan is ~10 s with the watcher, 1 hour without**, plus transfer, plus the requirement that the peer is awake. If the two devices cannot reach each other directly, traffic goes through a relay and "the transfer rate is much lower than a direct connection would allow" ([Relaying](https://docs.syncthing.net/users/relaying.html)).
+
+Against that, WebDAV's latency is whatever polling interval we choose — floored at 15 minutes on Android by WorkManager (§4.6), and immediate on desktop.
+
+### 2.5 Conflict semantics you inherit
+
+Because two devices never write the same file (ADR-0004 §2), content conflicts are not the interesting failure. What remains:
+
+**Partial files are handled well.** "Syncthing never writes directly to a destination file. Instead all changes are made to a temporary copy which is then moved in place over the old version. If an error occurs during the copying or syncing… the temporary file is kept around for up to a day" ([Understanding Synchronization](https://docs.syncthing.net/users/syncing.html)). Temporaries are named `.syncthing.<name>.tmp` on Unix. **[inference]:** a reader therefore never sees a half-written segment, but must ignore `.syncthing.*.tmp` when listing. This dovetails with ADR-0004 §11's rule that "a malformed *final* line is discarded silently", which covers the local crash case rather than the transport case.
+
+**Conflicts still get invented, and they replicate.** If the same path does somehow diverge, "the file with the older modification time will be marked as the conflicting file and thus be renamed" to `<filename>.sync-conflict-<date>-<time>-<modifiedBy>.<ext>`, ties broken by device ID; and those files "are treated as normal files after they are created", so the conflict copy itself syncs everywhere ([Conflicting Changes](https://docs.syncthing.net/users/syncing.html#conflicting-changes)). **[inference]:** with per-writer files this should never fire, but if it does, the reader must either parse or explicitly skip `*.sync-conflict-*` — and since rows are addressed by `(writer, sequence)` and merge by set union, parsing them is harmless and skipping them loses data.
+
+**Deletion propagates by default.** "Versioning… defaults to 'no file versioning', i.e. no old copies of files are kept" ([File Versioning](https://docs.syncthing.net/users/versioning.html)). A deletion anywhere is a deletion everywhere. For a log that is never compacted (ADR-0004 §10), the store has no protection we do not configure ourselves.
+
+**Filename constraints.** The synchroniser defaults `caseSensitiveFS: false`, meaning it runs "extra safety checks for case insensitive filesystems" by default ([Configuration](https://docs.syncthing.net/users/config.html)), and symlinks are unusable on Android — "even though Syncthing may try to synchronise symbolic links on Android, this will not succeed, as the OS does not support them on the user storage" ([FAQ](https://docs.syncthing.net/users/faq.html)). **[inference]:** ADR-0004's writer ids are hex, so names of the form `<writer-hex>-<seq>.jsonl.zst` are lowercase ASCII and dodge every case-folding and reserved-name hazard on Windows, macOS and Android alike. This is a constraint to keep, not a problem to solve.
+
+### 2.6 The handshake
+
+There is none. §Summary-4 above: a synced folder presents the local replica, and no API exposes "what does the remote hold". A device can compute its own `{writer id → highest sequence}` from what it can see, but "am I behind?" is unanswerable in this family — the only signal is that new bytes eventually appear. On Android through a SAF tree, even enumerating the local replica is a `ContentResolver` cursor rather than `readdir`, though a single query over `buildChildDocumentsUriUsingTree` with `COLUMN_DISPLAY_NAME`, `COLUMN_SIZE` and `COLUMN_LAST_MODIFIED` is one round trip, not N (§1.3).
+
+### 2.7 Setup burden, honestly
+
+Per device, before a single row moves, with the peer-to-peer synchroniser: install F-Droid or sideload an APK (not on Play, §2.1); grant all-files access through the special-access settings screen; grant the battery-optimisation exemption its manifest requests; pair the device with each other device by exchanging device IDs; create and share the folder; and on our side, either accept `getExternalMediaDirs()` (deprecated) or run the SAF picker once and persist the URI permission. That is roughly six user actions per Android device and four per desktop, none of which we can perform or verify programmatically. **[inference]**, but each step is sourced above.
+
+---
+
+## 3. WebDAV
+
+### 3.1 The protocol facts
+
+**Listing.** "All DAV-compliant resources MUST support the PROPFIND method"; "A client MUST submit a Depth header with a value of '0', '1', or 'infinity'… Servers MUST support '0' and '1' depth requests… and SHOULD support 'infinity'. In practice, support for infinite-depth requests MAY be disabled, due to the performance and security concerns" — and a server "MAY reject PROPFIND requests on collections with depth header of 'Infinity'" with 403 and a `propfind-finite-depth` precondition (RFC 4918 §9.1, §9.1.1). The response is `207 Multi-Status`, one `<response>` element per member URL, and an empty request body "MUST be treated as if it were an 'allprop' request" — which the RFC itself warns against: "Note that 'allprop' does not return values for all live properties. WebDAV servers increasingly have expensively-calculated or lengthy properties… Instead, WebDAV clients can use propname requests to discover what live properties exist, and request named properties when retrieving values."
+
+**The properties we care about are conditionally required.** `getcontentlength` "MUST be defined on any DAV-compliant resource that returns the Content-Length header in response to a GET" and is computed and therefore protected (§15.4). `getetag` "MUST be defined on any DAV-compliant resource that returns the Etag header" and "MUST be protected because this value is created and controlled by the server" (§15.6). `getlastmodified` likewise (§15.7) — with the RFC's own warning that it is the weaker tool: "since [RFC2616] requires clients to use ETags where provided, a server implementing ETags can count on clients using a much better mechanism than modification dates for offline synchronization or cache control". Note the shape of the requirement: each is a MUST *conditional on the server emitting the corresponding HTTP header*. A server that emits no `ETag` is not required to expose `getetag`.
+
+**PUT.** "A PUT performed on an existing resource replaces the GET response entity of the resource", and "A PUT that would result in the creation of a resource without an appropriately scoped parent collection MUST fail with a 409 (Conflict)" (RFC 4918 §9.7.1) — so a client must `MKCOL` the directory first. PUT to a collection is undefined and "MAY be treated as an error (405 Method Not Allowed)" (§9.7.2).
+
+### 3.2 Conditional writes: available, mandatory to honour, unreliable in practice
+
+**Available and specified.** `If-Match` "makes the request method conditional on the recipient origin server… having a current representation of the target resource that has an entity tag matching a member of the list", and "An origin server MUST use the strong comparison function when comparing entity tags for If-Match… since the client intends this precondition to prevent the method from being applied if there have been any changes" (RFC 9110 §13.1.1). `If-None-Match: *` is the create-if-absent primitive: it "can also be used with a value of `*` to prevent an unsafe request method (e.g., PUT) from inadvertently modifying an existing representation of the target resource when the client believes that the resource does not have a current representation" (§13.1.2).
+
+**Mandatory to honour, when sent.** "When an origin server receives a request that selects a representation and that request includes an If-Match header field, the origin server MUST evaluate the If-Match condition per Section 13.2 prior to performing the method", and "An origin server that evaluates an If-Match condition MUST NOT perform the requested method if the condition evaluates to false. Instead, the origin server MAY indicate that the conditional request failed by responding with a 412 (Precondition Failed) status code." For `If-None-Match` the failure response is not even optional: the server "MUST respond with either a) the 304 (Not Modified) status code if the request method is GET or HEAD or b) the 412 (Precondition Failed) status code for all other request methods" (§13.1.2).
+
+**But the validator that makes it work is only a SHOULD.** "An origin server **SHOULD** send an ETag for any selected representation for which detection of changes can be reasonably and consistently determined" (RFC 9110 §8.8.3), and "A sender MAY send the ETag field in a trailer section". WebDAV adds a preference, not a requirement: "Strong ETags are much more useful for authoring use cases than weak ETags… Note also that weak ETags have certain restrictions in HTTP, e.g., these cannot be used in If-Match headers", and "a WebDAV server **SHOULD NOT** change the ETag (or the Last-Modified time) for a resource that has an unchanged body and location" (RFC 4918 §8.6). **So the chain is: MAY generate → SHOULD send → MUST honour if sent. A server with no ETags is fully conformant and offers no conditional write at all.**
+
+**WebDAV's own `If` header is a weaker instrument than `If-Match`.** It "is intended to have similar functionality to the If-Match header… However, the If header handles any state token as well as ETags", and "If this header is evaluated and all state lists fail, then the request MUST fail with a 412 (Precondition Failed) status" (RFC 4918 §10.4, §10.4.1). But its matching rule is looser: "Matching entity tag: Where the entity tag matches an entity tag associated with the identified resource. **Servers MUST use either the weak or the strong comparison function**" (§10.4.4) — the client cannot tell which it got, where `If-Match` mandates strong comparison.
+
+**Two of three servers ignored it entirely.** [tested, §5.2–5.4] Against `rclone serve webdav` v1.74.4 and `dufs` 0.46.0, both `If-Match: "0000"` on a resource whose real tag was different, and `If-None-Match: *` on a resource that existed, returned **201 Created** and **replaced the file's contents**. Nextcloud 34.0.2 returned **412** for both and left the file untouched, then accepted the same PUT with the correct tag (204). Nothing in the response of the two non-conforming servers distinguishes "precondition passed" from "precondition ignored": both are a 2xx.
+
+**And even where it works, the tag you read may not be the tag you can write with.** A reproduced failure against a Nextcloud instance behind a compressing reverse proxy: a `GET` with gzip returns a weak tag `W/"…"`, a `PUT` with `If-Match: W/"…"` returns 412 forever, and the same PUT with `W/` stripped returns 204 — because "weak ETags… cannot be used in If-Match headers" (RFC 4918 §8.6) and compression at the proxy is enough to weaken them ([koreader#15707](https://github.com/koreader/koreader/issues/15707)). I did **not** reproduce this on my own instance — bare Apache did not compress the file body and the tag stayed strong [tested, §5.5] — so treat it as a hazard that depends on the host's proxy, which no host documents.
+
+### 3.3 Partial and range writes: reading yes, appending no
+
+**Appending via `Content-Range` on PUT is unsafe by specification.** RFC 9110 §14.5 "Partial PUT":
+
+> "Some origin servers support PUT of a partial representation when the user agent sends a Content-Range header field… though such support is inconsistent and depends on private agreements with user agents… An origin server SHOULD respond with a 400 (Bad Request) status code if it receives Content-Range on a PUT for a target resource that does not support partial PUT requests. **Partial PUT is not backwards compatible with the original definition of PUT. It may result in the content being written as a complete replacement for the current representation.**"
+
+That last sentence is the whole finding: the failure mode of guessing wrong is not an error, it is the file being replaced by the fragment. Both lightweight servers did exactly that — 201 Created, file left containing only the appended bytes [tested, §5.4]. Nextcloud returned 400 and preserved the file [tested]. RFC 9110 offers the only safe alternatives in the same section: "targeting a separately identified resource with state that overlaps or extends a portion of the larger resource" — i.e. **segment files** — "or by using a different method that has been specifically defined for partial updates (for example, the PATCH method defined in [RFC5789])".
+
+**The PATCH extension exists but is not a standard and is not portable.** The `Sabre\DAV\PartialUpdate\Plugin` implements RFC 5789 with `Content-Type: application/x-sabredav-partialupdate` and `X-Update-Range` taking `bytes=start-end`, `bytes=start-`, `bytes=-N` or `append`, advertising `sabredav-partialupdate` in the `DAV` response header ([sabre/dav](https://sabre.io/dav/http-patch/)). Tested: `dufs` implements it (**204**, bytes appended); `rclone serve webdav` returns **400**; Nextcloud — which is *built on* that library — returns **500 Internal Server Error** [tested, §5.4]. It is not advertised in any of the three servers' `DAV:` headers.
+
+**Range reads work everywhere I tested.** `Range: bytes=5-` returned `206 Partial Content` with `Content-Range: bytes 5-14/15` on `rclone serve webdav`, on `dufs`, and on Nextcloud [tested]. So a per-writer file can be published as a whole-file `PUT` and consumed incrementally by byte offset. **[inference]:** combined with `getcontentlength` from PROPFIND, a reader knows exactly how many new bytes exist and fetches only those — the append-only property is preserved on the read path even though the write path must rewrite.
+
+### 3.4 What that forces on segment sizing — measured
+
+Since appending is unavailable, each publish either rewrites the writer's whole file or starts a new segment. I generated 73,000 rows in ADR-0004 §11's exact JSON shape (three writer ids, 4,000 note UUIDs, realistic timestamps) and compressed at several segment sizes with `zstd -19` [tested, §5.8]:
+
+| rows/segment | segments/year | compressed total | ratio | bytes/row | avg segment |
+|---|---|---|---|---|---|
+| 200 (≈ one day) | 365 | 2,199,983 B | 5.02× | 30.1 | 6.0 KB |
+| 1,000 | 73 | 2,047,073 B | 5.40× | 28.0 | 28 KB |
+| 5,000 | 15 | 1,667,363 B | 6.63× | 22.8 | 111 KB |
+| 73,000 (one file/year) | 1 | 920,123 B | 12.01× | 12.6 | 920 KB |
+
+Raw was 11,049,129 B, i.e. **151.4 bytes/row** — ADR-0004 §11's "roughly 150 bytes" is accurate. The ADR's "compresses about ten to one" holds only for large blocks: **daily segmentation cuts the ratio from 12.0× to 5.0×, costing 2.4× the bytes.** Caveat on realism: my generator draws note UUIDs uniformly from 4,000 notes, so the identifier column carries near-maximal entropy; a real deck with skewed review distribution should compress somewhat better at every size, and the *ratio between* sizes is the transferable number, not the absolutes. **[inference]**
+
+Per writer per decade, extrapolating: **~9.2 MB in one rewritten-whole file, ~22 MB in 3,650 daily segments.** Three writers over a decade at daily segmentation is **~11,000 files, ~66 MB** — comfortably inside every quota in §3.6, but see §3.5 for what 11,000 files costs to list. The other side of the ledger: publishing a whole-file rewrite in year ten uploads 9.2 MB to add 6 KB of new rows, on a mobile connection, every time. **[inference]**
+
+### 3.5 The handshake, priced
+
+Measured against Nextcloud 34.0.2 with 100 entries in a collection, and against `rclone serve webdav` with 1,000 [tested, §5.9]:
+
+| Request | Nextcloud 34.0.2 | rclone serve webdav 1.74.4 |
+|---|---|---|
+| `PROPFIND Depth: 0`, `getetag` on the collection | **371 B**, 1 round trip | n/a — collection `getetag` returned 404 Not Found |
+| `PROPFIND Depth: 1`, named `getetag`+`getcontentlength` | 28,577 B / 100 = **286 B/entry** | 245,280 B / 1000 = **245 B/entry** |
+| …the same, `Accept-Encoding: gzip` | 2,794 B = **28 B/entry** (10.2× smaller) | **no compression offered** — 245,280 B on the wire |
+| `PROPFIND Depth: 1`, `allprop` | 42,485 B = **425 B/entry** | 787,570 B = **788 B/entry** |
+| `PROPFIND Depth: infinity` | not attempted | served, 1000 entries |
+
+Three consequences:
+
+- **The cheap handshake is real but server-specific.** One `PROPFIND Depth: 0` for the collection's `getetag` cost 371 bytes and changed both when a file was added and when an existing file was modified [tested]. That answers "has *anything* changed?" in one request. The lightweight Go server exposed no collection ETag at all (`getetag` came back inside a `404 Not Found` propstat for the collection [tested, §5.1]) — so this handshake is a property of the server, not of WebDAV.
+- **The full listing scales with segment count, and gzip decides whether that hurts.** 11,000 daily segments after a decade (§3.4) cost **3.1 MB uncompressed / 308 KB gzipped** on the Nextcloud-shaped server, versus **2.7 MB with no compression available** on the Go server. Using `allprop` instead of named properties inflates that by 1.5–3.2×.
+- **The incremental listing that would solve this is not available.** RFC 6578's `sync-collection` REPORT, which returns only what changed since a token, was refused: `415 Unsupported Media Type`, "The {DAV:}sync-collection REPORT is not supported on this url." [tested, §5.9]. It is implemented for calendars and contacts, not for files.
+
+**[inference]:** the two extremes price out very differently. Few large files means a 371-byte handshake, a `Depth: 1` listing of a handful of entries, `Range` reads for the tail, and 9.2 MB re-uploaded per publish. Many small segments means a 308 KB listing per handshake at decade scale and 6 KB uploads. Nothing in the protocol forces the choice; the numbers above are what it costs either way.
+
+### 3.6 Who sells it, and what it costs
+
+All prices observed **2026-07-30**; currency and billing period as published.
+
+| Provider | Price | Storage | WebDAV | App-specific credentials |
+|---|---|---|---|---|
+| [Hetzner Storage Box BX11](https://www.hetzner.com/storage/storage-box/) | **EUR 3.20 / USD 4.00 per month** | 1 TB | included, must be switched on | 100 sub-accounts, each with its own credentials and directory — no token mechanism |
+| [Koofr](https://koofr.eu/pricing/) | **EUR 0.50/mo** (10 GB), **EUR 2/mo** (100 GB), EUR 10/mo (1 TB) — "Currently only yearly subscriptions are possible" | 10 GB free tier | included | **mandatory** |
+| [The Good Cloud](https://thegood.cloud/consumers/) (hosted Nextcloud) | **€1,99/mo** billed annually (€23,88/yr) | 10 GB | core feature | app passwords |
+| [Hetzner Storage Share NX11](https://www.hetzner.com/storage/storage-share/) (managed Nextcloud) | **EUR 4.29 / USD 5.00 per month** | 1 TB | core feature | app passwords |
+| [Infomaniak kDrive Solo](https://www.infomaniak.com/en/ksuite/kdrive/prices) | **€4,99/mo** annual (€5,54 monthly) | 3 TB, "cannot be increased" | included on paid tiers, "UNAVAILABLE" on free | none documented |
+| [Fastmail](https://www.fastmail.com/help/files/davnftp.html) | bundled with mail | small | `https://webdav.fastmail.com/` | "an app password with WebDAV permissions" |
+| [pCloud](https://help.pcloud.com/article/webdav) | paid plans only | — | still offered | **none** — account password, plus email confirmation under 2FA |
+| Box | — | — | **removed** — WebDAV reached end of life on 2023-04-28 ([Announcing end of life for Box WebDAV support](https://support.box.com/hc/en-us/articles/360052806073-Announcing-end-of-life-for-Box-WebDAV-support); the article body is script-rendered, so I verified the title and a 200 response, not the body text) | — |
+
+Two further notes. The storage-box vendor lists its protocols as "FTP, FTPS, SFTP, SCP, Samba/CIFS, BorgBackup, Restic, Rclone, rsync via SSH, HTTPS, WebDAV", documents "Up to 10 simultaneous connections per Storage Box account" and "Up to 100 sub-accounts", and warns "The WebDAV protocol does not support the output of the available disk space" ([Hetzner docs](https://docs.hetzner.com/storage/storage-box/)); **what software serves that WebDAV is not stated anywhere first-party**, so its ETag behaviour is unknown until probed. One provider actively discourages the use case: its own FAQ frames WebDAV as for "specific and occasional use cases", disclaims third-party client compatibility, and states it does not support the protocol ([Infomaniak](https://www.infomaniak.com/en/support/faq/2409/connect-to-kdrive-via-webdav)).
+
+The provider list maintained by the self-hostable server's vendor no longer includes any of the hosts named above; it now lists Office EU, NL Hosting, Personal Phoenix, FOSSTech Projects, DKM Ecosystem, IONOS CLOUD, hosting.de, Leviia, Replicant IT and Kazteleport, none with a published consumer price on that page ([providers list](https://nextcloud.com/providers/)).
+
+**No provider in this survey documents ETag or conditional-request behaviour.** That absence was searched for, not stumbled into: the self-hostable server's own WebDAV developer manual mentions ETag once, as a PROPFIND property, enumerates six custom upload headers (`X-OC-MTime`, `X-OC-CTime`, `OC-Checksum`, `X-Hash`, `OC-Total-Length`, `X-NC-WebDAV-AutoMkcol`), and says of PUT only "Any existing file will be overwritten by the request" — `If-Match` and `If-None-Match` appear nowhere in it ([dev manual](https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/basic.html)).
+
+### 3.7 Auth from the client's side
+
+What a native app must store is a username and a long-lived secret, sent as HTTP Basic over TLS; app-specific passwords are the norm and in two cases mandatory:
+
+> "Each time you set up a new connection via WebDAV protocol … you need to generate a new application-specific password… **You will not be able to set up a WebDAV connection, without using an application-specific password.**"
+> — [Koofr](https://koofr.eu/help/koofr_with_webdav/which-password-to-use-when-connecting-via-webdav/)
+
+> "If you use two-factor authentication for your account, device-specific passwords are the only way to configure clients." / "The server will then deny connections from clients using your login password."
+> — [Nextcloud session management](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html)
+
+> "you should use an application password for login rather than your regular password. In addition to improved security, this increases performance significantly."
+> — [Nextcloud WebDAV access](https://docs.nextcloud.com/server/latest/user_manual/en/files/access_webdav.html)
+
+**On expiry:** there is no token refresh flow here — these are passwords, not OAuth tokens. They do not expire on a timer; they stop working when the user revokes the device entry, at which point the server returns 401 and the only remedy is a fresh secret entered by hand. **[inference]**, from the absence of any refresh mechanism in the cited documents. The digest-auth path exists in the client library (`digest_auth` is a direct dependency of `reqwest_dav` [tested, §5.10]) but no surveyed provider documents requiring it.
+
+No provider in the survey publishes a per-request rate limit. One publishes connection ceilings instead — "Up to 10 simultaneous connections per Storage Box account" ([Hetzner docs](https://docs.hetzner.com/storage/storage-box/)) — and one publishes a daily bandwidth figure of 1000 GB/day/user, framed as advisory ([Infomaniak](https://www.infomaniak.com/en/support/faq/2387/manage-kdrive-storage)). A login lockout returning HTTP 429 after repeated wrong passwords was reported in one provider's help centre but **I could not re-locate the page to verify it — treat as unsourced**. **[inference]:** whether or not that specific lockout exists, an unattended client that retries a rejected credential in a loop is the obvious way to get an account blocked, so a 401 must stop the loop rather than back off.
+
+### 3.8 Rust client support
+
+| Crate | Latest | Published | 90-day downloads | Licence | Verdict |
+|---|---|---|---|---|---|
+| [`reqwest_dav`](https://crates.io/crates/reqwest_dav) | 0.3.3 | 2026-03-02 | 254,184 | MIT OR Apache-2.0 | the only maintained option |
+| [`rustydav`](https://crates.io/crates/rustydav) | 0.1.3 | 2021-10-09 | 1,688 | **GPL-3.0** | unmaintained, licence unusable for a shipped binary |
+| [`webdavc`](https://crates.io/crates/webdavc) | 0.1.1 | 2022-12-31 | 12 | **GPL-3.0** | dead |
+| [`hyperdav`](https://crates.io/crates/hyperdav) | 0.2.0 | 2018-08-24 | 18 | MIT | dead |
+| [`dav-server`](https://crates.io/crates/dav-server) | 0.11.0 | 2026-02-21 | 120,938 | Apache-2.0 | **server**, not a client |
+| [`opendal`](https://crates.io/crates/opendal) | 0.57.0 | 2026-06-01 | 3,253,921 | Apache-2.0 | multi-backend abstraction with a WebDAV service; heavier |
+
+Registry data queried from the crates.io API on 2026-07-30.
+
+**Cross-compilation [tested, §5.10]:** `reqwest_dav` 0.3.3 with `reqwest` 0.13 (`default-features = false`, `rustls-tls`) passed `cargo ndk -t arm64-v8a check` against NDK 29.0.13846066 on rustc 1.97.0, pulling in `aws-lc-rs`, `rustls` 0.23, `rustls-platform-verifier` and `jni` 0.22.4. A plain `cargo check --target aarch64-linux-android` **fails** without the NDK on `PATH` — `error occurred in cc-rs: failed to find tool "aarch64-linux-android-clang"` — because the TLS backend compiles C.
+
+**What the crate does and does not give you** (source read at `reqwest_dav-0.3.3/src/lib.rs`):
+
+- `list_raw(path, depth)` hard-codes the request body to `<D:propfind xmlns:D="DAV:"><D:allprop/></D:propfind>` — the 425 B/entry form of §3.5, with no parameter for naming properties.
+- Typed methods are `get`, `put`, `delete`, `mkcol`, `mv`, `cp`, `list`, `unzip`. **No conditional-header parameter, no `Range`, no `PATCH`.**
+- `start_request(method, path)` returns a `reqwest::RequestBuilder` with auth already applied, so `If-Match`, `Range` and a named-property PROPFIND are all reachable — as hand-written requests.
+
+**[inference]:** this is close enough to "a plain HTTP client job" that the crate's value is the PROPFIND XML parsing (via `serde-xml-rs` 0.6) and the digest-auth handling, not the WebDAV abstraction.
+
+**Android runtime gotcha:** the TLS verifier this pulls in is not self-sufficient on Android. "In order for the crate to call into the JVM, it needs handles from Android" — `rustls_platform_verifier::android::init_hosted()` must be called with a `JNIEnv` and a `Context` "before any networking has a chance to run" ([docs.rs](https://docs.rs/rustls-platform-verifier/latest/rustls_platform_verifier/)). Under `android-activity` that means reaching the JVM through `ndk-context` at startup. Note that `ndk-context` 0.1.1 has not been published since 2022-04-19 despite 13.1 M downloads in 90 days [crates.io, 2026-07-30].
+
+### 3.9 Unattended on Android
+
+**Periodic work has a 15-minute floor and no timing guarantee.** "The minimum repeat interval that can be defined is 15 minutes (same as the JobScheduler API)"; "The interval period is defined as the minimum time between repetitions. The exact time that the worker is going to be executed depends on the constraints that you are using in your WorkRequest object and on the optimizations performed by the system"; and with constraints, a run "could be delayed, or even skipped if the conditions are not met within the run interval" ([WorkManager](https://developer.android.com/develop/background-work/background-tasks/persistent/getting-started/define-work)).
+
+**Doze suspends the network outright.** While in Doze the system suspends network access, ignores wake locks, defers standard alarms, and does not run sync adapters or JobScheduler jobs (which includes WorkManager); pending work runs in maintenance windows, and "over time, the system schedules maintenance windows less frequently". Under App Standby, an idle app gets network access "about once a day" ([Doze and App Standby](https://developer.android.com/training/monitoring-device-state/doze-standby)). The exemptions are foreground services and high-priority push messages — and push requires a server, which we do not have.
+
+**The foreground-service escape hatch is capped and store-reviewed.** A network sync is the `dataSync` type, requiring `FOREGROUND_SERVICE_DATA_SYNC` ([service types](https://developer.android.com/develop/background-work/services/fgs/service-types)), and on Android 15: "The system permits an app's `dataSync` services to run for a total of 6 hours in a 24-hour period, after which the system calls the running service's `Service.onTimeout(int, int)` method… If the service does not call `Service.stopSelf()`, the system throws an internal exception… `RemoteServiceException: "A foreground service of type dataSync did not stop within its timeout"`". Also: "Apps that target Android 15 or higher are not allowed to launch a data sync foreground service from a `BOOT_COMPLETED` broadcast receiver" — so there is no sync-on-boot. Google's stated alternatives are expedited WorkManager work (under ~10 minutes), a user-initiated data transfer job (`JobScheduler.setUserInitiated`, requiring a visible progress notification), or `shortService` (~3 minutes) ([data transfer options](https://developer.android.com/develop/background-work/background-tasks/data-transfer-options)).
+
+**Asking the user to opt out of Doze is not open to us.** "Google Play policies prohibit apps from requesting direct exemption from Power Management features — Doze and App Standby — in Android 6.0 and above unless the core function of the app is adversely affected", with acceptable cases limited to messaging/calling, safety, task automation and peripheral-companion apps ([Doze docs](https://developer.android.com/training/monitoring-device-state/doze-standby#exemption-cases)).
+
+**[inference]:** the realistic unattended envelope on Android is a 15-minute periodic job with a network constraint, degrading to roughly once a day for a phone left untouched, with a foreground service reserved for a sync the user explicitly started. That is adequate for a spaced-repetition log at 200 rows/day, but it means "unattended" is measured in hours, not seconds.
+
+---
+
+## 4. The two families side by side
+
+| | Folder synced by another app | WebDAV against rented storage |
+|---|---|---|
+| Server of ours | none | none |
+| Android: can our app use ordinary file I/O? | only in `getExternalMediaDirs()` (deprecated at API 30); otherwise SAF `content://` URIs | n/a — it is HTTP |
+| Android: is the peer software installable from the store? | no for the peer-to-peer synchroniser (Play listing 404, upstream archived 2024-12-03); the drive clients do not sync folders at all | n/a |
+| "Am I behind?" | **unanswerable** — only the local replica is visible | 1 request, 371 B (collection `getetag`) where the server exposes one; otherwise a full listing at 28–788 B/entry |
+| Append to remote | n/a — local append, then it propagates | **impossible portably**; `Content-Range` PUT may silently truncate |
+| Read only new bytes | n/a | yes — `Range` → 206 on all three servers tested |
+| Conditional write | n/a | mandated by RFC 9110 §13.1.1; **silently ignored by 2 of 3 servers tested** |
+| Write→visible latency | ~10 s watcher + transfer, **but both devices must be awake together**; 1 h if the watcher is off | our polling interval; ≥15 min on Android, immediate on desktop |
+| Partial-file exposure | none — temp file then atomic rename | none for whole-file PUT [inference] |
+| Deletion | propagates by default (versioning defaults to off) | ours alone to issue |
+| Cost to the user | free software, ≈6 setup actions per Android device | EUR 0.50–4.29/month, one account, one app password per device |
+| Devices must overlap in time | **yes** | no |
+
+---
+
+## 5. What I tested, and how to reproduce it
+
+Environment: Linux 7.1.5 x86_64, cargo/rustc 1.97.0, `rclone` v1.74.4, `dufs` 0.46.0, Nextcloud 34.0.2 in Docker (`nextcloud:latest`, SQLite), NDK 29.0.13846066, `zstd` from PATH. All servers were local; no third-party account was touched.
+
+**5.1 PROPFIND shape.** `rclone serve webdav /tmp/davroot --etag-hash MD5`; `PROPFIND Depth: 1` with named props returned `207` and, per file, `<D:getcontentlength>18</D:getcontentlength>`, `<D:getlastmodified>`, `<D:getetag>"1946340162867fa47344419ace58597b"</D:getetag>`. For the **collection itself**, `getcontentlength` and `getetag` came back inside a `HTTP/1.1 404 Not Found` propstat — no collection ETag.
+
+**5.2 Conditional PUT, lightweight Go server.** Against a file created via PUT whose real tag was `"e06d0d302a7ccf3af6bc8199ee2c1d3c"`:
+```
+PUT If-Match: "0000000000000000"  -> 201   file content became "CLOBBER"
+PUT If-None-Match: *  (existing)  -> 201   file content became "CLOBBER"
+```
+
+**5.3 Conditional PUT, Nextcloud 34.0.2** (`/remote.php/dav/files/admin/`, Basic auth):
+```
+PUT If-Match: "0000"              -> 412   content unchanged ("row1")
+PUT If-None-Match: * (existing)   -> 412   content unchanged
+PUT If-Match: <correct etag>      -> 204   content updated
+OPTIONS -> DAV: 1, 3, extended-mkcol, access-control, …, 2
+```
+
+**5.4 Partial write, all three servers.** `dufs` — `PUT Content-Range: bytes 8-12/13` → **201**, file replaced by the 5-byte fragment; `PATCH` with `X-Update-Range: append` → **204**, bytes appended. `rclone serve webdav` — `PUT Content-Range: bytes 18-35/36` → **201**, 18-byte file containing only the appended row; `PATCH … append` → **400**. Nextcloud — `PUT Content-Range` → **400**, content preserved; `PATCH … append` → **500 Internal Server Error**. `Range: bytes=5-` GET → **206** with `Content-Range: bytes 5-14/15` on all three.
+
+**5.5 Weak-ETag hazard, not reproduced here.** `GET` and `HEAD` with and without `Accept-Encoding: gzip` against bare Nextcloud+Apache all returned the same strong tag `"89b93fd1784f2c3d577a36f25579ad02"` — no `W/` prefix, no `Content-Encoding`. The failure reported in [koreader#15707](https://github.com/koreader/koreader/issues/15707) requires a compressing layer in front; my instance had none.
+
+**5.6 Peer-to-peer synchroniser fork, distribution and permissions.** `curl` of `play.google.com/store/apps/details?id=com.github.catfriend1.syncthingfork` → **HTTP 404**. Its `app/src/main/AndroidManifest.xml` declares `WRITE_EXTERNAL_STORAGE`, `RECEIVE_BOOT_COMPLETED`, `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`, `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_SPECIAL_USE`, `MANAGE_EXTERNAL_STORAGE`, and a service with `android:foregroundServiceType="specialUse"`.
+
+**5.7 SAF listing cost, from AOSP source.** `TreeDocumentFile.listFiles()` issues one `resolver.query(childrenUri, new String[] { COLUMN_DOCUMENT_ID }, …)`; `getName()`, `lastModified()` and `length()` each route to `queryForString`/`queryForLong`, which issue `resolver.query(self, new String[]{column}, …)` — one query per field per file.
+
+**5.8 Segment compression.** `python3` generator producing 73,000 rows in ADR-0004 §11's shape, piped to `zstd -19`; results in §3.4. Raw 11,049,129 B = 151.4 B/row.
+
+**5.9 Handshake cost.** 100 files created over WebDAV on Nextcloud, 1,000 on the Go server; `curl -w '%{size_download}'` on each PROPFIND form; numbers in §3.5. Collection `getetag` changed from `"6a6b53270b404"` → `"6a6b5333a17ee"` on adding a file and → `"6a6b5333e96fd"` on modifying an existing one. `REPORT` with a `sync-collection` body → `415`, `Sabre\DAV\Exception\ReportNotSupported`.
+
+**5.10 Android cross-compile.** `cargo ndk -t arm64-v8a --manifest-path /tmp/davcheck/Cargo.toml check` with `ANDROID_NDK_HOME=…/ndk/29.0.13846066` → `Finished dev profile … in 7.34s`, having checked `reqwest_dav v0.3.3`, `reqwest v0.13.4`, `rustls v0.23.43`, `rustls-platform-verifier v0.7.0`, `aws-lc-rs v1.17.3`, `jni v0.22.4`. Without the NDK: `error occurred in cc-rs: failed to find tool "aarch64-linux-android-clang"`.
+
+---
+
+## Confidence
+
+**High** — Android's storage visibility rules and the `Android/data` / `Android/media` split (first-party reference documentation, corroborated by two independent applications' source); the peer-to-peer Android client's discontinuation and the fork's distribution channel (archived repo, maintainer's own announcement, HTTP 404 from the store); the commercial drive clients not syncing folders on Android (explicit first-party statements, strongest from Microsoft); RFC text on PROPFIND, PUT, `If-Match`/`If-None-Match`, partial PUT, and the `If` header; the Android background-execution limits and their numbers; the measured PROPFIND sizes, compression ratios and cross-compile result — all reproduced locally with commands recorded above.
+
+**Medium** — that conditional writes are broadly unreliable across hosted providers. I tested three server implementations and two ignored preconditions, but those two are lightweight file servers, not what a paid host runs; the one production-grade server behaved correctly. The right reading is "not safe to assume", not "usually broken". Also medium: the prices in §3.6, which I did not verify against a checkout flow and which carry no first-party VAT statement in the storage-box case; and the claim that a SAF tree can be granted over `Android/media/<pkg>` — the exclusion list names only `Android/data` and `Android/obb`, but I could not test on a device and OEM behaviour varies.
+
+**Low / untested** — the weak-ETag-under-compression failure (§3.2, §5.5): reported and reproduced by a third party, not by me. SAF throughput for real file I/O through a content URI on a real handset: I read the API surface and the AOSP listing code but ran nothing on the Pixel; per AGENTS.md rule 9, this needs the real handset before anything is designed on it. What software serves the storage-box WebDAV endpoint, and therefore its ETag semantics: no first-party statement exists.
+
+---
+
+## Sources
+
+**Android platform (first-party documentation and AOSP source)**
+
+- [Data and file storage overview](https://developer.android.com/training/data-storage) — storage categories, scoped storage at API 29, cross-app visibility table
+- [App-specific storage](https://developer.android.com/training/data-storage/app-specific) — "Other apps cannot access files stored within internal storage"; uninstall behaviour
+- [Access documents and other files (SAF)](https://developer.android.com/training/data-storage/shared/documents-files) — `ACTION_OPEN_DOCUMENT_TREE`, `takePersistableUriPermission`, excluded directories, the large-directory performance caution
+- [Manage all files on a storage device](https://developer.android.com/training/data-storage/manage-all-files) — what `MANAGE_EXTERNAL_STORAGE` grants and denies; the May 2021 Play policy
+- [Google Play — Permissions and APIs that Access Sensitive Information](https://support.google.com/googleplay/android-developer/answer/10467955) — all-files-access eligibility and removal from the store
+- [Storage updates in Android 11](https://developer.android.com/about/versions/11/privacy/storage) — direct file paths for media; `Android/data` and `Android/obb` exclusion
+- [Access media files from shared storage](https://developer.android.com/training/data-storage/shared/media) — direct file paths only for own/attributed files; "random reads and writes… up to twice as slow"
+- [`Context.getExternalMediaDirs()`](https://developer.android.com/reference/android/content/Context#getExternalMediaDirs()) — "no security enforced"; deprecated at API 30
+- [`TreeDocumentFile.java`](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/documentfile/documentfile/src/main/java/androidx/documentfile/provider/TreeDocumentFile.java) · [`DocumentsContractApi19.java`](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/documentfile/documentfile/src/main/java/androidx/documentfile/provider/DocumentsContractApi19.java) — one query per field per file
+- [Doze and App Standby](https://developer.android.com/training/monitoring-device-state/doze-standby) — network suspension, maintenance windows, the Play prohibition on requesting exemption
+- [Define your work requests (WorkManager)](https://developer.android.com/develop/background-work/background-tasks/persistent/getting-started/define-work) — 15-minute floor; no timing guarantee
+- [Foreground service types](https://developer.android.com/develop/background-work/services/fgs/service-types) — `dataSync`, `specialUse` and its Play Console review
+- [Behavior changes: Android 15](https://developer.android.com/about/versions/15/behavior-changes-15) — 6-hour `dataSync` cap, `onTimeout`, no FGS from `BOOT_COMPLETED`
+- [Alternatives to data transfer foreground services](https://developer.android.com/develop/background-work/background-tasks/data-transfer-options)
+
+**Peer-to-peer file synchronisation (first-party)**
+
+- [syncthing/syncthing-android](https://github.com/syncthing/syncthing-android) — archived 2024-12-03, discontinuation notice
+- [Discontinuing syncthing-android](https://forum.syncthing.net/t/discontinuing-syncthing-android/23002) — maintainer's stated reasons, 2024-10-20
+- [Catfriend1/syncthing-android](https://github.com/Catfriend1/syncthing-android) — fork, distribution channels, `AndroidManifest.xml`
+- [Understanding Synchronization](https://docs.syncthing.net/users/syncing.html) — watcher vs hourly scan, temp-file-then-rename, conflict naming and tie-break
+- [FAQ](https://docs.syncthing.net/users/faq.html) — "online at the same time"; Android symlink limitation
+- [Configuration](https://docs.syncthing.net/users/config.html) — `fsWatcherDelayS: 10`, `rescanIntervalS: 3600`, `caseSensitiveFS: false`
+- [File Versioning](https://docs.syncthing.net/users/versioning.html) — defaults to none
+- [Relaying](https://docs.syncthing.net/users/relaying.html) — relayed transfer rate
+
+**Server-backed sync clients (first-party source and help centres)**
+
+- [nextcloud/android `AndroidManifest.xml`](https://github.com/nextcloud/android/blob/master/app/src/main/AndroidManifest.xml) · [`DocumentsStorageProvider.java`](https://github.com/nextcloud/android/blob/master/app/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java) · [`FileStorageUtils.java`](https://github.com/nextcloud/android/blob/master/app/src/main/java/com/owncloud/android/utils/FileStorageUtils.java) · [`DataStorageProvider.java`](https://github.com/nextcloud/android/blob/master/app/src/main/java/com/owncloud/android/datastorage/DataStorageProvider.java) · [`OfflineSyncWork.kt`](https://github.com/nextcloud/android/blob/master/app/src/main/java/com/nextcloud/client/jobs/OfflineSyncWork.kt) · [`SynchronizeFileOperation.kt`](https://github.com/nextcloud/android/blob/master/app/src/main/java/com/owncloud/android/operations/SynchronizeFileOperation.kt) · [`BackgroundJobManagerImpl.kt`](https://github.com/nextcloud/android/blob/master/app/src/main/java/com/nextcloud/client/jobs/BackgroundJobManagerImpl.kt)
+- [Dropbox — Access files offline](https://help.dropbox.com/sync/access-files-offline) · [Sync overview](https://help.dropbox.com/sync/sync-overview) · [Export files](https://help.dropbox.com/installs/export-files-mobile)
+- [Google — Drive for desktop system requirements](https://support.google.com/drive/answer/2375082) · [Use Drive offline](https://support.google.com/drive/answer/2375012?co=GENIE.Platform%3DAndroid)
+- [Microsoft — Use OneDrive on Android](https://support.microsoft.com/en-US/onedrive/use-onedrive-on-android) · [Automatically save photos and videos](https://support.microsoft.com/en-us/office/automatically-save-photos-and-videos-with-onedrive-for-android-66605e54-48b8-4f55-bcff-34159702e344)
+- [rclone downloads.md](https://github.com/rclone/rclone/blob/master/docs/content/downloads.md) · [bisync](https://rclone.org/bisync/) · [README](https://github.com/rclone/rclone/blob/master/README.md)
+
+**Standards**
+
+- [RFC 4918 — HTTP Extensions for WebDAV](https://www.rfc-editor.org/rfc/rfc4918.html) — §8.6 ETag, §9.1 PROPFIND, §9.7 PUT, §10.4 the `If` header, §15.4/15.6/15.7 live properties
+- [RFC 9110 — HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110.html) — §8.8 validators, §9.3.4 PUT, §13.1.1/13.1.2 preconditions, §14.5 Partial PUT
+- [RFC 5789 — PATCH Method for HTTP](https://www.rfc-editor.org/rfc/rfc5789.html) · [sabre/dav HTTP PATCH support](https://sabre.io/dav/http-patch/) — the `X-Update-Range: append` extension
+- RFC 6578 (`sync-collection` REPORT) — tested absent on the files endpoint, §5.9
+
+**Hosted storage (first-party pricing and docs, observed 2026-07-30)**
+
+- [Hetzner Storage Box](https://www.hetzner.com/storage/storage-box/) · [Storage Box docs](https://docs.hetzner.com/storage/storage-box/) · [Storage Share](https://www.hetzner.com/storage/storage-share/)
+- [Koofr pricing](https://koofr.eu/pricing/) · [Koofr WebDAV help](https://koofr.eu/help/koofr_with_webdav/which-password-to-use-when-connecting-via-webdav/)
+- [The Good Cloud](https://thegood.cloud/consumers/) · [Nextcloud providers list](https://nextcloud.com/providers/)
+- [Infomaniak kDrive pricing](https://www.infomaniak.com/en/ksuite/kdrive/prices) · [kDrive WebDAV FAQ](https://www.infomaniak.com/en/support/faq/2409/connect-to-kdrive-via-webdav)
+- [Nextcloud — Accessing files via WebDAV](https://docs.nextcloud.com/server/latest/user_manual/en/files/access_webdav.html) · [Session management](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html) · [WebDAV developer manual](https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/basic.html)
+- [pCloud WebDAV](https://help.pcloud.com/article/webdav) · [Fastmail WebDAV](https://www.fastmail.com/help/files/davnftp.html) · [Box WebDAV end of life](https://support.box.com/hc/en-us/articles/360043696414)
+
+**Rust ecosystem**
+
+- crates.io API (`/api/v1/crates/{name}`), queried 2026-07-30, for `reqwest_dav`, `rustydav`, `webdavc`, `hyperdav`, `dav-server`, `opendal`, `jni`, `ndk-context`, `android-activity`
+- [`reqwest_dav`](https://github.com/niuhuan/reqwest_dav) — source read at 0.3.3 (`src/lib.rs`)
+- [`rustls-platform-verifier`](https://docs.rs/rustls-platform-verifier/latest/rustls_platform_verifier/) — Android `init_hosted()` requirement
+- [rust-mobile/ndk#266](https://github.com/rust-mobile/ndk/issues/266) — needing an `Activity` subclass for `onActivityResult`, which the SAF picker requires
+
+**Third-party reports (not primary; flagged in place)**
+
+- [koreader#15707](https://github.com/koreader/koreader/issues/15707) — weak ETag under gzip producing an infinite 412 loop against WebDAV


### PR DESCRIPTION
Findings for [Research: sync transport over storage we do not own](https://github.com/amin-bf/leitner/issues/33), a `wayfinder:research` ticket under [Map: local-first Leitner app spec](https://github.com/amin-bf/leitner/issues/1).

**This is evidence, not a decision.** Four transport families remain live; one is structurally disqualified. Choosing between them is a later ticket's job.

## What landed

- [`docs/research/sync-transport/README.md`](https://github.com/amin-bf/leitner/blob/research/sync-transport/docs/research/sync-transport/README.md) — the synthesis: what the three slices say together that none says alone.
- Three slice notes, each with its own sources, measurement commands and confidence levels: a git remote; a folder another application syncs, plus WebDAV; a rented object store, plus personal cloud drives.

## The findings that most constrain the decision

- **Conditional writes are not needed** under a per-writer keyspace — and declining to need them is worth more than having them, because two of three WebDAV servers tested silently ignored the precondition in the data-losing direction. Holds provided ADR-0004 §7's mutable surface is also published per writer.
- **Segment granularity is a dial penalised at both ends.** Whole-log republish costs 1,800 MiB/device/month of uplink against 0.2 MiB for segments; but fine-grained segments collapse compression from 12.01× to 5.02×, break listing-as-handshake at the 1,000-key page cap, and — on a content-addressed store — one growing file per writer gives 911.8× write amplification. Monthly buckets measured 15.7× and a decade of history smaller than the text it stores.
- **A folder another application syncs cannot answer "am I behind?" even in principle** — no remote to interrogate, so ADR-0004 §2's handshake has no counterparty. Compounded on Android, where the only mutually-readable directory was deprecated at API 30 and anything else needs a Storage Access Framework tree, which needs the same `Activity` seam `AGENTS.md` rule 8 already records as missing.
- **Android caps unattended sync identically for every candidate**, so it constrains what the app can promise rather than which store it should use.
- **Per-writer *files* do not prevent push conflicts on a git remote** — the compare-and-swap is on the ref. Per-writer *branches* do. "One writer, one namespace" is the invariant the design rests on whichever store wins.

## Knock-ons for ADR-0004

Its row size and decade projection are confirmed to within 1%. Its "compresses about ten to one" is **conditional on the compressor window and the segment size** — 11.76× with a large-window compressor, 3.99× with a 32 KiB window, 5.02× under daily segmentation — neither of which §11 fixes.

## Not verified

Nothing was run on the Pixel 8 Pro (`AGENTS.md` rule 9). Decade-scale repository figures are extrapolated from three measured points and labelled as such; all workload numbers come from synthetic logs generated to ADR-0004 §11's shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)