### PR TITLE
Workspace / Crate and Workspace Layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,30 @@ argue the trade-off on its own merits.
 
 This applies to every agent working in this repo, on every artifact that persists.
 
+## Landing work
+
+Tickets here are worked in **parallel worktree sessions**, each branching from `origin/main` and
+never seeing what merged afterwards. Two things break silently because of it.
+
+### Rules that are easy to break silently
+
+1. **If commit signing fails, stop and ask. Never fall back to `--no-gpg-sign`.** Every commit on
+   `main` is signed, and this repo merges with merge commits rather than squashing, so unsigned work
+   lands on `main` as-is and someone has to clean it up. The passphrase comes from a GUI prompt, so
+   an unattended session gets `gpg: signing failed: Timeout` and **no commit object is written** —
+   the work is not lost, it simply has not been committed yet. Land everything that needs no commit
+   first (tracker updates, verification runs) so the pause blocks only the commit, then wait.
+   To repair history that already went unsigned:
+   `git rebase --exec 'git commit --amend --no-edit -S' origin/main` then
+   `git push --force-with-lease`.
+2. **Re-check the highest ADR number immediately before committing**, not when you start writing.
+   `git fetch origin && git ls-tree --name-only origin/main docs/adr/` — a parallel session may have
+   taken your number, and the worktree's own `docs/adr/` is a stale answer that looks authoritative.
+   When renumbering, **sed only your own files**: `AGENTS.md` and older ADRs may already reference
+   the *other* ADR at that number, and a blind replace corrupts those links. Re-read whatever landed
+   meanwhile, too — an ADR that merged mid-session may place requirements on the ticket you are
+   resolving.
+
 ## Start with the context map
 
 **[`CONTEXT-MAP.md`](./CONTEXT-MAP.md) is the entry point to the codebase** — the five crates, the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,43 @@ argue the trade-off on its own merits.
 
 This applies to every agent working in this repo, on every artifact that persists.
 
+## Start with the context map
+
+**[`CONTEXT-MAP.md`](./CONTEXT-MAP.md) is the entry point to the codebase** — the five crates, the
+seven contexts, and an index saying which ADR sections bind which context. `docs/adr/` is over 2,600
+lines; the index is what stops "read the ADRs" from meaning all of them.
+
+Read this file first, then the context map, then the `CONTEXT.md` for the area you are touching.
+`docs/research/` is the evidence trail for reopening a decision, not reading for implementing one.
+
+## The workspace
+
+Five crates, laid out in [ADR-0009](./docs/adr/0009-crate-and-workspace-layout.md):
+`leitner-core` (the domain, pure), `leitner-store` (SQLite and the platform seam), `leitner-export`
+(the `.ldeck` container), `leitner-app` (egui, lib + cdylib), `leitner-desktop` (a shim, forced by
+`cargo-apk`).
+
+Contexts are **modules, not crates**. Vocabulary lives in a `CONTEXT.md` beside the code; decisions
+live system-wide in `docs/adr/`, and context-scoped `docs/adr/` directories are not used here.
+
+### Rules that are easy to break silently
+
+1. **`leitner-core` has no dependencies, and adding one is an ADR-sized decision.** Its empty
+   `[dependencies]` is what makes `cargo test -p leitner-core` need no database, no window and no
+   handset. `rusqlite` belongs in `leitner-store`; `egui` and `eframe` belong in `leitner-app`.
+2. **Time and identity are values, never injected traits.** Replay needs no clock at all — day
+   numbers are frozen on the row at write time, and fuzz is seeded from card identity. The two call
+   sites that need "now" take it as a parameter. A `SystemTime::now()` inside `leitner-core` breaks
+   the property that two devices replaying one log agree.
+3. **There is no fake store.** Store tests open a real SQLite database in a temp directory, because
+   the design *is* WAL, `BEGIN IMMEDIATE`, `ATTACH` and `INSERT OR IGNORE`.
+4. **A new ADR must be added to `CONTEXT-MAP.md`'s index.** One that is not there is invisible to
+   the agent it was written for.
+
 ## The client stack
 
-**egui / eframe**, chosen in [ADR-0003](./docs/adr/0003-client-stack.md). One crate, one binary per
-platform, no webview, no IPC. Setup and commands are in [`README.md`](./README.md).
+**egui / eframe**, chosen in [ADR-0003](./docs/adr/0003-client-stack.md). One binary per platform,
+no webview, no IPC. Setup and commands are in [`README.md`](./README.md).
 
 **The targets are desktop and Android.** The web target was ruled out of scope in
 [ADR-0007 §1](./docs/adr/0007-the-local-store.md) — a browser cannot be the system of record for an
@@ -37,12 +70,17 @@ because they are validated findings, not because a web build ships.
    otherwise bypasses the helper. Note that caret and selection are then in visual order while the
    buffer is logical, so RTL editing is imprecise; design around it rather than fighting it.
 3. **The storage seam is a compile-time `#[cfg]`.** Keep it that way. Never introduce a runtime
-   platform check — the whole stack choice rests on wrong platform code failing the build.
+   platform check — the whole stack choice rests on wrong platform code failing the build. It is two
+   functions in `leitner-store::platform`, and a **third function appearing there means the seam is
+   eroding**. A `#[cfg(target_os)]` anywhere else in the workspace is a defect.
 4. **Immediate mode has nowhere to `await`.** Spawn the future, store a handle, read the result on a
    later frame, and call `ctx.request_repaint()` on completion or the result sits unseen until the
    next input event.
-5. **The desktop binary must live in its own crate.** `cargo-apk` panics after signing when one crate
-   has both a cdylib and a bin. The APK is fine; the exit code is not, and CI will break.
+5. **The desktop binary lives in its own crate, and that crate stays empty.** `cargo-apk` panics
+   after signing when one crate has both a cdylib and a bin — the APK is fine, the exit code is not,
+   and CI breaks. So never add a `[[bin]]` to `leitner-app`, and never put logic in
+   `leitner-desktop`: code there is never compiled for Android and never runs on the handset.
+   It takes `eframe` by re-export from `leitner-app`, not as its own dependency.
 6. **`eframe`'s dependency is split per target** — its default `accesskit` feature is rejected
    alongside `android-native-activity`.
 7. **Fonts are ours to ship — and must be installed on the first frame, not in `CreationContext`.**

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,129 @@
+# Context Map
+
+Start here. This file says what the codebase is made of, which vocabulary applies where, and — most
+importantly — **which parts of `docs/adr/` bind the code you are about to touch**, so you do not
+have to read 2,600 lines to find the 300 that matter.
+
+Laid out by [ADR-0009](./docs/adr/0009-crate-and-workspace-layout.md).
+
+## Read in this order
+
+Ordered by what breaks silently if you skip it.
+
+1. **[`AGENTS.md`](./AGENTS.md)** — the rules that fail *without an error message*. About forty
+   lines, and every one of them is a bug that neither the compiler nor the tests will catch. Read it
+   even if you are making a one-line change.
+2. **This file** — the crates, the contexts, and the ADR index below.
+3. **The `CONTEXT.md` for the area you are touching** — vocabulary, so your code and your commit
+   message use the words the ADRs use.
+4. **Only the ADR sections the index says bind your context.**
+
+**`docs/research/` is not in this list.** It is the evidence trail for *reopening* a decision, not
+reading for implementing one — its findings are already distilled into the ADRs that cite it. Start
+there and you will spend your budget before writing a line.
+
+## Crates
+
+Five crates. Two of the boundaries are forced by the toolchain; see ADR-0009 §1.
+
+| Crate | Path | What it is |
+|---|---|---|
+| `leitner-core` | [`crates/core/`](./crates/core) | The domain, entire and pure. **Zero dependencies**, permanently. |
+| `leitner-store` | [`crates/store/`](./crates/store) | SQLite persistence and the whole platform seam. |
+| `leitner-export` | [`crates/export/`](./crates/export) | The `.ldeck` container and the import policy. Holds the zip dependency. |
+| `leitner-app` | [`crates/app/`](./crates/app) | The egui application, the bidi helper, the Android entry point. |
+| `leitner-desktop` | [`crates/desktop/`](./crates/desktop) | A twenty-line shim. Forced by `cargo-apk`; keep it empty. |
+
+Two rules about this table that are easy to break:
+
+- **Nothing is added to `leitner-core`'s `[dependencies]` casually.** Its emptiness is what makes
+  `cargo test -p leitner-core` need no database, no window and no handset. Adding to it is an ADR-
+  sized decision.
+- **`leitner-app` has no `src/main.rs`, and `leitner-desktop` has no logic.** `cargo-apk` panics
+  after signing when one crate has both a cdylib and a bin, so the split is load-bearing, and code
+  put in `desktop` is never compiled for Android and never runs on the handset.
+
+## Contexts
+
+| Context | `CONTEXT.md` | What it owns |
+|---|---|---|
+| Content | [`crates/core/src/content/`](./crates/core/src/content/CONTEXT.md) | Notes, cards, kinds, fields, decks, tags |
+| Log | [`crates/core/src/log/`](./crates/core/src/log/CONTEXT.md) | Rows, writer ids, sequences, day scale, stamps, interchange |
+| Scheduling | [`crates/core/src/scheduling/`](./crates/core/src/scheduling/CONTEXT.md) | FSRS arithmetic, grades, memory state, boxes |
+| Replay | [`crates/core/src/replay/`](./crates/core/src/replay/CONTEXT.md) | The join: what exists, what state it is in, what is due |
+| Store | [`crates/store/src/`](./crates/store/src/CONTEXT.md) | The two databases, device identity, the platform seam |
+| Export | [`crates/export/src/`](./crates/export/src/CONTEXT.md) | Deck files, profiles, revisions, import policy |
+| UI | [`crates/app/src/`](./crates/app/src/CONTEXT.md) | Screens, the session, the bidi helper |
+
+### How they relate
+
+```
+content ──┬──> log ───────┬──> replay ──> store, ui
+          │               │
+          │               └──> export ──> ui
+          └──> scheduling ┘
+```
+
+- **`content` is the base.** A log row carries a `CardRef`, and scheduler fuzz is seeded from
+  `CardRef`'s 18-byte encoding — so content depends on nothing, and everything else may depend on it.
+- **`scheduling` does not depend on `log`.** It takes grades and day numbers as values, which is what
+  lets FSRS arithmetic be tested against a hand-written list with no rows and no merge.
+- **`replay` is the join, and the deep module of the system.** Behind a small interface — what is
+  due, what box is this card in, record this grade — sit the log, the content, the scheduler and the
+  cache.
+- **`export` is a crate, not a module, for the same reason `replay` is a context**: it spans content
+  and (once #37 specifies the progress profile) the log, so it belongs inside neither — and it holds
+  the zip dependency that `leitner-core` cannot.
+- **A `sync` context is anticipated, not created.** It will need a network dependency, which cannot
+  live in `leitner-core`, so expect a *sixth crate* rather than a fifth module.
+
+## Which ADRs bind which context
+
+Read the ADR sections in your row. Read the whole ADR only if you are changing the decision.
+
+| Context | Binding ADRs | Also bound by |
+|---|---|---|
+| `content` | [0002](./docs/adr/0002-the-card-model.md), [0005](./docs/adr/0005-the-deck-model.md) | — |
+| `log` | [0004](./docs/adr/0004-the-review-event-log.md) | 0002 §7, 0001 §6 |
+| `scheduling` | [0001](./docs/adr/0001-scheduling-algorithm-and-grade-scale.md) | 0004 §4, 0004 §5 |
+| `replay` | *none of its own* | 0001 §7, 0002 §7, 0004 §9, 0007 §2 |
+| `store` | [0007](./docs/adr/0007-the-local-store.md) | 0004 §11, 0003 §5 |
+| `export` | [0008](./docs/adr/0008-the-deck-export-format.md) | 0005, 0002 §9, 0004 §11 |
+| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md) | 0002 §4 |
+| *the workspace itself* | [0009](./docs/adr/0009-crate-and-workspace-layout.md) | — |
+
+**`replay` having no ADR of its own is why it is a context.** Its rules were each written for another
+purpose and sit scattered across four documents; its `CONTEXT.md` is the only place they appear as
+one mechanism. If you are touching replay, read that file before the ADRs.
+
+**If you write a new ADR, add it to this table.** An ADR that is not in this index is invisible to
+the agent it was written for.
+
+## Testing
+
+- **`cargo test -p leitner-core`** needs no database, no window and no handset. Most of the
+  specification is verifiable here, and that is deliberate.
+- **Time and identity are values, never injected traits.** Replay needs no clock at all — day
+  numbers are frozen on the row at write time and fuzz is seeded from card identity. The two places
+  that need "now" take it as a parameter.
+- **There is no fake store.** Store tests open a real SQLite database in a temp directory, because
+  the design *is* WAL, `BEGIN IMMEDIATE`, `ATTACH` and `INSERT OR IGNORE`.
+- **Store tests run on desktop.** On Android the store depends on the activity existing, so
+  `leitner-store` is not independently runnable there.
+- **The highest-value test in the repository** is that any interleaving of two devices' rows replays
+  to the same state. It needs no sync implementation and no second device.
+
+## Building
+
+See [`README.md`](./README.md) for prerequisites. In short:
+
+```sh
+cargo run -p leitner-desktop            # desktop
+cargo test --workspace                  # everything testable without hardware
+
+source scripts/android-env.sh           # required before ANY Android command
+cd crates/app && cargo apk build        # APK: a manifest and one .so
+```
+
+Verify UI judgements on the **real handset** — the emulator is x86_64 and the Pixel 8 Pro is
+arm64-v8a only.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,4522 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
+name = "accesskit"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
+name = "accesskit_atspi_common"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8c61bee90b42a772d39d06a740207dc71a4e780004ace1db8d99fb1baaa954"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer 0.36.0",
+ "atspi-common",
+ "phf",
+ "serde",
+ "zvariant",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e0d7e25d06f4dc21d1774d67146e9e80d6789216cbd4d1e88185b0095dba60"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d10a236f96f87d70732e44520046785431ef01d5bcd6b041317bfadd2f88245"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce02dc63b43f0c9296af9ac946312a2dc8814427d7a64d2d600971dac55b6076"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer 0.38.0",
+ "hashbrown 0.16.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "accesskit_unix"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b016ca8db0ea0ea2ceff29a9d6240391492d960716aa471967c00e8cc8cb197c"
+dependencies = [
+ "accesskit",
+ "accesskit_atspi_common",
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "atspi",
+ "futures-lite",
+ "futures-util",
+ "serde",
+ "zbus",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff7009f1a532e917d66970a1e80c965140c6cfbbabbdde3d64e5431e6c78e21"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer 0.35.0",
+ "hashbrown 0.16.1",
+ "static_assertions",
+ "windows",
+ "windows-core",
+]
+
+[[package]]
+name = "accesskit_winit"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe9a94394896352cc4660ca2288bd4ef883d83238853c038b44070c8f134313"
+dependencies = [
+ "accesskit",
+ "accesskit_macos",
+ "accesskit_unix",
+ "accesskit_windows",
+ "raw-window-handle",
+ "winit",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android-activity"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
+dependencies = [
+ "android-properties",
+ "bitflags 2.13.1",
+ "cc",
+ "jni 0.22.4",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-context",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atspi"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+]
+
+[[package]]
+name = "atspi-common"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus",
+ "zbus-lockstep",
+ "zbus-lockstep-macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.13.1",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
+dependencies = [
+ "bitflags 2.13.1",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "tracing",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop 0.13.0",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
+dependencies = [
+ "calloop 0.14.4",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "cgl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "color"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dpi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "ecolor"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6758be723a3f298bbfda4db75748bc2ba0abafe096b6383c7c32da264764fbc3"
+dependencies = [
+ "bytemuck",
+ "emath",
+]
+
+[[package]]
+name = "eframe"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc8234e2f681b2afd2b2e8c332fa614de2fddbdcb28d0acf5c420449682ea90"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "egui",
+ "egui-wgpu",
+ "egui-winit",
+ "egui_glow",
+ "glutin",
+ "glutin-winit",
+ "image",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "pollster",
+ "profiling",
+ "raw-window-handle",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "web-time",
+ "wgpu",
+ "windows-sys 0.61.2",
+ "winit",
+]
+
+[[package]]
+name = "egui"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796c98d50b79631281d516343a6f6e93c0666462ca36e2c93b39f25d7793325"
+dependencies = [
+ "accesskit",
+ "ahash",
+ "bitflags 2.13.1",
+ "emath",
+ "epaint",
+ "itertools",
+ "log",
+ "nohash-hasher",
+ "profiling",
+ "smallvec",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "egui-wgpu"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e6cfac0725563555fa4f91e9f799b9d7c6c5dd831fca6abc8234afc64b7a34"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "egui",
+ "epaint",
+ "log",
+ "profiling",
+ "thiserror 2.0.19",
+ "type-map",
+ "web-time",
+ "wgpu",
+ "winit",
+]
+
+[[package]]
+name = "egui-winit"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea6bf3608db949588b95b8b341ee358d0c3f95cf4dc3f53d8d76717edee87db"
+dependencies = [
+ "accesskit_winit",
+ "arboard",
+ "bytemuck",
+ "egui",
+ "log",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "profiling",
+ "raw-window-handle",
+ "smithay-clipboard",
+ "web-time",
+ "webbrowser",
+ "winit",
+]
+
+[[package]]
+name = "egui_glow"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52274b9bfb8d8e252cd0f00c9f6214f360d75a0962baa77a2d62ddb002fe99d4"
+dependencies = [
+ "bytemuck",
+ "egui",
+ "glow",
+ "log",
+ "memoffset",
+ "profiling",
+ "winit",
+]
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "emath"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd4ec073c9898516584d8c6cfdcee95b530b3d941cd5031ef4050aa36812308b"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "epaint"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e60a8888b51da911df23918fd7301359b1d43a406a0ff3b8863af093dd7fc6c"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "ecolor",
+ "emath",
+ "epaint_default_fonts",
+ "font-types",
+ "harfrust",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "profiling",
+ "self_cell",
+ "skrifa",
+ "smallvec",
+ "unicode-general-category",
+ "unicode-segmentation",
+ "vello_cpu",
+]
+
+[[package]]
+name = "epaint_default_fonts"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ee4e1f553a3584c301f3a56ff1a775f1384781396cea301c8d952e9b93f560"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "fearless_simd"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-util"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
+name = "glifo"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d99fc21d493812643aae86d53b7bbd02f376434a90317e8a790bc209fdd6605e"
+dependencies = [
+ "bytemuck",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
+ "log",
+ "peniko",
+ "skrifa",
+ "smallvec",
+ "vello_common",
+]
+
+[[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg_aliases",
+ "cgl",
+ "dispatch2",
+ "glutin_egl_sys",
+ "glutin_glx_sys",
+ "glutin_wgl_sys",
+ "libloading",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "once_cell",
+ "raw-window-handle",
+ "wayland-sys",
+ "windows-sys 0.52.0",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin-winit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
+dependencies = [
+ "cfg_aliases",
+ "glutin",
+ "raw-window-handle",
+ "winit",
+]
+
+[[package]]
+name = "glutin_egl_sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4680ba6195f424febdc3ba46e7a42a0e58743f2edb115297b86d7f8ecc02d2"
+dependencies = [
+ "gl_generator",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "glutin_glx_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7bb2938045a88b612499fbcba375a77198e01306f52272e692f8c1f3751185"
+dependencies = [
+ "gl_generator",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.19",
+ "windows",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.13.1",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "guillotiere"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b17e70c989c36bad147b27a58d148c0741c51448aa5653436547323e524d0ab"
+dependencies = [
+ "euclid",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
+name = "harfrust"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0431e8e389aa0f1e72bb9d1c2db8957a1a7a3580e8ed97db819c14837aac9b3e"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "read-fonts",
+ "smallvec",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.19",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
+]
+
+[[package]]
 name = "leitner-app"
 version = "0.1.0"
+dependencies = [
+ "android-activity",
+ "eframe",
+ "egui",
+ "leitner-core",
+ "leitner-export",
+ "leitner-store",
+ "unicode-bidi",
+ "winit",
+]
+
+[[package]]
+name = "leitner-core"
+version = "0.1.0"
+
+[[package]]
+name = "leitner-desktop"
+version = "0.1.0"
+dependencies = [
+ "leitner-app",
+]
+
+[[package]]
+name = "leitner-export"
+version = "0.1.0"
+dependencies = [
+ "leitner-core",
+]
+
+[[package]]
+name = "leitner-store"
+version = "0.1.0"
+dependencies = [
+ "jni 0.21.1",
+ "leitner-core",
+ "ndk-context",
+ "rusqlite",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "plain",
+ "redox_syscall 0.9.1",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "naga"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
+ "hexf-parse",
+ "indexmap",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "thiserror 2.0.19",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.13.1",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "raw-window-handle",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.1",
+ "dispatch2",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.13.1",
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-contacts",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "dispatch",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+ "objc2-link-presentation",
+ "objc2-quartz-core 0.2.2",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "orbclient"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
+dependencies = [
+ "libc",
+ "libredox",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "peniko"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo",
+ "linebender_resource_handle",
+ "smallvec",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+dependencies = [
+ "bitflags 2.13.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sctk-adwaita"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2",
+ "smithay-client-toolkit 0.19.2",
+ "tiny-skia",
+]
+
+[[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "skrifa"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.13.1",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
+dependencies = [
+ "bitflags 2.13.1",
+ "calloop 0.14.4",
+ "calloop-wayland-source 0.4.1",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 1.1.4",
+ "thiserror 2.0.19",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-experimental",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71704c03f739f7745053bde45fa203a46c58d25bc5c4efba1d9a60e9dba81226"
+dependencies = [
+ "libc",
+ "smithay-client-toolkit 0.20.0",
+ "wayland-backend",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl 2.0.19",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.3",
+]
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vello_common"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "guillotiere",
+ "hashbrown 0.17.1",
+ "log",
+ "peniko",
+ "smallvec",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588691169aed86b5c8fb487266afee01323234e6fd0a3f2aaec0eaa8e4007f23"
+dependencies = [
+ "bytemuck",
+ "glifo",
+ "hashbrown 0.17.1",
+ "vello_common",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.13.1",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.13.1",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix 1.1.4",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-experimental"
+version = "20250721.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef62a3d5f7b2411119a11b6f62570dbff91d7105e011a20fb83fbf8f5761c40f"
+dependencies = [
+ "jni 0.22.4",
+ "log",
+ "ndk-context",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "url",
+ "web-sys",
+]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wgpu"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.1",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.13.1",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.19",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1fb1798be2a912497d4c224f72d39bb0cb34af50e8bcc29865bc339c943059"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e592c1bbef6ad047647ae6e666ebd8cee7a32bb4544d9700ec96cbf73230257"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags 2.13.1",
+ "block2 0.6.2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "naga",
+ "ndk-sys",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "thiserror 2.0.19",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows",
+ "windows-core",
+ "windows-result",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "raw-window-handle",
+ "web-sys",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winit"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
+dependencies = [
+ "ahash",
+ "android-activity",
+ "atomic-waker",
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "bytemuck",
+ "calloop 0.13.0",
+ "cfg_aliases",
+ "concurrent-queue",
+ "core-foundation",
+ "core-graphics",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "libc",
+ "memmap2",
+ "ndk",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit 0.2.2",
+ "orbclient",
+ "percent-encoding",
+ "pin-project",
+ "raw-window-handle",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.44",
+ "sctk-adwaita",
+ "smithay-client-toolkit 0.19.2",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "as-raw-xcb-connection",
+ "gethostname",
+ "libc",
+ "libloading",
+ "once_cell",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.13.1",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
+dependencies = [
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep-macros"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zbus-lockstep",
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_xml"
+version = "5.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1586c021a01ca0a9216dcd874e546382e156a5cbab5fab6cb5f10087e22682a"
+dependencies = [
+ "serde",
+ "winnow",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.119",
+ "winnow",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,42 @@
-[package]
-name = "leitner-app"
+[workspace]
+resolver = "3"
+members = [
+  "crates/core",
+  "crates/store",
+  "crates/export",
+  "crates/app",
+  "crates/desktop",
+]
+
+[workspace.package]
 version = "0.1.0"
 edition = "2024"
+publish = false
+license = "MIT"
 
-[dependencies]
+# Dependency versions live here so the five crates cannot drift apart. The Android set is pinned to
+# the versions proven on the handset in #7 and #8 — see docs/environment/android-toolchain.md.
+[workspace.dependencies]
+leitner-core = { path = "crates/core" }
+leitner-store = { path = "crates/store" }
+leitner-export = { path = "crates/export" }
+leitner-app = { path = "crates/app" }
+
+egui = "0.35"
+rusqlite = { version = "0.40", features = ["bundled"] }
+
+# `eframe` is deliberately absent. Its two arms disagree on `default-features` (ADR-0003 §5), and a
+# workspace entry cannot be overridden that way — so both arms are declared literally in
+# `crates/app`, side by side in one file where they cannot drift apart. `crates/desktop` gets it by
+# re-export rather than by dependency, which is what keeps that crate a shim.
+unicode-bidi = "0.3.18"
+
+android-activity = "0.6"
+jni = "0.21"
+ndk-context = "0.1"
+winit = "0.30"
+
+[profile.release]
+opt-level = "z"
+lto = true
+strip = true

--- a/README.md
+++ b/README.md
@@ -1,33 +1,47 @@
 # leitner-app
 
-A local-first, offline-by-default spaced-repetition flashcard app in Rust, for **desktop, web and
+A local-first, offline-by-default spaced-repetition flashcard app in Rust, for **desktop and
 Android**, with no server of our own.
 
-Agent instructions live in [`AGENTS.md`](./AGENTS.md). Decisions live in [`docs/adr/`](./docs/adr).
+Agent instructions live in [`AGENTS.md`](./AGENTS.md). The codebase entry point is
+[`CONTEXT-MAP.md`](./CONTEXT-MAP.md). Decisions live in [`docs/adr/`](./docs/adr).
+
+## Layout
+
+A five-crate workspace, laid out in
+[ADR-0009](./docs/adr/0009-crate-and-workspace-layout.md):
+
+| Crate | What it is |
+|---|---|
+| `leitner-core` | The domain, entire and pure. Zero dependencies — testable with no database, window or handset. |
+| `leitner-store` | SQLite persistence and the whole platform seam (two functions wide). |
+| `leitner-export` | The `.ldeck` deck-file container and import policy. Holds the zip dependency. |
+| `leitner-app` | The egui application. `lib` + `cdylib`; the Android entry point lives here. |
+| `leitner-desktop` | A twenty-line shim, forced by `cargo-apk`. Keep it empty. |
 
 ## Stack
 
-**egui / eframe** — one crate, one binary per platform, no webview, no IPC. Chosen in
+**egui / eframe** — one binary per platform, no webview, no IPC. Chosen in
 [ADR-0003](./docs/adr/0003-client-stack.md) after building the same slice four ways and measuring
 them on real hardware.
+
+The web target was ruled out of scope in [ADR-0007 §1](./docs/adr/0007-the-local-store.md): for an
+app whose only copy of the data is local, the browser is the one platform where "local" is not
+reliably durable.
 
 ## Prerequisites
 
 ```sh
-rustup target add wasm32-unknown-unknown aarch64-linux-android
-
-cargo install trunk --locked      # web bundler
+rustup target add aarch64-linux-android
 cargo install cargo-apk --locked  # Android packaging
 ```
 
-**Linux desktop** needs no webkit — egui renders to a canvas:
-
-```sh
-# nothing beyond a working GPU/OpenGL stack
-```
+**Linux desktop** needs no webkit — egui renders to a canvas, so a working GPU/OpenGL stack is all
+it takes.
 
 **Android** — source the environment script before *any* Android command. It sets `JAVA_HOME`,
-`ANDROID_HOME` and `NDK_HOME` (see [`docs/environment/android-toolchain.md`](./docs/environment/android-toolchain.md)):
+`ANDROID_HOME` and `NDK_HOME` (see
+[`docs/environment/android-toolchain.md`](./docs/environment/android-toolchain.md)):
 
 ```sh
 source scripts/android-env.sh
@@ -38,25 +52,36 @@ Skipping it produces `Failed to get android tools`, which does not say what is m
 ## Running
 
 ```sh
-cargo run                                  # desktop
-trunk serve                                # web
-cargo apk build && adb install -r <apk>    # Android
-cargo apk build --release                  # Android release (~5.4 MB)
+cargo run -p leitner-desktop          # desktop
+cargo test --workspace                # everything verifiable without hardware
+cargo test -p leitner-core            # the domain alone: no database, no window, no handset
+
+source scripts/android-env.sh
+cd crates/app && cargo apk build      # APK: a manifest and one .so, no classes.dex
 ```
+
+`cargo apk build --release` compiles but stops at signing — no release keystore is configured, since
+the only one available is a local developer debug key and deployment is out of scope.
 
 Under Wayland, winit ignores `GDK_BACKEND`. For an X11 window (e.g. to drive it with `xdotool`):
 
 ```sh
-env -u WAYLAND_DISPLAY WINIT_UNIX_BACKEND=x11 cargo run
+env -u WAYLAND_DISPLAY WINIT_UNIX_BACKEND=x11 cargo run -p leitner-desktop
 ```
+
+Verify UI judgements on the **real handset** — the emulator is x86_64 and the Pixel 8 Pro is
+arm64-v8a only.
 
 ## Where data lives
 
-| Target | Location |
-|---|---|
-| Desktop | `$XDG_DATA_HOME/leitner/` |
-| Android | `/data/user/0/<pkg>/files/` (via JNI — see `AGENTS.md`) |
-| Web | OPFS, origin-scoped |
+Resolved by `leitner_store::platform`, which is the entire platform surface of the application.
 
-Web storage is a **best-effort** bucket — `navigator.storage.persisted()` is `false` by default and
-the browser may evict it. The web build is not the system of record.
+| Target | Collection (`collection.db`, `derived.db`) | Writer marker |
+|---|---|---|
+| Desktop | `$XDG_DATA_HOME/leitner/` | `$XDG_STATE_HOME/leitner/` |
+| Android | `getFilesDir()`, via JNI | `getNoBackupFilesDir()`, via JNI |
+
+The two are separate on purpose. Android's Auto Backup is on by default and restores the data
+directory onto a replacement phone — including the writer identity, which would make two devices the
+same writer and silently drop reviews. The marker sits outside the backup set so a restore becomes a
+clean fork instead. See [ADR-0007 §6](./docs/adr/0007-the-local-store.md).

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "leitner-app"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
+
+[dependencies]
+leitner-core.workspace = true
+leitner-store.workspace = true
+leitner-export.workspace = true
+egui.workspace = true
+unicode-bidi.workspace = true
+
+# ADR-0003 §5: eframe's default features include accesskit, which eframe refuses alongside
+# android-native-activity. So the dependency is split per target — this is not tidiness, the
+# unified form does not build for Android.
+[target.'cfg(not(target_os = "android"))'.dependencies]
+eframe = "0.35"
+
+[target.'cfg(target_os = "android")'.dependencies]
+android-activity.workspace = true
+winit.workspace = true
+eframe = { version = "0.35", default-features = false, features = [
+  "default_fonts",
+  "wgpu",
+  "android-native-activity",
+] }
+
+# ADR-0003 §5: `cargo-apk` panics after signing (`Bin is not compatible with Cdylib`) when one crate
+# has both a cdylib and a bin. So this crate has NO src/main.rs — the desktop binary is
+# `crates/desktop`, and adding a `[[bin]]` here breaks CI.
+[lib]
+name = "leitner_app"
+crate-type = ["lib", "cdylib"]
+
+# cargo-apk packaging: NativeActivity, so the APK is a manifest plus a `.so` — no Java, no Kotlin,
+# no Gradle project in the repository (ADR-0003 §2). GameActivity was tried and reverted in #8.
+[package.metadata.android]
+package = "dev.leitner.app"
+build_targets = ["aarch64-linux-android"]
+apk_name = "leitner"
+
+[package.metadata.android.sdk]
+min_sdk_version = 24
+target_sdk_version = 36
+
+[package.metadata.android.application]
+label = "Leitner"

--- a/crates/app/src/CONTEXT.md
+++ b/crates/app/src/CONTEXT.md
@@ -1,0 +1,59 @@
+# UI
+
+The egui application: every screen the user sees, the text-layout helper every one of them goes
+through, and both platform entry points.
+
+**Bound by** [ADR-0003](../../../docs/adr/0003-client-stack.md) and
+[ADR-0006](../../../docs/adr/0006-the-review-session-experience.md); also by
+[ADR-0002 §4](../../../docs/adr/0002-the-card-model.md) (layout is data, stored once per kind).
+
+## Language
+
+**Session**:
+One sitting of review: a chosen card count, with a 10-minute timer running from the same moment.
+**Not a domain object** (ADR-0005 §6) — it exists only here, and its position is never stored, only
+derived from the log.
+_Avoid_: Study session, cram session, queue.
+
+**Checkpoint**:
+What the timer surfaces when it expires: finish here, or keep going. A courtesy check-in, never an
+enforcement mechanism — reaching the chosen count is what ends a session normally.
+
+**Reveal**:
+Tapping the card to show its back. Verified identical by touch and by mouse; the two platforms do
+not diverge here.
+
+**Box badge**:
+The small, non-interactive indicator shown **only after reveal**. Reports durability. Never sorted,
+never counted, never presented as a queue — see `scheduling`'s rules, which bind everything in this
+file.
+
+**Interval preview**:
+The illustrative next-interval shown on each grade button. Confirmed wanted rather than noise once
+seen rather than described.
+
+**Backlog**:
+More cards due than the user will get through. Always *framed* ("pick a comfortable size, the rest
+will keep"), never reported as a bare number.
+
+## Rules that are easy to break silently
+
+- **All user-visible text goes through `bidi`.** egui places text runs left-to-right in logical
+  order, so a plain `ui.label("…")` renders Persian with the words backwards and Arabic-Indic digits
+  reversed. This is the single most likely way to break the app without any test failing.
+- **`TextEdit` needs the same treatment, via `.layouter()`** — it lays out its own text and
+  otherwise bypasses the helper. Caret and selection are then in visual order while the buffer is
+  logical, so RTL editing is imprecise; design around it rather than fighting it.
+- **Immediate mode has nowhere to `await`.** Spawn the future, store a handle, read the result on a
+  later frame, and call `ctx.request_repaint()` on completion or the result sits unseen until the
+  next input event.
+- **Fonts are installed on the first frame, never in `CreationContext`**, and every added face must
+  be registered in **every** family including `Monospace`, or text silently renders as boxes.
+- **Android text input is ASCII-only and cannot be fixed here.** winit's Android backend has no IME
+  path. Never design a feature that requires typing non-Latin text on Android.
+- **Verify on the real handset.** The emulator is x86_64; the Pixel 8 Pro is arm64-v8a only.
+
+## Why this crate has no `main.rs`
+
+`cargo-apk` panics after signing when one crate has both a cdylib and a bin. The desktop binary is
+`leitner-desktop`. Adding a `[[bin]]` here breaks the Android release build (ADR-0003 §5).

--- a/crates/app/src/bidi.rs
+++ b/crates/app/src/bidi.rs
@@ -1,0 +1,190 @@
+//! Bidi, patched **in our app** — no fork of epaint required.
+//!
+//! Carried into the workspace from tag `prototypes/issue-11` per ADR-0003 §7, which records this as
+//! a validated decision rather than a prototype artefact. The logic below is unchanged — only
+//! `rustfmt` has touched it. The tests are new: the prototype verified this by eye, on a handset,
+//! and by a Persian reader, which is evidence but not a regression guard.
+//!
+//! epaint shapes correctly (harfrust + `guess_segment_properties()` infers RTL from the script, so
+//! Arabic letters join and each run is laid out right-to-left *internally*). What it does not do is
+//! order the runs: it places them left-to-right in logical order, which is why a Persian sentence
+//! comes out with its words backwards while each word looks right.
+//!
+//! epaint's own docs say "each section is an independent shaping run", and sections are laid out in
+//! the order given. So we run the Unicode bidi algorithm ourselves and hand egui a `LayoutJob`
+//! whose **sections are already in visual order**, each still holding its text in logical order so
+//! shaping is untouched.
+//!
+//! **Every user-visible string goes through here.** A plain `ui.label("…")` on card content is a
+//! bug, not a style choice — see `AGENTS.md` rule 1. `TextEdit` needs the same treatment via
+//! `.layouter()`, and note that caret and selection are then in visual order while the buffer is
+//! logical, so RTL editing is imprecise by construction.
+//!
+//! If epaint ever implements bidi upstream, **delete this module** rather than keeping it
+//! alongside — two bidi passes would double-reverse (ADR-0003 Consequences).
+
+use egui::text::{LayoutJob, TextFormat};
+use egui::{Color32, FontId};
+
+/// Arabic-Indic digits carry the Arabic script property, so `guess_segment_properties()` infers
+/// RTL for them and epaint emits them right-to-left — `۱۲۳۴۵` comes out as `۵۴۳۲۱`. Numbers are
+/// supposed to read left-to-right even inside RTL text.
+///
+/// Digits have no joining behaviour, so reversing them is safe in a way that reversing letters is
+/// not: it cancels epaint's reversal and shaping is unaffected.
+fn fix_digits(word: &str) -> std::borrow::Cow<'_, str> {
+    let is_arabic_digit = |c: char| matches!(c, '\u{0660}'..='\u{0669}' | '\u{06F0}'..='\u{06F9}');
+    if !word.is_empty() && word.chars().all(is_arabic_digit) {
+        std::borrow::Cow::Owned(word.chars().rev().collect())
+    } else {
+        std::borrow::Cow::Borrowed(word)
+    }
+}
+
+/// True when the text's base direction is RTL — i.e. its first strong character is Arabic-script.
+/// Use it to right-align widgets around the text, and to set `TextEdit::horizontal_align`.
+pub fn is_rtl(text: &str) -> bool {
+    let info = unicode_bidi::BidiInfo::new(text, None);
+    info.paragraphs.first().is_some_and(|p| p.level.is_rtl())
+}
+
+/// Build a `LayoutJob` whose sections are ordered by the Unicode bidirectional algorithm.
+pub fn job(text: &str, font_id: FontId, color: Color32) -> LayoutJob {
+    use unicode_bidi::BidiInfo;
+
+    let mut job = LayoutJob::default();
+    let fmt = TextFormat {
+        font_id,
+        color,
+        ..Default::default()
+    };
+
+    let info = BidiInfo::new(text, None);
+    if info.paragraphs.is_empty() {
+        job.append(text, 0.0, fmt);
+        return job;
+    }
+
+    // Base direction, resolved the way HTML's dir="auto" does it: from the first strong character.
+    // A Persian paragraph is right-aligned; a Latin one is not. Without this the runs are ordered
+    // correctly but the block still hugs the left edge, which reads wrong.
+    if info.paragraphs[0].level.is_rtl() {
+        job.halign = egui::Align::RIGHT;
+    }
+
+    for (i, para) in info.paragraphs.iter().enumerate() {
+        if i > 0 {
+            job.append("\n", 0.0, fmt.clone());
+        }
+        let (levels, runs) = info.visual_runs(para, para.range.clone());
+        for run in runs {
+            let slice = &text[run.clone()];
+            // epaint re-splits a section into sub-runs and places those left-to-right. So for an
+            // RTL run we emit its *words* in reverse, each word keeping logical character order —
+            // placement comes out right and harfrust still sees well-formed text, so joining holds.
+            if levels[run.start].is_rtl() {
+                let words: Vec<&str> = slice.split(' ').collect();
+                for (i, w) in words.iter().rev().enumerate() {
+                    if i > 0 {
+                        job.append(" ", 0.0, fmt.clone());
+                    }
+                    job.append(&fix_digits(w), 0.0, fmt.clone());
+                }
+            } else {
+                // Even an LTR-classified run can contain Arabic-Indic digits, which epaint still
+                // emits right-to-left. A pure-digit string is classified LTR, so it lands here.
+                for (i, w) in slice.split(' ').enumerate() {
+                    if i > 0 {
+                        job.append(" ", 0.0, fmt.clone());
+                    }
+                    job.append(&fix_digits(w), 0.0, fmt.clone());
+                }
+            }
+        }
+    }
+    job
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The visual-order string we hand epaint. `LayoutJob::append` concatenates into `job.text` in
+    /// section order, and epaint lays sections out in that order — so this string *is* what the
+    /// user sees, left to right. Asserting on it needs no GPU, no window and no font.
+    fn visual(text: &str) -> String {
+        job(text, FontId::default(), Color32::WHITE).text
+    }
+
+    fn halign(text: &str) -> egui::Align {
+        job(text, FontId::default(), Color32::WHITE).halign
+    }
+
+    #[test]
+    fn latin_is_left_untouched() {
+        assert_eq!(visual("hello world"), "hello world");
+        assert_eq!(halign("hello world"), egui::Align::LEFT);
+        assert!(!is_rtl("hello world"));
+    }
+
+    #[test]
+    fn a_persian_sentence_has_its_words_reversed() {
+        // The whole defect in one assertion: epaint would place these two words left-to-right in
+        // logical order, so the reader sees the sentence backwards. We pre-reverse to cancel it.
+        assert_eq!(visual("سلام دنیا"), "دنیا سلام");
+        assert!(is_rtl("سلام دنیا"));
+    }
+
+    #[test]
+    fn an_rtl_paragraph_is_right_aligned() {
+        // Ordering the runs is not enough on its own — without this the block still hugs the left
+        // edge, which reads wrong to a Persian reader even though the words are in the right order.
+        assert_eq!(halign("سلام دنیا"), egui::Align::RIGHT);
+    }
+
+    #[test]
+    fn characters_within_a_word_are_never_touched() {
+        // Reversing characters rather than words was tried in #8 and rejected: it breaks harfrust's
+        // joining, so the letters stop connecting. Each word must survive byte-identical.
+        let word = "سلام";
+        assert_eq!(visual(word), word);
+    }
+
+    #[test]
+    fn persian_digits_are_reversed_back() {
+        // Extended Arabic-Indic digits carry the Arabic script property, so epaint emits them RTL.
+        // Reversing cancels that. Safe here and only here: digits have no joining behaviour.
+        assert_eq!(visual("۱۲۳"), "۳۲۱");
+    }
+
+    #[test]
+    fn arabic_indic_digits_are_reversed_back() {
+        assert_eq!(visual("١٢٣"), "٣٢١");
+    }
+
+    #[test]
+    fn a_mixed_word_is_not_treated_as_a_number() {
+        // fix_digits only fires when the *whole* word is digits, so a word that merely contains one
+        // keeps its logical order and shaping is untouched.
+        let mixed = "a۱";
+        assert_eq!(visual(mixed), mixed);
+    }
+
+    #[test]
+    fn empty_input_survives() {
+        assert_eq!(visual(""), "");
+        assert!(!is_rtl(""));
+    }
+
+    #[test]
+    fn every_section_indexes_real_text() {
+        // Guards the invariant epaint relies on: each section's byte range must land on a character
+        // boundary inside job.text, or layout panics at draw time rather than here.
+        let j = job("hello سلام ۱۲۳ world", FontId::default(), Color32::WHITE);
+        assert!(!j.sections.is_empty());
+        for s in &j.sections {
+            let (start, end): (usize, usize) = (s.byte_range.start.into(), s.byte_range.end.into());
+            assert!(j.text.is_char_boundary(start) && j.text.is_char_boundary(end));
+        }
+    }
+}

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1,0 +1,68 @@
+//! The egui application: every screen, and both entry points.
+//!
+//! **This crate deliberately has no `src/main.rs`.** `cargo-apk` panics after signing
+//! (`Bin is not compatible with Cdylib`) when one crate has both a cdylib and a bin — the APK comes
+//! out correct but the exit code does not, and CI breaks. The desktop binary is `leitner-desktop`,
+//! which is a shim with no logic (ADR-0003 §5, ADR-0009 §3).
+//!
+//! See `CONTEXT.md` beside this file, [ADR-0003](../../../docs/adr/0003-client-stack.md) and
+//! [ADR-0006](../../../docs/adr/0006-the-review-session-experience.md).
+
+pub mod bidi;
+
+/// Re-exported so `leitner-desktop` needs no `eframe` dependency of its own — it cannot then
+/// resolve a different feature set from the one this crate was built with, and it has no route to
+/// grow real code unnoticed.
+pub use eframe;
+
+/// The application. No behaviour has landed yet — ADR-0009 laid out the workspace and stopped at
+/// the seam, so this opens a window and renders one string through the bidi helper.
+pub struct LeitnerApp;
+
+impl LeitnerApp {
+    pub fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+        // Fonts are installed on the **first frame**, never here. Registering a face during
+        // creation was found in #8 to break rendering on some backends; deferring it one frame
+        // fixes it. When the Arabic face lands, it goes in `update`, guarded by a `bool` — and it
+        // must be registered into *every* family including `Monospace`, or text silently renders
+        // as boxes (ADR-0003 §4).
+        Self
+    }
+}
+
+impl eframe::App for LeitnerApp {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        // Through the helper, not `ui.label("…")` — even here, so the skeleton demonstrates the
+        // rule rather than modelling its violation.
+        ui.label(bidi::job(
+            "Leitner",
+            egui::TextStyle::Heading.resolve(ui.style()),
+            ui.visuals().text_color(),
+        ));
+    }
+}
+
+/// Android entry point. `NativeActivity` hosts the app directly: the APK is this `.so` plus a
+/// manifest, with no Java, no Kotlin and no Gradle project in the repository.
+///
+/// GameActivity was built and tested in #8 and reverted — it implements IME correctly, but winit's
+/// Android backend never reads it, so non-Latin text input stays unavailable at any packaging cost.
+/// Never design a feature that requires typing non-Latin text on Android (`AGENTS.md` rule 8).
+#[cfg(target_os = "android")]
+#[unsafe(no_mangle)]
+fn android_main(app: android_activity::AndroidApp) {
+    use winit::platform::android::EventLoopBuilderExtAndroid as _;
+
+    let options = eframe::NativeOptions {
+        android_app: Some(app.clone()),
+        event_loop_builder: Some(Box::new(move |b| {
+            b.with_android_app(app.clone());
+        })),
+        ..Default::default()
+    };
+    let _ = eframe::run_native(
+        "Leitner",
+        options,
+        Box::new(|cc| Ok(Box::new(LeitnerApp::new(cc)))),
+    );
+}

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "leitner-core"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
+
+# INTENTIONALLY EMPTY, and it is the point of this crate. ADR-0009 §2: the domain is pure, so
+# `cargo test -p leitner-core` needs no database, no window and no handset. A dependency added here
+# is a decision, not a convenience — and `rusqlite`, `eframe` and `egui` in particular belong in
+# `leitner-store` and `leitner-app` respectively. See ADR-0009 §6 for why `log` the crate must never
+# appear here: it would collide with the `log` context module.
+[dependencies]

--- a/crates/core/src/content/CONTEXT.md
+++ b/crates/core/src/content/CONTEXT.md
@@ -1,0 +1,105 @@
+# Content
+
+The authored, mutable half of a collection: notes, the cards generated from them, and the decks that
+ship them. Everything here is editable and settles by ADR-0004 §7's rule; nothing here is a log row.
+
+This is the base context — `log`, `scheduling` and `replay` all depend on it, and it depends on none
+of them.
+
+**Bound by** [ADR-0002](../../../../docs/adr/0002-the-card-model.md) and
+[ADR-0005](../../../../docs/adr/0005-the-deck-model.md), whose glossaries this file supersedes; also
+amended by [ADR-0008](../../../../docs/adr/0008-the-deck-export-format.md), which widened §2 to admit
+acquired kind definitions and §4's per-deck slot to hold authoring values.
+
+## Language
+
+### Notes and cards
+
+**Note**:
+The unit of authored content: a kind, a set of named field values, and tags. Never scheduled, never
+shown as a question.
+_Avoid_: Fact, entry, item.
+
+**Card**:
+A question generated from a note by rule, and the unit that carries a schedule. Identified by
+`CardRef`, never by an identifier of its own.
+
+**CardRef**:
+The pair `(note id, ordinal)` identifying a card. Encodes as exactly 18 bytes (ADR-0002 §6), which
+`scheduling` uses as its fuzz seed — so the encoding is load-bearing beyond this context.
+
+**Ordinal**:
+A card's index within its note: the position in the kind's `cards` list for fixed-arity kinds, the
+authored blank number for `cloze`.
+
+**Sibling**:
+Another card generated from the same note.
+
+### Kinds and fields
+
+**Kind**:
+The closed-set identifier declaring a note's fields and how its cards are generated. A permanent
+string, never reused. Defined in code, never authored by a user.
+_Avoid_: Note type, template, model.
+
+**Kind definition**:
+The read-only data describing a kind's fields and cards. Shipped with the application and carried in
+exports, so a deck file explains itself.
+
+**Acquired kind definition**:
+A kind definition the collection holds because it arrived in an imported file, for a kind this build
+does not ship. Read-only, and never displaces a shipped definition. A widening of the closed set's
+*provenance*, not of its editability — see [`export`](../../../export/src/CONTEXT.md), which owns the
+import side of it.
+
+**Field**:
+A named text value on a note, either **asked** or **shown-with**. A plain string of restricted
+Markdown — no media, no mathematical notation (ADR-0002 §8, §9).
+
+**Asked field**:
+A field that may serve as a card's prompt or answer.
+
+**Shown-with field**:
+A field never asked, rendering wherever its anchor field renders. This is what makes a pronunciation
+follow its term to whichever side of the card the term lands on.
+
+**Blank**:
+A numbered `{{n::text}}` region in a `cloze` note's text. Each distinct number generates one card.
+Auto-renumbering blanks is forbidden — it silently retypes review history onto the wrong card.
+
+### Decks
+
+**Deck**:
+The unit of ownership and export: `{ id, name }`, plus the notes whose `deck` reference names it.
+Never a filing structure — personal organisation is tags' job, and `::` in a name carries no
+structural meaning.
+_Avoid_: Folder, category, collection (which means the whole body of a user's data).
+
+**Deck id**:
+A UUIDv4, minted once at creation and preserved through export and import. What lets an import be
+recognised as an update to the same deck rather than a new one.
+
+**Unfiled**:
+The state of a note whose `deck` reference names no deck the collection currently holds. Fully
+reviewable, never dropped.
+
+**Personal deck preference**:
+A per-deck setting on the mutable surface, keyed by deck id, that never exports and never appears in
+the review log. Distinguished from deck content by one test: does it travel with the deck?
+
+### The two halves
+
+**Note store**:
+The mutable half of a collection — content, tags, kind, deck references. Last edit wins, by ADR-0004
+§7's settling rule. Contrast **review log**, which is `log`'s term for the append-only half.
+
+## Rules that are easy to break silently
+
+- **Never reorder a kind's `cards` list**, and **never auto-renumber cloze blanks**. Both silently
+  retype existing review history onto the wrong card, and nothing downstream can detect it
+  (ADR-0002 §6).
+- **A card is never minted, only derived.** Two offline devices must reach the same `CardRef`
+  without communicating; a minted id splits one blank's history across two irreconcilable
+  identities.
+- **Card retirement does not exist.** The card set is computed from current content; events with no
+  matching card are retained and simply not projected. See **dormant card** in `replay`.

--- a/crates/core/src/content/mod.rs
+++ b/crates/core/src/content/mod.rs
@@ -1,0 +1,3 @@
+//! See `CONTEXT.md` beside this file for the vocabulary, the binding ADR sections, and the rules
+//! that break silently. No behaviour has landed here yet — ADR-0009 laid out the workspace and
+//! stopped at the seam.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,0 +1,24 @@
+//! The Leitner domain, entire and pure.
+//!
+//! This crate has no dependencies, and that is its interface (ADR-0009 §2). No SQLite, no egui, no
+//! clock, no randomness — every value that cannot be derived is passed in by the caller. The
+//! consequence worth protecting: `cargo test -p leitner-core` verifies most of the specification
+//! with no database, no window and no handset.
+//!
+//! Four contexts, in dependency order. `content` is the base because a log row carries a `CardRef`
+//! (ADR-0004 §5) and scheduler fuzz is seeded from `CardRef`'s 18-byte encoding (ADR-0001 §7), so
+//! nothing depends on `log` or `scheduling` in the other direction:
+//!
+//! ```text
+//! content ──┬──> log ───────┬──> replay
+//!           └──> scheduling ┘
+//! ```
+//!
+//! Each context has a `CONTEXT.md` beside it holding its vocabulary. Read `CONTEXT-MAP.md` at the
+//! repository root first — it carries the reading order and says which ADR sections bind which
+//! context.
+
+pub mod content;
+pub mod log;
+pub mod replay;
+pub mod scheduling;

--- a/crates/core/src/log/CONTEXT.md
+++ b/crates/core/src/log/CONTEXT.md
@@ -1,0 +1,90 @@
+# Log
+
+The append-only, immutable half of a collection, and the identity scheme that makes two devices'
+logs mergeable by set union. Holds the **inputs to replay** — not "immutable facts", which scheduler
+configuration violates.
+
+Depends on `content` (a row carries a `CardRef`). Depends on nothing else.
+
+**Bound by** [ADR-0004](../../../../docs/adr/0004-the-review-event-log.md), whose glossary this file
+supersedes; also by [ADR-0002 §7](../../../../docs/adr/0002-the-card-model.md) and
+[ADR-0001 §6](../../../../docs/adr/0001-scheduling-algorithm-and-grade-scale.md).
+
+> **Naming hazard.** This module is called `log` and would shadow the `log` crate. `leitner-core`
+> therefore takes no dependencies at all (ADR-0009 §2), which makes the collision unreachable rather
+> than merely unlikely. Logging belongs at the edges, in `leitner-store` and `leitner-app`.
+
+## Language
+
+### Rows
+
+**Review log**:
+The append-only half of a collection. Reviews and scheduler configuration. Never compacted, never
+migrated, never edited. Contrast **note store**, `content`'s term for the mutable half.
+
+**Row**:
+One entry in the review log. Immutable, self-contained, identified by `(writer id, sequence
+number)`.
+_Avoid_: Event — preferred only when speaking about the abstract occurrence, never the stored
+artefact.
+
+**Row kind**:
+The discriminator naming what a row is: `reviewed`, `config-set`, `history-cutoff-set`. Unknown
+kinds are **skipped, never errors** — this is what lets an old build relay a newer one's data.
+
+**History cutoff**:
+The instant before which replay ignores every `reviewed` row. The only repair available for a
+clock-skew corrupted history, and it is collection-wide.
+
+### Identity and ordering
+
+**Writer id**:
+The machine-owned random identifier of one sequential writer. Never reused, never adopted, not shown
+to the user. **Not a device** — one device may own several over its life.
+
+**Sequence number**:
+A writer's own gap-free counter, incremented once per row it writes. Together with the writer id it
+*is* the row's identity, so there is no separate event id.
+
+**Version summary**:
+`{writer id → highest sequence}`, computed by scanning a log. Answers "am I ahead of or behind that
+device?". Lives in the sync handshake, never on a row.
+_Avoid_: Vector clock — accurate but imports guarantees we do not make.
+
+**Device label**:
+The user-owned name for a device, grouping one or more writer ids. Mutable content, not a log row.
+
+### Time
+
+**Day number**:
+The day bucket a review fell in, computed at write time under the collection day scale and **frozen**.
+What replay uses — never recomputed, so changing the rollover hour cannot retroactively re-bucket
+history.
+
+**Day scale**:
+The collection-wide timezone and rollover hour defining where a day starts. 4am.
+Note that "due today" and daily limits use the **device's local** day instead, not this.
+
+### The mutable surface
+
+**Stamp**:
+The `(counter, writer id)` pair attached to every mutable value, deciding which of two competing
+values is later. The counter jumps above any counter it sees. **Never a wall clock.**
+_Avoid_: Timestamp, version, mtime.
+
+### Interchange
+
+**Interchange form**:
+The canonical JSON-lines encoding of ADR-0004 §11. Local storage may differ; it must round-trip.
+Relayed **byte for byte and never re-encoded**, so an old build cannot strip a newer one's field.
+
+## Rules that are easy to break silently
+
+- **Never take the next sequence number from `MAX(seq) WHERE writer = me`.** After a merge that
+  continues *another* device's numbering — the exact duplicate-writer failure this scheme exists to
+  prevent. Use the sequence high-water in `store`.
+- **Never adopt a writer id.** A sequence number promises "I wrote exactly rows 1..N and nobody else
+  ever will", which only continuous possession establishes.
+- **Guard writes against the log's own contents.** A device whose clock is years wrong writes rows
+  that sort into an order that never happened; the guard is the only thing that catches it before
+  the data is permanent (ADR-0004 §8).

--- a/crates/core/src/log/mod.rs
+++ b/crates/core/src/log/mod.rs
@@ -1,0 +1,3 @@
+//! See `CONTEXT.md` beside this file for the vocabulary, the binding ADR sections, and the rules
+//! that break silently. No behaviour has landed here yet — ADR-0009 laid out the workspace and
+//! stopped at the seam.

--- a/crates/core/src/replay/CONTEXT.md
+++ b/crates/core/src/replay/CONTEXT.md
@@ -1,0 +1,79 @@
+# Replay
+
+The join. Given the current content and the whole review log, replay computes what the collection
+looks like right now: which cards exist, each card's memory state, and what is due. Everything it
+produces is derived and disposable — the log is the only authority.
+
+Depends on all three of `content`, `log` and `scheduling`, and nothing depends on it inside `core`.
+
+**This context has no ADR of its own, and that is the reason it exists as a context.** Its rules were
+each written for another purpose and are scattered across four documents; gathered here they are one
+coherent mechanism, and separated they get reimplemented wrongly. Read
+[ADR-0001 §7](../../../../docs/adr/0001-scheduling-algorithm-and-grade-scale.md) (replay purity),
+[ADR-0002 §7](../../../../docs/adr/0002-the-card-model.md) (content and progress live apart),
+[ADR-0004 §9](../../../../docs/adr/0004-the-review-event-log.md) (order, cache, no projection
+versioning) and [ADR-0007 §2](../../../../docs/adr/0007-the-local-store.md) (the stored line is
+authoritative).
+
+## Language
+
+**Replay**:
+Deriving current state by reading the log in order and applying each row. The one mechanism that
+keeps the scheduler swappable: changing the algorithm means re-deriving, never migrating.
+_Avoid_: Projection, rebuild, fold, materialisation.
+
+**Cache**:
+Locally computed scheduling state. Disposable, never authoritative, never synced, never exported.
+Lives in `derived.db` (see `store`), but *what* it holds is this context's decision.
+
+**Derivation version**:
+The constant identifying our replay arithmetic plus the pinned scheduler version. A mismatch deletes
+the cache and forces a full replay. Bump it whenever a change would make old cached state disagree
+with fresh arithmetic.
+
+**Cache high-water**:
+The `(writer, sequence)` the cache has consumed through. Behind is recoverable by replaying forward;
+unprovable is discarded.
+
+**Dormant card**:
+A `CardRef` with events in the log that the current content no longer generates. **Not a stored
+state** — it is the absence of a generated card, and it reattaches by itself if the content returns.
+_Avoid_: Retired, deleted, orphaned, tombstoned — all of which imply a stored lifecycle that
+deliberately does not exist.
+
+**Due**:
+A card whose next scheduled day has arrived, measured against the **device's local** day — not the
+collection day scale, which is only ever used for stamping rows at write time.
+_Avoid_: Overdue, pending, scheduled.
+
+## The mechanism, in one paragraph
+
+The card set is computed from **current content**. The log is read in `(day number, then stable tie
+break)` order, and each `reviewed` row is applied to the card its `CardRef` names; rows whose
+`CardRef` names no currently-generated card are **retained and simply not projected**. `config-set`
+rows change scheduler parameters from that point forward; rows before a `history-cutoff-set` are
+ignored entirely. The result is memory state per card, from which `scheduling` derives the box and
+the due day.
+
+That paragraph is the whole prize of ADR-0002 §7: **card retirement does not exist**. There are no
+tombstones, no lifecycle and no deletion events, because a card that stops being generated stops
+being projected, and starts again if it returns.
+
+## Rules that are easy to break silently
+
+- **Replay takes no clock and no randomness.** Day numbers are frozen on the row at write time
+  (ADR-0004 §4) and fuzz is seeded from `CardRef` (ADR-0001 §7). If replay ever reads the wall
+  clock, two devices stop agreeing and the entire merge design is void.
+- **Never delete a row because nothing projects it.** An unmatched `CardRef` is the mechanism, not
+  garbage.
+- **A cache that cannot prove how far it got is discarded, not trusted.** Losing the cache costs a
+  full replay; trusting a stale one costs wrong memory state that looks right.
+- **The projection is not versioned; the derivation is.** There is no migration path for cached
+  state — bump the derivation version and let it rebuild.
+
+## The highest-value test in the repository
+
+ADR-0004 §2 makes merging set union with duplicates dropped. The claim the whole sync design rests
+on is therefore: **any interleaving of two devices' rows replays to the same state.** That is a
+property test over shuffled row sets, it needs no sync implementation and no second device, and it
+is verifiable today.

--- a/crates/core/src/replay/mod.rs
+++ b/crates/core/src/replay/mod.rs
@@ -1,0 +1,3 @@
+//! See `CONTEXT.md` beside this file for the vocabulary, the binding ADR sections, and the rules
+//! that break silently. No behaviour has landed here yet — ADR-0009 laid out the workspace and
+//! stopped at the seam.

--- a/crates/core/src/scheduling/CONTEXT.md
+++ b/crates/core/src/scheduling/CONTEXT.md
@@ -1,0 +1,76 @@
+# Scheduling
+
+FSRS-6 arithmetic: given a card's ordered grades and day numbers, what is its memory state, when is
+it next due, and which box does it show. Pure — no clock, no randomness, no storage.
+
+Depends on `content` for `CardRef` (the fuzz seed). Deliberately does **not** depend on `log`: this
+context takes grades and day numbers as values, so its arithmetic is testable against a hand-written
+list with no rows, no writers and no merge.
+
+**Bound by** [ADR-0001](../../../../docs/adr/0001-scheduling-algorithm-and-grade-scale.md), whose
+glossary this file supersedes; also by
+[ADR-0004 §4 and §5](../../../../docs/adr/0004-the-review-event-log.md).
+
+## Language
+
+### Grading
+
+**Grade**:
+The user's rating of a single recall attempt, one of `Forgot`, `Barely`, `Good`, `Easy`, encoded
+1–4. `Forgot` is the only failure.
+_Avoid_: Rating, score, answer, ease.
+
+**Lapse**:
+A review graded `Forgot`. Collapses stability per the model; we define no rule of our own for it.
+
+### Memory
+
+**Memory state**:
+A card's `(stability, difficulty)` pair, derived by replaying its review history. Never authored
+directly, never the source of truth.
+
+**Stability**:
+Days for recall probability to fall to 90%. Provably non-decreasing on a pass and non-increasing on
+a lapse — which is what makes it safe to build a box on.
+
+**Difficulty**:
+How hard it is to increase a card's stability, clamped to `[1, 10]`.
+
+**Retrievability**:
+Current recall probability, a function of stability and elapsed time.
+
+### The user-facing bucket
+
+**Box**:
+A UI-level bucket, 1 to 5, computed from **stability alone** — thresholds 1 / 7 / 30 / 180 days.
+Expresses durability, never urgency.
+_Avoid_: Level, stage, bucket, interval band.
+
+**Durability**:
+The property a box reports: how long you would remember this. Distinct from **due-ness**, which is
+separate and is never expressed as a box.
+
+### Configuration
+
+**Scheduler parameters**:
+The 21-weight vector plus algorithm identity. Collection state carried in the log, not a device
+setting — otherwise two devices replay the same log and compute different memory states.
+_Avoid_: Weights (too narrow — the algorithm identity travels with them).
+
+**Desired retention**:
+The target recall probability at the scheduled due date. Fixed at 0.9.
+
+## Rules that are easy to break silently
+
+- **The box is derived from stability, never from the scheduled interval.** Fuzz and minimum-gap
+  make intervals non-monotone, so a box built on them could *fall after a pass*.
+- **Three UI rules bind anything that displays a box** (constraint 4): boxes are never sorted,
+  counted, or presented as a review queue; "due today" is a separate number never expressed as a
+  box; and nothing may state or imply that lower boxes come up more often.
+- **Lateness is never penalised.** `delta_t` is actual elapsed days, and a low retrievability
+  *increases* the stability gain. Do not add a catch-up rule.
+- **Load balancing, calendar shaping and sibling avoidance stay disabled.** They are what buys
+  replay purity; enabling one makes a card's schedule depend on the rest of the collection, and
+  replay stops being a function of the card's own history.
+- **Fuzz is seeded from `CardRef`, never from an RNG.** Two devices replaying the same log must
+  reach the same answer.

--- a/crates/core/src/scheduling/mod.rs
+++ b/crates/core/src/scheduling/mod.rs
@@ -1,0 +1,3 @@
+//! See `CONTEXT.md` beside this file for the vocabulary, the binding ADR sections, and the rules
+//! that break silently. No behaviour has landed here yet — ADR-0009 laid out the workspace and
+//! stopped at the seam.

--- a/crates/desktop/Cargo.toml
+++ b/crates/desktop/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "leitner-desktop"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
+
+# This crate exists for exactly one reason (ADR-0003 §5): `cargo-apk` panics after signing when one
+# crate has both a cdylib and a bin, so the desktop binary cannot live in `leitner-app`. It must
+# stay a shim with no logic — anything written here is never compiled by the Android build and never
+# exercised on the handset, which is the same class of defect as a runtime platform check.
+#
+# It depends on `leitner-app` and nothing else — `eframe` arrives by re-export. That is not
+# tidiness: a direct `eframe` here could resolve different features from the ones `leitner-app` was
+# built with, and it would give this crate a way to grow real code without anyone noticing.
+[dependencies]
+leitner-app.workspace = true
+
+[[bin]]
+name = "leitner"
+path = "src/main.rs"

--- a/crates/desktop/src/main.rs
+++ b/crates/desktop/src/main.rs
@@ -1,0 +1,25 @@
+//! The desktop binary.
+//!
+//! This crate exists for one reason: `cargo-apk` panics after signing when a single crate has both
+//! a cdylib and a bin, so the desktop entry point cannot live in `leitner-app` (ADR-0003 §5).
+//!
+//! **Keep it this short.** Logic added here is never compiled by the Android build and never
+//! exercised on the handset — a silent desktop-only path, which is the same class of defect as a
+//! runtime platform check and is exactly what ADR-0003's compile-time seam exists to prevent.
+//! Anything that looks like it belongs here belongs in `leitner_app`.
+
+use leitner_app::eframe;
+
+fn main() -> eframe::Result<()> {
+    let options = eframe::NativeOptions {
+        viewport: eframe::egui::ViewportBuilder::default()
+            .with_inner_size([560.0, 860.0])
+            .with_title("Leitner"),
+        ..Default::default()
+    };
+    eframe::run_native(
+        "Leitner",
+        options,
+        Box::new(|cc| Ok(Box::new(leitner_app::LeitnerApp::new(cc)))),
+    )
+}

--- a/crates/export/Cargo.toml
+++ b/crates/export/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "leitner-export"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
+
+# This crate exists because ADR-0008 chose a **zip archive** as the deck file container, and
+# `leitner-core`'s empty dependency list (ADR-0009 §2) has no room for a compression library. It is
+# also the right shape independently: export spans content and — once #37 specifies the progress
+# profile — the log, so it cannot live inside either, exactly like `replay`.
+#
+# The zip dependency lands here when the container is built. ADR-0008 §2 already verified the
+# feature flags, and the obvious-looking one is the broken one:
+#   zip 8.6 --no-default-features --features deflate-flate2-zlib-rs
+# builds from nine transitive crates with no `-sys` crate, so deflate needs no C toolchain.
+[dependencies]
+leitner-core.workspace = true

--- a/crates/export/src/CONTEXT.md
+++ b/crates/export/src/CONTEXT.md
@@ -1,0 +1,55 @@
+# Export
+
+Deck files: the `.ldeck` container, what goes in it, and the policy deciding what an imported file is
+allowed to change. This is constraint 2 of the map made concrete — decks are portable and
+publishable.
+
+Depends on `content`. Will depend on `log` once [#37](https://github.com/amin-bf/leitner/issues/37)
+specifies the progress profile — which is why this is a peer of `replay` rather than a module inside
+`content`.
+
+**Bound by** [ADR-0008](../../../docs/adr/0008-the-deck-export-format.md), whose glossary this file
+supersedes; also by [ADR-0005](../../../docs/adr/0005-the-deck-model.md) (deck identity) and
+[ADR-0002 §9](../../../docs/adr/0002-the-card-model.md) (the container must be able to carry binary
+from day one, even though no media ships).
+
+## Language
+
+**Deck file**:
+A `.ldeck` zip archive carrying one or more decks' content and **no review progress**. The artifact
+handed to another person.
+_Avoid_: Export, bundle, package — all of which also name the act rather than the thing.
+
+**Profile**:
+Which payload a container carries: `deck` (specified) or `progress` (reserved for #37). Declared in
+the manifest, and distinguished to the operating system by extension.
+
+**Revision**:
+A per-deck monotonic integer declared by the file, advancing only when the deck's content digest
+changes. Compared **only within one deck id's lineage** — it is meaningless across decks.
+
+**Tombstone**:
+A note id marked deleted, carrying no content, by which an author retracts a note from a published
+deck. The only kind of deletion that travels; deck deletion never does.
+
+**Acquired kind definition**:
+A kind definition a collection holds because it arrived in an imported file, for a kind the running
+build does not ship. Read-only, and never displaces a shipped definition.
+
+**Update path / create path**:
+The two import branches, selected by whether the file's deck id is already held. Authority follows
+deck id, never a user's choice.
+
+## Rules that are easy to break silently
+
+- **A per-deck progress export does not exist, and cannot.** The log has no deck column by design,
+  so scoping progress to a deck means filtering by *current* membership — the same log exported
+  twice a week apart, with one note moved, yields different "progress for the same deck". Progress
+  is coherent collection-wide and incoherent deck-wide.
+- **On import, the file wins for everything it carries.** Settling stamps are per-collection
+  counters and are meaningless compared across collections, so import is policy, not merge.
+- **Stamps do not travel.** Import restamps only what actually changes.
+- **The deck profile carries no log, so it carries no writer ids.** The disclosure question answers
+  itself; do not add a policy to contain it, and do not add a log member to the deck profile.
+- **One container, not two.** A backup artifact reuses this container with a different profile.
+  Two containers means two parsers, two versioning stories and two sets of path-traversal rules.

--- a/crates/export/src/lib.rs
+++ b/crates/export/src/lib.rs
@@ -1,0 +1,9 @@
+//! Deck files: the `.ldeck` container, and the import policy that decides what a received file is
+//! allowed to change.
+//!
+//! The one artifact that leaves the machine and arrives with someone who does not have this
+//! application — which is why ADR-0008 traded bytes for inspectability here, as ADR-0002 §8 and
+//! ADR-0004 §11 did before it.
+//!
+//! No behaviour has landed yet — ADR-0009 laid out the workspace and stopped at the seam. See
+//! `CONTEXT.md` beside this file, and [ADR-0008](../../../docs/adr/0008-the-deck-export-format.md).

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "leitner-store"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+license.workspace = true
+
+[dependencies]
+leitner-core.workspace = true
+# ADR-0007 §2: two SQLite files via rusqlite, `bundled` so no system SQLite is required and the
+# cross-compile proven in #7 keeps working.
+rusqlite.workspace = true
+
+# ADR-0003 §5 / ADR-0007 §6: Android's data directory is reachable only through hand-written JNI.
+# These two crates exist solely for `platform/android.rs` and must not be used anywhere else.
+[target.'cfg(target_os = "android")'.dependencies]
+jni.workspace = true
+ndk-context.workspace = true

--- a/crates/store/src/CONTEXT.md
+++ b/crates/store/src/CONTEXT.md
@@ -1,0 +1,54 @@
+# Store
+
+Where a collection is kept on disk, and where the platform seam lives. Two SQLite files via
+`rusqlite` with `bundled`, plus the two directory lookups that locate them.
+
+**Bound by** [ADR-0007](../../../docs/adr/0007-the-local-store.md), whose glossary this file
+supersedes; also by [ADR-0004 §11](../../../docs/adr/0004-the-review-event-log.md) (relay byte for
+byte) and [ADR-0003 §5](../../../docs/adr/0003-client-stack.md) (the platform seam).
+
+## Language
+
+**Collection database** (`collection.db`):
+The authoritative file. Three tables: `log`, `mutable`, `local`. Nothing here can be lost except by
+a failure of SQLite itself.
+
+**Derived database** (`derived.db`):
+The disposable cache, attached to the same connection. Deletable at any time; losing it costs a full
+replay and nothing else.
+
+**Sequence high-water** (`local.seq_highwater`):
+The highest sequence number *this install* has written. Both the source of the next sequence number
+and — inverted — the self-heal detector: a log row above it means someone else is writing as us.
+_Avoid_: Max seq, last seq — the names that invite the `MAX(seq) WHERE writer = me` bug.
+
+**Writer marker**:
+The copy of the writer id held outside the backup set. Its absence or disagreement means this
+collection was copied here, and a fresh writer id must be minted.
+
+**Line**:
+The `log.line` column: the interchange row exactly as received. **The only authoritative column** —
+every other column in the table, and everything in `derived.db`, is derived from it and may be
+dropped and rebuilt.
+
+## Rules that are easy to break silently
+
+- **`INSERT OR IGNORE` is for merge-ingest only. Our own writes use plain `INSERT`.** On another
+  device's rows it is the union merge; on our own it silently drops a review.
+- **Never take the next sequence number from `MAX(seq) WHERE writer = me`.** After a merge that
+  continues *another* device's numbering. Use `local.seq_highwater`.
+- **Every write transaction is `BEGIN IMMEDIATE`.** Sequence allocation is a read-modify-write; a
+  deferred transaction loses updates between two processes.
+- **Derived columns do not have to round-trip. Only `line` does.**
+- **The writer marker lives outside the backup set** — never move it into the data directory.
+- **WAL on both files; `synchronous=FULL` on the collection, `OFF` on the cache.**
+
+## The platform seam
+
+`platform/` is the entire platform surface of the whole application, and it is two functions wide:
+`data_dir()` and `state_dir()`. Three `#[cfg]` arms, the third a `compile_error!` so an unrecognised
+target fails the build rather than silently taking the desktop path.
+
+**A third function appearing here means the seam is eroding.** Everything else in this crate is
+portable — `rusqlite` with `bundled` compiles unchanged for desktop and Android, proven on the
+handset in #7.

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -1,0 +1,10 @@
+//! Persistence for a collection: two SQLite files, and the two directory lookups that locate them.
+//!
+//! This crate is where `rusqlite` lives, and it is the only crate in the workspace that knows the
+//! difference between desktop and Android. Everything domain-shaped belongs in `leitner-core`; if
+//! logic starts accumulating here it is in the wrong crate.
+//!
+//! See `CONTEXT.md` beside this file, and
+//! [ADR-0007](../../../docs/adr/0007-the-local-store.md).
+
+pub mod platform;

--- a/crates/store/src/platform/android.rs
+++ b/crates/store/src/platform/android.rs
@@ -1,0 +1,61 @@
+//! Android directories, reached by hand-written JNI.
+//!
+//! Android exposes no data directory to this stack — ADR-0003 §5 records that Tauri's
+//! `app_data_dir()` was the only candidate that avoided this, and it lost. So we call
+//! `Context.getFilesDir()` and `Context.getNoBackupFilesDir()` ourselves. The `getFilesDir` half is
+//! carried forward from the #8 slice, where it was proven on the handset.
+//!
+//! **Ordering hazard.** The JVM handle comes from `ndk_context`, which is populated by
+//! `android-activity` inside `leitner-app`. So the store cannot be opened before the activity
+//! exists. Under `android_main` that is automatic; it does mean `leitner-store` is not
+//! independently runnable on Android, and store tests run on desktop.
+
+use super::PlatformError;
+use std::path::PathBuf;
+
+/// `Context.getFilesDir()` — app-private internal storage.
+///
+/// Survives an app update. Does not survive uninstall or "clear data". **Is** included in Auto
+/// Backup, which is why the writer marker lives in [`state_dir`] instead.
+pub fn data_dir() -> Result<PathBuf, PlatformError> {
+    context_dir("getFilesDir")
+}
+
+/// `Context.getNoBackupFilesDir()` — app-private storage excluded from Auto Backup by default.
+///
+/// This is the **only** exclusion mechanism available to us: XML backup rules require `@xml/…`
+/// under `res/`, and ADR-0003 §2's no-Gradle-project property rests on the APK being a manifest
+/// plus a `.so`, with no Android resources at all. The no-backup directory needs no XML.
+pub fn state_dir() -> Result<PathBuf, PlatformError> {
+    context_dir("getNoBackupFilesDir")
+}
+
+/// Both lookups are the same three JNI calls with a different method name: ask the activity for a
+/// `java.io.File`, then ask that for its absolute path.
+fn context_dir(method: &str) -> Result<PathBuf, PlatformError> {
+    let err = |e: jni::errors::Error| PlatformError(format!("{method}: {e}"));
+
+    let ctx = ndk_context::android_context();
+    // SAFETY: `ndk_context` hands back the JavaVM and Activity pointers that `android-activity`
+    // stored during `android_main`. Valid for the process lifetime once the activity exists.
+    let vm = unsafe { jni::JavaVM::from_raw(ctx.vm().cast()) }.map_err(err)?;
+    let mut env = vm.attach_current_thread().map_err(err)?;
+    let activity = unsafe { jni::objects::JObject::from_raw(ctx.context().cast()) };
+
+    let file = env
+        .call_method(&activity, method, "()Ljava/io/File;", &[])
+        .map_err(err)?
+        .l()
+        .map_err(err)?;
+    let path = env
+        .call_method(&file, "getAbsolutePath", "()Ljava/lang/String;", &[])
+        .map_err(err)?
+        .l()
+        .map_err(err)?;
+    let path: String = env
+        .get_string(&jni::objects::JString::from(path))
+        .map_err(err)?
+        .into();
+
+    Ok(PathBuf::from(path))
+}

--- a/crates/store/src/platform/desktop.rs
+++ b/crates/store/src/platform/desktop.rs
@@ -1,0 +1,39 @@
+//! Desktop directories, per the XDG Base Directory specification (ADR-0007 §6).
+//!
+//! No crate dependency for this: the two lookups plus their documented fallbacks are a dozen lines,
+//! and `leitner-store`'s dependency list is short enough to be worth keeping that way.
+
+use super::PlatformError;
+use std::path::PathBuf;
+
+const APP_DIR: &str = "leitner";
+
+fn home() -> Result<PathBuf, PlatformError> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+        .ok_or_else(|| PlatformError("HOME is unset".into()))
+}
+
+/// `$XDG_DATA_HOME/leitner`, falling back to `~/.local/share/leitner`.
+pub fn data_dir() -> Result<PathBuf, PlatformError> {
+    xdg("XDG_DATA_HOME", ".local/share")
+}
+
+/// `$XDG_STATE_HOME/leitner`, falling back to `~/.local/state/leitner`.
+///
+/// XDG's slot for state that persists but is not the user's portable data — which is exactly the
+/// writer marker's requirement. The desktop form of the Android backup hazard is a collection in a
+/// cloud-synced folder or copied to a second machine, and this catches those identically.
+pub fn state_dir() -> Result<PathBuf, PlatformError> {
+    xdg("XDG_STATE_HOME", ".local/state")
+}
+
+fn xdg(var: &str, fallback: &str) -> Result<PathBuf, PlatformError> {
+    let base = match std::env::var_os(var) {
+        // The spec requires an absolute path; a relative value is defined to be ignored.
+        Some(v) if !v.is_empty() && PathBuf::from(&v).is_absolute() => PathBuf::from(v),
+        _ => home()?.join(fallback),
+    };
+    Ok(base.join(APP_DIR))
+}

--- a/crates/store/src/platform/mod.rs
+++ b/crates/store/src/platform/mod.rs
@@ -1,0 +1,71 @@
+//! The entire platform surface, and it is two functions wide.
+//!
+//! ADR-0003 makes the platform seam a compile-time `#[cfg]` and forbids ever replacing it with a
+//! runtime check — the whole stack choice rests on wrong platform code failing the build. ADR-0007
+//! §442 then shrank what has to cross the seam to two directory lookups; everything else in this
+//! crate is portable.
+//!
+//! **The third arm is the point.** A binary `android` / `not(android)` partition is tidier and can
+//! never fail to compile — which is exactly its defect: a new target would silently take the
+//! desktop arm and fail on a device instead of in CI. The `compile_error!` is what makes the rule
+//! real rather than stylistic.
+//!
+//! **If a third function ever appears here, the seam is eroding.** That is the signal to stop and
+//! ask why, not to add it.
+
+use std::fmt;
+use std::path::PathBuf;
+
+#[cfg(target_os = "android")]
+#[path = "android.rs"]
+mod imp;
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[path = "desktop.rs"]
+mod imp;
+
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+)))]
+compile_error!(
+    "unsupported target: add an arm to leitner_store::platform. \
+     Do not widen an existing arm to cover it — see ADR-0003 and ADR-0009 §4."
+);
+
+/// Where `collection.db` and `derived.db` live (ADR-0007 §6).
+///
+/// On Android this is `getFilesDir()`, which **is** in the Auto Backup set. That is deliberate: the
+/// collection should be restored onto a replacement phone. What must not be restored is the writer
+/// identity, which is why [`state_dir`] exists.
+pub fn data_dir() -> Result<PathBuf, PlatformError> {
+    imp::data_dir()
+}
+
+/// Where the writer marker lives — **outside the backup set** (ADR-0007 §6).
+///
+/// This is load-bearing, not tidiness. Auto Backup defaults to on and restores `getFilesDir()`
+/// wholesale, which would carry `local.writer_id` onto a replacement phone and make two devices the
+/// same writer — the duplicate-writer failure ADR-0004 §2 and §3 exist to prevent, arriving through
+/// a platform default nobody opted into. A marker held here turns a restore into a clean fork.
+///
+/// Moving this into the data directory reintroduces the bug silently, and sync would not notice
+/// until the two devices eventually met.
+pub fn state_dir() -> Result<PathBuf, PlatformError> {
+    imp::state_dir()
+}
+
+/// A platform directory could not be resolved. Not recoverable in-process: without a data directory
+/// there is nowhere to put the collection.
+#[derive(Debug)]
+pub struct PlatformError(pub String);
+
+impl fmt::Display for PlatformError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "platform directory unavailable: {}", self.0)
+    }
+}
+
+impl std::error::Error for PlatformError {}

--- a/docs/adr/0001-scheduling-algorithm-and-grade-scale.md
+++ b/docs/adr/0001-scheduling-algorithm-and-grade-scale.md
@@ -298,29 +298,12 @@ widening of constraint 1; the first added the event-kind discriminator.
 strictly timestamp-ordered with `delta_t` in days, so a device with a wrong wall clock writes wrong
 facts into a log that is immutable by design. That tension remains #9's to confront.
 
-## Glossary (provisional)
+## Glossary
 
-These terms are settled by this ADR. They move into a scheduling context's `CONTEXT.md` once
-[Decide: crate and workspace layout](https://github.com/amin-bf/leitner/issues/14) fixes where
-contexts live; until then this ADR is their definition of record.
-
-- **Grade** — the user's rating of a single recall attempt, one of `Forgot`, `Barely`, `Good`,
-  `Easy`, encoded 1–4. `Forgot` is the only failure.
-- **Memory state** — a card's `(stability, difficulty)` pair, derived by replaying its review
-  history. Never authored directly, never the source of truth.
-- **Stability** — days for recall probability to fall to 90%. Non-decreasing on a pass,
-  non-increasing on a lapse.
-- **Difficulty** — how hard it is to increase a card's stability, clamped to `[1, 10]`.
-- **Retrievability** — current recall probability, a function of stability and elapsed time.
-- **Box** — a UI-level bucket, 1 to 5, computed from stability alone. Expresses **durability**
-  ("how long you would remember this"), never urgency.
-- **Durability** — the property a box reports. Distinct from **due-ness**, which is separate and
-  never expressed as a box.
-- **Lapse** — a review graded `Forgot`. Collapses stability per the model; we define no rule of our
-  own for it.
-- **Scheduler parameters** — the 21-weight vector plus algorithm identity. Collection state carried
-  in the log, not a device setting.
-- **Desired retention** — the target recall probability at the scheduled due date. Fixed at 0.9.
+**Moved.** These terms are now of record in [`scheduling`](../../crates/core/src/scheduling/CONTEXT.md), per
+[ADR-0009 §6](0009-crate-and-workspace-layout.md), which fixed where contexts live. They
+were marked provisional here precisely so this could happen: the `CONTEXT.md` is
+authoritative, and this ADR keeps the reasoning behind them.
 
 ## Consequences
 

--- a/docs/adr/0002-the-card-model.md
+++ b/docs/adr/0002-the-card-model.md
@@ -416,36 +416,14 @@ Removal under set union needs its own answer, which is #9's to give.
 An **authoring/editing experience** ticket: the Markdown subset with live preview (§8), entering and
 proofreading numbered blanks (§5), and the warning before an edit retires a card with history (§7).
 
-## Glossary (provisional)
+## Glossary
 
-Settled by this ADR. They move into a context's `CONTEXT.md` once
-[Decide: crate and workspace layout](https://github.com/amin-bf/leitner/issues/14) fixes where
-contexts live; until then this ADR is their definition of record. This follows ADR-0001, which
-deferred its glossary the same way and for the same reason.
+**Moved.** These terms are now of record in [`content`](../../crates/core/src/content/CONTEXT.md), per
+[ADR-0009 §6](0009-crate-and-workspace-layout.md), which fixed where contexts live. They
+were marked provisional here precisely so this could happen: the `CONTEXT.md` is
+authoritative, and this ADR keeps the reasoning behind them.
 
-- **Note** — the unit of authored content: a kind plus a set of named field values plus tags. Never
-  scheduled, never shown as a question. The term was chosen deliberately over *fact*, *entry* and
-  *item* for reading naturally in "one note, two cards".
-- **Card** — a question generated from a note by rule, and the unit that carries a schedule.
-  Identified by `CardRef`, never by an identifier of its own.
-- **CardRef** — the pair `(note id, ordinal)` identifying a card. Encodes as 18 bytes (§6).
-- **Ordinal** — a card's index within its note: the position in the kind's `cards` list for
-  fixed-arity kinds, the authored blank number for `cloze`.
-- **Kind** — the closed-set identifier declaring a note's fields and how its cards are generated.
-  A permanent string, never reused.
-- **Kind definition** — the read-only data describing a kind's fields and cards. Shipped with the
-  application and carried in exports.
-- **Field** — a named text value on a note, either **asked** or **shown-with** another field.
-- **Asked field** — one that may serve as a card's prompt or answer.
-- **Shown-with field** — one never asked, rendering wherever its anchor field renders.
-- **Blank** — a numbered `{{n::text}}` region in a `cloze` note's text. Each distinct number
-  generates one card.
-- **Sibling** — another card generated from the same note.
-- **Note store** — the mutable half of the data. Content, tags, kind. Last edit wins.
-- **Review log** — the append-only, immutable half. Reviews and scheduler configuration.
-- **Dormant card** — a `CardRef` with events in the log that the current content no longer
-  generates. Not a stored state; the absence of a generated card. Reattaches if the content
-  returns.
+**Dormant card** moved to [`replay`](../../crates/core/src/replay/CONTEXT.md) instead: it names the join between content and the log, not a property of content.
 
 ## Consequences
 

--- a/docs/adr/0004-the-review-event-log.md
+++ b/docs/adr/0004-the-review-event-log.md
@@ -512,33 +512,14 @@ bad byte must never render the application unusable.
 1. A same-session re-show after a lapse is a **real logged review** with a zero day gap, not a UI-only
    loop (ADR-0001 §5, §1 here).
 
-## Glossary (provisional)
+## Glossary
 
-Settled by this ADR. They move into a context's `CONTEXT.md` once
-[Decide: crate and workspace layout](https://github.com/amin-bf/leitner/issues/14) fixes where
-contexts live; until then this ADR is their definition of record, following ADR-0001 and ADR-0002.
+**Moved.** These terms are now of record in [`log`](../../crates/core/src/log/CONTEXT.md), per
+[ADR-0009 §6](0009-crate-and-workspace-layout.md), which fixed where contexts live. They
+were marked provisional here precisely so this could happen: the `CONTEXT.md` is
+authoritative, and this ADR keeps the reasoning behind them.
 
-- **Row** — one entry in the review log. Immutable, self-contained, identified by `(writer id,
-  sequence number)`. Preferred over *event* when speaking about the stored artefact.
-- **Row kind** — the discriminator naming what a row is: `reviewed`, `config-set`,
-  `history-cutoff-set`. Unknown kinds are skipped, never errors.
-- **Writer id** — the machine-owned random identifier of one sequential writer. Never reused, never
-  adopted, not shown to the user. Not a device: one device may own several over its life.
-- **Sequence number** — a writer's own gap-free counter, incremented once per row it writes.
-- **Version summary** — `{writer id → highest sequence}`, computed by scanning a log. Answers "am I
-  ahead of or behind that device?". Lives in the sync handshake, never on a row.
-- **Device label** — the user-owned name for a device. Groups one or more writer ids. Mutable
-  content, not a log row.
-- **Day number** — the day bucket a review fell in, computed at write time under the collection day
-  scale and frozen. What replay uses.
-- **Day scale** — the collection-wide timezone and rollover hour defining where a day starts. 4am.
-- **History cutoff** — the instant before which replay ignores every `reviewed` row.
-- **Stamp** — the `(counter, writer id)` pair attached to every mutable value, deciding which of two
-  competing values is later. The counter jumps above any counter it sees. Never a wall clock.
-- **Interchange form** — the canonical JSON-lines encoding of §11. Local storage may differ; it must
-  round-trip.
-- **Cache** — locally computed scheduling state. Disposable, never authoritative, never synced,
-  never exported.
+**Cache** moved to [`replay`](../../crates/core/src/replay/CONTEXT.md), which decides what it holds.
 
 ## Consequences
 

--- a/docs/adr/0005-the-deck-model.md
+++ b/docs/adr/0005-the-deck-model.md
@@ -287,21 +287,14 @@ The policy:
 3. Decide how a per-deck limit **composes with the single collection-wide queue** (§6) if one is
    introduced.
 
-## Glossary (provisional)
+## Glossary
 
-Settled by this ADR. They move into a context's `CONTEXT.md` once
-[Decide: crate and workspace layout](https://github.com/amin-bf/leitner/issues/14) fixes where contexts
-live; until then this ADR is their definition of record.
+**Moved.** These terms are now of record in [`content`](../../crates/core/src/content/CONTEXT.md), per
+[ADR-0009 §6](0009-crate-and-workspace-layout.md), which fixed where contexts live. They
+were marked provisional here precisely so this could happen: the `CONTEXT.md` is
+authoritative, and this ADR keeps the reasoning behind them.
 
-- **Deck** — the unit of ownership and export: `{ id, name }`, plus the notes whose `deck` reference
-  names it. Never a filing structure; personal organisation is tags' job.
-- **Deck id** — a UUIDv4, minted once at creation, preserved through export and import. The stable
-  identity that lets an update be recognised as the same deck rather than a new one.
-- **Unfiled** — the state of a note whose `deck` reference names no deck the collection currently
-  holds. Fully reviewable, never dropped.
-- **Personal deck preference** — a per-deck setting living on the mutable surface, keyed by deck id,
-  that never exports and never appears in the review log. Distinguished from deck content by the test:
-  does it travel with the deck?
+Decks did not earn a context of their own — see ADR-0009 §6. Deck *files* did: see [`export`](../../crates/export/src/CONTEXT.md).
 
 ## Consequences
 

--- a/docs/adr/0007-the-local-store.md
+++ b/docs/adr/0007-the-local-store.md
@@ -459,21 +459,14 @@ here forecloses it.
 1. Suspension as a fourth row kind needs no schema change: `kind` is a column and unknown kinds are
    skipped (§9).
 
-## Glossary (provisional)
+## Glossary
 
-Following ADR-0004, these are of record here until
-[#14](https://github.com/amin-bf/leitner/issues/14) fixes where contexts live.
+**Moved.** These terms are now of record in [`store`](../../crates/store/src/CONTEXT.md), per
+[ADR-0009 §6](0009-crate-and-workspace-layout.md), which fixed where contexts live. They
+were marked provisional here precisely so this could happen: the `CONTEXT.md` is
+authoritative, and this ADR keeps the reasoning behind them.
 
-- **Collection database** (`collection.db`) — the authoritative file: `log`, `mutable`, `local`.
-- **Derived database** (`derived.db`) — the disposable cache, attached to the same connection.
-- **Derivation version** — the constant identifying our replay arithmetic plus the pinned scheduler
-  version. A mismatch deletes the cache.
-- **Cache high-water** — the `(writer, sequence)` the cache has consumed through. Behind is
-  recoverable; unprovable is discarded.
-- **Sequence high-water** — the highest sequence *this install* has written. Both the source of the
-  next sequence number and the self-heal detector (§5).
-- **Writer marker** — the copy of the writer id held outside the backup set, whose absence or
-  disagreement means this collection was copied here and a fresh writer id must be minted (§6).
+**Derivation version** and **cache high-water** moved to [`replay`](../../crates/core/src/replay/CONTEXT.md), which owns the arithmetic they version.
 
 ## Consequences
 

--- a/docs/adr/0008-the-deck-export-format.md
+++ b/docs/adr/0008-the-deck-export-format.md
@@ -425,24 +425,14 @@ syncing is open at all.
 3. Author, description and licence are **typed deliberately or left empty** (§12) — never
    auto-populated.
 
-## Glossary (provisional)
+## Glossary
 
-Settled by this ADR. They move into a context's `CONTEXT.md` once
-[Decide: crate and workspace layout](https://github.com/amin-bf/leitner/issues/14) fixes where contexts
-live; until then this ADR is their definition of record.
+**Moved.** These terms are now of record in [`export`](../../crates/export/src/CONTEXT.md), per
+[ADR-0009 §6](0009-crate-and-workspace-layout.md), which fixed where contexts live. They
+were marked provisional here precisely so this could happen: the `CONTEXT.md` is
+authoritative, and this ADR keeps the reasoning behind them.
 
-- **Deck file** — a `.ldeck` zip archive carrying one or more decks' content and no review progress.
-  The artifact handed to another person.
-- **Profile** — which payload a container carries: `deck` (specified here) or `progress` (reserved for
-  #37). Declared in the manifest; distinguished to the operating system by extension.
-- **Revision** — a per-deck monotonic integer declared by the file, advancing only when the deck's
-  content digest changes. Compared only within one deck id's lineage.
-- **Tombstone** — a note id marked deleted, carrying no content, by which an author retracts a note
-  from a published deck.
-- **Acquired kind definition** — a kind definition a collection holds because it arrived in an imported
-  file, for a kind the running build does not ship. Read-only; never displaces a shipped definition.
-- **Update path / create path** — the two import branches, selected by whether the file's deck id is
-  already held (§11).
+**Acquired kind definition** is also noted in [`content`](../../crates/core/src/content/CONTEXT.md), since it is a kind definition first and an import artefact second.
 
 ## Consequences
 

--- a/docs/adr/0009-crate-and-workspace-layout.md
+++ b/docs/adr/0009-crate-and-workspace-layout.md
@@ -1,0 +1,356 @@
+# ADR-0009: Crate and workspace layout
+
+- **Status**: Accepted
+- **Date**: 2026-07-30
+- **Resolves**: [Decide: crate and workspace layout](https://github.com/amin-bf/leitner/issues/14)
+- **Map**: [Map: local-first Leitner app spec](https://github.com/amin-bf/leitner/issues/1)
+- **Related**: every prior ADR. This one gives the other seven a place to live.
+
+## Context
+
+This is the last decision before the spec is handed off. Seven ADRs settled *what* the application
+is; none of them said where any of it goes, and six of them
+([ADR-0001](0001-scheduling-algorithm-and-grade-scale.md),
+[ADR-0002](0002-the-card-model.md), [ADR-0004](0004-the-review-event-log.md),
+[ADR-0005](0005-the-deck-model.md), [ADR-0007](0007-the-local-store.md) and
+[ADR-0008](0008-the-deck-export-format.md)) deferred their glossaries to this ticket with the same
+sentence: *"they move into a context's `CONTEXT.md` once #14 fixes where contexts live."* Roughly 52
+settled terms have been waiting on this file.
+
+The map fixes **agents implement this**, which changes what a good layout is. The usual prizes —
+compile times, publishability, a pleasant import graph — matter less than two properties an agent
+cannot intuit its way around:
+
+1. **Mistakes must fail the build**, not the app on a handset.
+2. **The right thing must be findable** without reading everything. `docs/adr/` is 2,591 lines.
+
+Two constraints arrive already fixed. [ADR-0003 §5](0003-client-stack.md) records that `cargo-apk`
+panics after signing (`Bin is not compatible with Cdylib`) when one crate has both a cdylib and a
+bin — the APK is correct, the exit code is not — so **the desktop binary must live in its own
+crate**. And [ADR-0007](0007-the-local-store.md) narrowed the platform surface to *two directory
+lookups plus the Android JNI shim*, which is far smaller than ADR-0003's "the storage backend"
+framing implied: `rusqlite` with `bundled` compiles unchanged for both targets.
+
+## Decision
+
+### 1. Five crates
+
+```
+leitner/
+├── Cargo.toml              workspace root, resolver 3
+├── CONTEXT-MAP.md          the reading order and the ADR index
+├── docs/adr/               every ADR, one sequence
+└── crates/
+    ├── core/     leitner-core     lib          the domain, pure, zero dependencies
+    ├── store/    leitner-store    lib          rusqlite, the two files, the platform seam
+    ├── export/   leitner-export   lib          the .ldeck container and the import policy
+    ├── app/      leitner-app      lib+cdylib   egui, the bidi helper, the Android entry point
+    └── desktop/  leitner-desktop  bin          a shim, forced by cargo-apk
+```
+
+Two of these lines are forced by the toolchain. `desktop` is separate because of the `cargo-apk`
+panic above. `app` is separate from `store` because only one of them is a cdylib and only one of
+them splits `eframe` per target.
+
+The rest are chosen, and §2, §4 and §11 say why.
+
+### 2. `leitner-core` has no dependencies, and that is its interface
+
+Its `[dependencies]` section is empty, deliberately and permanently. No `rusqlite`, no `egui`, no
+clock, no random number generator, no serialisation crate.
+
+This is affordable only because [ADR-0007 §2](0007-the-local-store.md) made the stored `line` column
+authoritative and every other column derived: the domain deals in interchange lines, so it never
+needs to know a database exists. The property bought is that **`cargo test -p leitner-core` verifies
+most of the specification with no database, no window and no handset** — and it is build-checked
+rather than merely intended.
+
+A trait-based store seam was considered and rejected. There is exactly one store adapter, and
+`rusqlite` opens `:memory:` databases, so an abstraction would exist only to serve tests that do not
+need it. A crate boundary is not a swappable-adapter seam; it is the only way to state *this code
+cannot reach a database* such that the compiler enforces it.
+
+### 3. Contexts are modules, not crates
+
+`content`, `log`, `scheduling` and `replay` are modules inside `leitner-core`, each with a
+`CONTEXT.md` beside it.
+
+Crates were the obvious alternative and would enforce privacy between contexts. They were rejected
+because **nothing varies across a context line** — one implementation each — and because the
+dependency graph makes the cost concrete rather than theoretical. A log row carries a `CardRef`
+([ADR-0004 §5](0004-the-review-event-log.md)) and scheduler fuzz is seeded from `CardRef`'s 18-byte
+encoding ([ADR-0001 §7](0001-scheduling-algorithm-and-grade-scale.md)), so a crate-per-context split
+needs a fifth shared-types crate on day one. That crate would be the tell that the line was drawn in
+the wrong place.
+
+The graph is acyclic with `content` at the base:
+
+```
+content ──┬──> log ───────┬──> replay
+          └──> scheduling ┘
+```
+
+`scheduling` deliberately does **not** depend on `log`: it takes grades and day numbers as values,
+so FSRS arithmetic is testable against a hand-written list with no rows, no writers and no merge.
+
+### 4. The platform seam is three arms, and the third is `compile_error!`
+
+All of it lives in `leitner-store::platform`, and it is two functions wide — `data_dir()` and
+`state_dir()`.
+
+```rust
+#[cfg(target_os = "android")]                    #[path = "android.rs"]  mod imp;
+#[cfg(any(linux, macos, windows))]               #[path = "desktop.rs"]  mod imp;
+#[cfg(not(any(android, linux, macos, windows)))] compile_error!("unsupported target: …");
+```
+
+The third arm is the decision. A binary `android` / `not(android)` partition is tidier and can never
+fail to compile — which is precisely its defect: a new target silently takes the desktop arm and
+fails at runtime, on a device, which is the failure mode ADR-0003 spent four prototypes buying its
+way out of. **Verified**: `cargo check -p leitner-store --target wasm32-unknown-unknown` fails with
+the message above rather than compiling.
+
+**A third function appearing in this module means the seam is eroding.** That is the signal to stop,
+not to add it.
+
+The two arms are not symmetric in one respect worth recording: `store`'s Android arm reads the JVM
+handle from `ndk_context`, which `android-activity` populates inside `leitner-app`. So the store
+cannot be opened before the activity exists, **`leitner-store` is not independently runnable on
+Android**, and store tests run on desktop.
+
+### 5. `leitner-desktop` is a shim, and a re-export is what keeps it one
+
+Its `main.rs` is twenty lines and its only dependency is `leitner-app`; `eframe` arrives by
+re-export rather than by a dependency of its own.
+
+That is not tidiness. A direct `eframe` dependency here could resolve a different feature set from
+the one `leitner-app` was built with, and it would give this crate a route to grow real code.
+Anything written here is **never compiled by the Android build and never exercised on the handset** —
+a silent desktop-only path, which is the same class of defect as a runtime platform check wearing a
+different hat.
+
+`leitner-app` correspondingly has **no `src/main.rs`**, and adding a `[[bin]]` to it breaks the
+Android release build.
+
+One manifest detail that resisted the obvious form: `eframe` cannot be a workspace dependency,
+because its Android arm needs `default-features = false` (its default `accesskit` is refused
+alongside `android-native-activity`, per ADR-0003 §5) and Cargo forbids overriding a workspace
+entry's `default-features`. Both arms are therefore declared literally in `crates/app/Cargo.toml`,
+side by side in one file where they cannot drift.
+
+### 6. Seven contexts
+
+| Context | Lives in | Supersedes the glossary of |
+|---|---|---|
+| `content` | `crates/core/src/content/` | ADR-0002, ADR-0005 |
+| `log` | `crates/core/src/log/` | ADR-0004 |
+| `scheduling` | `crates/core/src/scheduling/` | ADR-0001 |
+| `replay` | `crates/core/src/replay/` | the cache terms of ADR-0004 and ADR-0007 |
+| `store` | `crates/store/src/` | ADR-0007 |
+| `export` | `crates/export/src/` | ADR-0008 |
+| `ui` | `crates/app/src/` | ADR-0006 |
+
+Decks fold into `content` rather than taking a context of their own: ADR-0005 §5 settles a deck as
+`{ id, name }` and nothing else, and §8 puts membership on the note. Four terms and a two-field
+struct do not survive the deletion test. **Deck *files* are a different matter — see §11.**
+
+**`replay` is a context, and it is the one worth arguing about.** It produces scheduling state, so
+filing it under `scheduling` is tempting. It is separate because
+[ADR-0002 §7](0002-the-card-model.md)'s prize — the card set is computed from current content,
+unmatched events are retained and simply not projected, history reattaches by itself — is precisely
+the *join* between content and log. Filing it under `scheduling` would make `scheduling` depend on
+`content` and forfeit §3's testability property.
+
+It is also **the only context with no ADR of its own**, and that is the strongest argument for
+giving it one. Its rules were each written for another purpose and sit scattered across ADR-0001 §7,
+ADR-0002 §7, ADR-0004 §9 and ADR-0007 §2. Gathered into one `CONTEXT.md` they are a single coherent
+mechanism; left scattered they get reimplemented wrongly.
+
+The name was chosen over `collection`, which has textual support elsewhere in these ADRs but also
+names a *file* (`collection.db`) in a different crate. A context sharing a name with a database file
+is an ambiguity an agent will resolve wrongly at some point.
+
+**Naming hazard, recorded because it is invisible until it bites:** the `log` module would shadow
+the `log` crate. §2's zero-dependency rule makes that collision unreachable rather than merely
+unlikely — logging belongs at the edges, in `store` and `app`.
+
+### 7. ADRs are system-wide; `CONTEXT.md` files are local
+
+**Every ADR lives in `docs/adr/` under one sequence. Context-scoped `docs/adr/` directories are not
+used in this repository** — `docs/agents/domain.md` permits them, and we decline.
+
+**Every `CONTEXT.md` sits next to the code it describes**, with `CONTEXT-MAP.md` at the root.
+
+The principle: **a glossary describes code you are looking at; a decision constrains code you are
+not.** Vocabulary wants locality. Decisions want one discoverable sequence, because their whole
+value is reaching the agent who did not know to look for them.
+
+The evidence is one-sided. Every ADR here is cross-cutting — ADR-0004 places requirements on five
+separate tickets, ADR-0002 on four — so filing one under a single context would mean choosing a home
+for a decision that deliberately does not have one, and an agent working in `scheduling` would never
+find the row-format constraint that binds it.
+
+"Both are permitted" was rejected as worse than either: it reliably produces a split-brain where half
+the decisions are somewhere else, and it forces an agent to know which contexts exist before it can
+find the decisions.
+
+When a decision really is local to one context, it still goes in `docs/adr/`. Numbering is free;
+discoverability is not.
+
+### 8. Time and identity are values, not injected traits
+
+`leitner-core` has no `Clock` trait, no RNG trait, and no store trait.
+
+The ADRs make this unusually cheap. [ADR-0004 §4](0004-the-review-event-log.md) stamps the day number
+at write time and freezes it, and ADR-0001 §7 disables load balancing, calendar shaping and sibling
+avoidance to buy replay purity, seeding fuzz from card identity. **Replay therefore needs no clock
+and no randomness at all** — it is a pure function from ordered rows and configuration to memory
+state. Only two call sites need "now": stamping a new row, and computing "due today" against the
+device-local day. Both are at the edge, in `store` and `app`.
+
+A `Clock` trait would be a hypothetical seam by the two-adapter rule — one clock, one RNG, abstracted
+solely for tests that a plain parameter serves better. The payoff is concrete: ADR-0004 §8's
+clock-skew guard is tested by passing a `now` two years in the past and asserting the guard fires
+against the log's own contents.
+
+**Two testing rules follow.**
+
+- **No fake store.** Store tests open a real SQLite database in a temp directory. ADR-0007's design
+  *is* WAL, `BEGIN IMMEDIATE`, `ATTACH` and `INSERT OR IGNORE` on `(writer, seq)`; a fake would pass
+  while testing none of it, and its existence would make the real adapter's tests look redundant.
+  This is the one place slow tests are preferable to a second adapter.
+- **Merge commutativity is a property test.** ADR-0004 §2 makes merging set union with duplicates
+  dropped, so the claim the entire sync design rests on is that *any interleaving of two devices'
+  rows replays to the same state*. That is verifiable today, with no sync implementation and no
+  second device, and it is the highest-value test in the repository.
+
+### 9. What an implementing agent reads, in order
+
+Defined at the top of `CONTEXT-MAP.md`, ordered by what breaks silently if skipped:
+
+1. **`AGENTS.md`** — the rules that fail without an error message. ~40 lines, and every one of them
+   is a bug the compiler and the tests will not catch.
+2. **`CONTEXT-MAP.md`** — four crates, six contexts, and which `CONTEXT.md` covers your area.
+3. **The one or two relevant `CONTEXT.md` files** — vocabulary, so new code uses the ADRs' words.
+4. **Only the ADR sections that bind your context**, via the index in `CONTEXT-MAP.md`.
+
+Step 4 is the part that does real work: without an index, "read the ADRs" means 2,591 lines, and an
+agent that skims will miss the rule that breaks silently.
+
+`docs/research/` is deliberately **not** in the reading order. It is the evidence trail for
+reopening a decision, not reading for implementing one, and its findings are already distilled into
+the ADRs that cite it. An agent that starts there spends its budget before writing a line.
+
+### 10. What was verified, not merely asserted
+
+The layout was built and compiled rather than described, because ADR-0003 §5's constraints are the
+kind that read fine in prose and fail on a handset.
+
+| Check | Result |
+|---|---|
+| `cargo check --workspace --all-targets` | clean |
+| `cargo test --workspace` | 9 bidi tests pass |
+| `cargo apk build` (aarch64-linux-android) | **exit 0** — no `Bin is not compatible with Cdylib` |
+| APK contents | `AndroidManifest.xml` + `lib/arm64-v8a/libleitner_app.so`, no `classes.dex`, no `res/` |
+| `rusqlite` + `bundled` cross-compile | builds for `aarch64-linux-android` |
+| `cargo check -p leitner-store --target wasm32-unknown-unknown` | fails with §4's `compile_error!` |
+
+Release signing is deliberately **not** configured: the only working keystore is a developer's local
+debug key, an absolute path to one machine, and deployment is out of scope for this map.
+`cargo apk build --release` compiles fully and stops at signing.
+
+### 11. Export is a fifth crate, decided after ADR-0008 landed
+
+[ADR-0008](0008-the-deck-export-format.md) merged while this ticket was being resolved, and it
+changes the answer this ADR would otherwise have given. Its "Requirements this places on downstream
+tickets" section for #13 originally read *export belongs in `leitner-core`, and if a container format
+needs a binary framing library then §2's zero-dependency rule is consciously spent*. ADR-0008 §2
+chose a **zip archive**, so that rule would have been spent on the first line of the first
+implementation. It is not, and export gets its own crate instead.
+
+Two independent reasons, either of which would be enough:
+
+- **The dependency.** ADR-0008 §2 verified `zip` 8.6 with
+  `--no-default-features --features deflate-flate2-zlib-rs` at nine transitive crates with no `-sys`
+  crate. Nine crates is cheap, and it still has no business in a domain crate whose emptiness is the
+  property §2 exists to protect.
+- **The shape.** Export spans contexts. It reads `content` today, and ADR-0008 §1 reserves a
+  **progress** profile carrying ADR-0004 §11 interchange lines, which
+  [#37](https://github.com/amin-bf/leitner/issues/37) will specify — so it will read `log` too. A
+  thing that spans content and log is a peer of `replay`, not a module inside either.
+
+**`leitner-app` depends on `leitner-export`**, so the UI can offer import and export without
+reaching around the domain. Nothing in `leitner-core` depends on it, and nothing should: the
+container is a serialisation concern, and the domain must stay ignorant of it exactly as it stays
+ignorant of SQLite.
+
+This is the one decision in this ADR that was not put to the human first — ADR-0008 landed after the
+layout had been settled, and leaving it unplaced would have left six terms homeless and the
+zero-dependency rule ambiguous on day one. It is cheap to reverse: folding `export` back into
+`content` is a directory move plus a dependency line, for as long as no code has landed in it.
+
+## Requirements this places on downstream tickets
+
+### [#37 — backup and restore](https://github.com/amin-bf/leitner/issues/37)
+
+1. The **progress** profile lands in `leitner-export`, not a new crate — ADR-0008 §1 rejected a
+   second container, and §11 above gives the first one a home.
+2. It is the point at which `leitner-export` gains a dependency on `log`. That is expected, not a
+   violation.
+
+### [#39 / #40 — sync transport and the sync experience](https://github.com/amin-bf/leitner/issues/39)
+
+1. A `sync` context is **anticipated but not created**. It will depend on `log` (the version summary
+   is already `log`'s term) and will need a network dependency, which cannot go in `core` under §2 —
+   so expect a fifth crate, `leitner-sync`, rather than a fifth module.
+2. The version summary and the ahead/behind test are `log`'s, not sync's. Do not reimplement them.
+
+### [#42 — when parameter optimisation runs](https://github.com/amin-bf/leitner/issues/42)
+
+1. The optimiser is a `scheduling` concern, but *when it runs* is a `ui` one — Android freezes a
+   backgrounded app, so scheduling the work is a foreground-lifecycle question.
+
+### Any ticket that adds a platform capability
+
+1. It goes through `leitner-store::platform` or it does not exist. A second `#[cfg(target_os)]`
+   elsewhere in the workspace is a defect, not a shortcut.
+
+## Where the deferred glossaries went
+
+The five "provisional" glossary sections are now superseded. Each ADR's glossary block has been
+replaced by a pointer to its context:
+
+| ADR | Terms | Now of record in |
+|---|---|---|
+| ADR-0001 | 10 | `crates/core/src/scheduling/CONTEXT.md` |
+| ADR-0002 | 14 | `crates/core/src/content/CONTEXT.md` (dormant card → `replay`) |
+| ADR-0004 | 12 | `crates/core/src/log/CONTEXT.md` (cache → `replay`) |
+| ADR-0005 | 4 | `crates/core/src/content/CONTEXT.md` |
+| ADR-0007 | 6 | `crates/store/src/CONTEXT.md` (derivation version, cache high-water → `replay`) |
+| ADR-0008 | 6 | `crates/export/src/CONTEXT.md` (acquired kind definition also noted in `content`) |
+
+## Consequences
+
+- **`leitner-core`'s empty dependency list is now a decision with a guard.** Adding anything to it
+  is a deliberate act that should be argued in an ADR, not a convenience.
+- **Most of the specification is verifiable without hardware**, which is what makes an agent fleet
+  workable: the expensive checks (handset, APK, real SQLite) are a small minority.
+- **The `#[cfg]` seam is two functions and one file.** It is small enough to review at a glance,
+  which is the only reason a rule against eroding it can be enforced.
+- **The reading order is now a maintained artefact.** A new ADR that binds a context must be added
+  to `CONTEXT-MAP.md`'s index, or it becomes invisible to the agent it was written for.
+- **Six `CONTEXT.md` files are the vocabulary of record.** Drift between them and the ADRs is now
+  possible in a way it was not when the ADRs held the glossaries; the `CONTEXT.md` wins, and the ADR
+  keeps the reasoning.
+- **A sixth crate is expected for sync**, for the same reason export got the fifth: it needs a
+  network dependency that `leitner-core` cannot hold. The crate count is not a target; the rule is
+  that contexts are modules unless a dependency or a cross-context span forces otherwise.
+
+## Open items handed onward
+
+| Item | Owner |
+|---|---|
+| A `sync` crate, once the transport is chosen | [#39](https://github.com/amin-bf/leitner/issues/39) |
+| Whether `export` should have been a module in `content` after all | Reversible while the crate is empty |
+| Release signing configuration for the APK | Out of scope: deployment and CI |
+| Build sequencing for the implementing fleet — what lands first | The fleet, not this map |

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
Resolves [#14](https://github.com/amin-bf/leitner/issues/14) — the last decision before the spec is handed off to an implementing fleet. Lands [ADR-0009](../blob/worktree-wayfinder-14-workspace-layout/docs/adr/0009-crate-and-workspace-layout.md), `CONTEXT-MAP.md`, seven `CONTEXT.md` files, and a workspace skeleton that compiles for both targets.

## What was decided

| | |
|---|---|
| **Five crates** | `core` (pure domain) · `store` (SQLite + platform seam) · `export` (the `.ldeck` container) · `app` (egui, lib+cdylib) · `desktop` (a shim) |
| **Contexts are modules, not crates** | Nothing varies across a context line, and a crate-per-context split needs a shared-types crate on day one — a log row carries a `CardRef`, and scheduler fuzz is seeded from its 18-byte encoding |
| **`leitner-core` has zero dependencies** | The only way to state *this code cannot reach a database* such that the compiler enforces it. A trait store seam was rejected: one adapter, and `rusqlite` opens `:memory:` anyway |
| **The platform seam is three `#[cfg]` arms** | The third is a `compile_error!`, chosen over the tidier `android`/`not(android)` partition *because* that one can never fail to compile — a new target would take the desktop arm and fail on a device instead of in CI |
| **ADRs system-wide, `CONTEXT.md` local** | A glossary describes code you are looking at; a decision constrains code you are not |
| **Time and identity are values, not injected traits** | Replay needs no clock at all — day numbers are frozen at write time, fuzz is seeded from card identity |
| **A four-step reading order** | With an ADR-per-context index, because `docs/adr/` is now over 2,600 lines |

`replay` is the argued call: it produces scheduling state, so filing it under `scheduling` is tempting, but ADR-0002 §7's prize is precisely the *join* between content and log — and filing it under `scheduling` would forfeit the property that FSRS arithmetic is testable against a hand-written list of grades.

It is also the only context with **no ADR of its own**, which is the strongest argument for giving it a `CONTEXT.md`: its rules sit scattered across ADR-0001 §7, ADR-0002 §7, ADR-0004 §9 and ADR-0007 §2.

## Verified, not asserted

ADR-0003 §5's constraints are the kind that read fine in prose and fail on a handset, so the skeleton was built and run rather than described:

| Check | Result |
|---|---|
| `cargo fmt --check`, `cargo clippy --workspace --all-targets` | clean |
| `cargo test --workspace` | 9 bidi tests pass |
| `cargo apk build` (aarch64-linux-android) | **exit 0** — no `Bin is not compatible with Cdylib` panic |
| APK contents | `AndroidManifest.xml` + one `.so`. No `classes.dex`, no `res/` |
| `rusqlite` + `bundled` cross-compile | builds for `aarch64-linux-android` |
| `cargo check -p leitner-store --target wasm32-unknown-unknown` | fails on the `compile_error!`, as designed |

## Glossaries moved

Six ADRs marked their glossary provisional pending this ticket; ~52 terms now live in their contexts, with each ADR keeping the reasoning and pointing at the new home. Three terms moved to a context other than their ADR's, because they name a join: **dormant card** (0002), **cache** (0004), **derivation version** and **cache high-water** (0007) all went to `replay`.

## One decision that was not grilled first

[ADR-0008](https://github.com/amin-bf/leitner/pull/43) (deck export) merged *while this ticket was being resolved*, and it chose a **zip archive** container. The pre-existing plan put export in `leitner-core`, which would have spent the zero-dependency rule on the first line of the first implementation.

So **export became a fifth crate** — also the right shape independently, since it spans `content` and, once [#37](https://github.com/amin-bf/leitner/issues/37) specifies the progress profile, `log`. Reasoning is in ADR-0009 §11, and it is cheap to reverse while the crate is still empty: a directory move plus a dependency line.

## Also lands: two rules for parallel sessions

`AGENTS.md` gains a **Landing work** section recording the two things that broke during this ticket and are invisible until they bite: **if commit signing fails, stop and ask** rather than falling back to `--no-gpg-sign` (main is fully signed and this repo merges rather than squashes), and **re-check the highest ADR number immediately before committing**, since the worktree branches from `origin/main` and never sees later merges.

## Carried over

The bidi helper comes from tag `prototypes/issue-11` as ADR-0003 §7 requires, with **tests written for the first time**. The prototype verified it by eye, on a handset, and by a Persian reader — evidence, but not a regression guard. The nine tests assert on the visual-order string handed to epaint, so they need no GPU, window or font.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
