### PR TITLE
Docs / Correct the Crate and Context Counts After leitner-sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,8 @@ never seeing what merged afterwards. Two things break silently because of it.
 
 ## Start with the context map
 
-**[`CONTEXT-MAP.md`](./CONTEXT-MAP.md) is the entry point to the codebase** — the five crates, the
-seven contexts, and an index saying which ADR sections bind which context. `docs/adr/` is over 2,600
+**[`CONTEXT-MAP.md`](./CONTEXT-MAP.md) is the entry point to the codebase** — the six crates, the
+eight contexts, and an index saying which ADR sections bind which context. `docs/adr/` is over 2,600
 lines; the index is what stops "read the ADRs" from meaning all of them.
 
 Read this file first, then the context map, then the `CONTEXT.md` for the area you are touching.
@@ -52,13 +52,16 @@ Read this file first, then the context map, then the `CONTEXT.md` for the area y
 
 ## The workspace
 
-Five crates, laid out in [ADR-0009](./docs/adr/0009-crate-and-workspace-layout.md):
+Six crates, laid out in [ADR-0009](./docs/adr/0009-crate-and-workspace-layout.md) and extended by
+[ADR-0013 §11](./docs/adr/0013-the-sync-transport.md):
 `leitner-core` (the domain, pure), `leitner-store` (SQLite and the platform seam), `leitner-export`
-(the `.ldeck` container), `leitner-app` (egui, lib + cdylib), `leitner-desktop` (a shim, forced by
-`cargo-apk`).
+(the `.ldeck` container), `leitner-sync` (publishing to the remote; holds the network dependencies),
+`leitner-app` (egui, lib + cdylib), `leitner-desktop` (a shim, forced by `cargo-apk`).
 
-Contexts are **modules, not crates**. Vocabulary lives in a `CONTEXT.md` beside the code; decisions
-live system-wide in `docs/adr/`, and context-scoped `docs/adr/` directories are not used here.
+Contexts are **modules, not crates** — with two exceptions, both for the same reason: `export` and
+`sync` hold dependencies `leitner-core` may not have. A context becomes a crate only when it must
+carry one. Vocabulary lives in a `CONTEXT.md` beside the code; decisions live system-wide in
+`docs/adr/`, and context-scoped `docs/adr/` directories are not used here.
 
 ### Rules that are easy to break silently
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,16 @@ Agent instructions live in [`AGENTS.md`](./AGENTS.md). The codebase entry point 
 
 ## Layout
 
-A five-crate workspace, laid out in
-[ADR-0009](./docs/adr/0009-crate-and-workspace-layout.md):
+A six-crate workspace, laid out in
+[ADR-0009](./docs/adr/0009-crate-and-workspace-layout.md) and extended by
+[ADR-0013 §11](./docs/adr/0013-the-sync-transport.md):
 
 | Crate | What it is |
 |---|---|
 | `leitner-core` | The domain, entire and pure. Zero dependencies — testable with no database, window or handset. |
 | `leitner-store` | SQLite persistence and the whole platform seam (two functions wide). |
 | `leitner-export` | The `.ldeck` deck-file container and import policy. Holds the zip dependency. |
+| `leitner-sync` | Publishing the log to the remote and reading it back. Holds the network dependencies. |
 | `leitner-app` | The egui application. `lib` + `cdylib`; the Android entry point lives here. |
 | `leitner-desktop` | A twenty-line shim, forced by `cargo-apk`. Keep it empty. |
 

--- a/docs/adr/0009-crate-and-workspace-layout.md
+++ b/docs/adr/0009-crate-and-workspace-layout.md
@@ -54,6 +54,13 @@ them splits `eframe` per target.
 
 The rest are chosen, and §2, §4 and §11 say why.
 
+> **Extended by [ADR-0013 §11](0013-the-sync-transport.md)**: a sixth crate, `crates/sync/`
+> (`leitner-sync`, lib), holds HTTP, TLS and OAuth. **This is not an overturning** — `CONTEXT-MAP.md`
+> recorded the prediction as this ADR landed (*"a `sync` context is anticipated, not created… expect
+> a sixth crate rather than a fifth module"*), on §2's ground that a network dependency cannot live
+> in `leitner-core`. The count in this heading is left as written, because it records what was
+> decided here; the live list is `CONTEXT-MAP.md`'s.
+
 ### 2. `leitner-core` has no dependencies, and that is its interface
 
 Its `[dependencies]` section is empty, deliberately and permanently. No `rusqlite`, no `egui`, no


### PR DESCRIPTION
Follow-up to #50, which added the sixth crate (`leitner-sync`) and updated `CONTEXT-MAP.md` but left three other documents saying five.

## Why this is worth its own PR

`AGENTS.md` is the damaging one. Its own reading order puts it **first** — ahead of `CONTEXT-MAP.md` — so an agent met a crate list with `leitner-sync` missing before reaching the map that corrects it, while `CONTEXT-MAP.md` said "Six crates" two files later. A contradiction between the two entry-point documents is exactly the kind of thing that costs someone a confused half-hour.

## Changes

| File | Was | Now |
|---|---|---|
| `AGENTS.md` | "the five crates, the seven contexts"; a five-item crate list | six / eight, with `leitner-sync` in the list |
| `README.md` | "A five-crate workspace" + a five-row table | six-crate workspace, `leitner-sync` row added |
| `docs/adr/0009` §1 | no pointer to the sixth crate | an amendment note |

Two judgement calls worth flagging:

**ADR-0009 §1 keeps its "Five crates" heading.** An ADR records what was decided *at the time*, so it gets an amendment blockquote rather than a rewrite — the same treatment ADR-0004 §7 got from ADR-0008. The note also makes the relationship explicit: the sixth crate was `CONTEXT-MAP.md`'s own prediction (*"expect a sixth crate rather than a fifth module"*), not a reversal of ADR-0009.

**`AGENTS.md`'s "contexts are modules, not crates" is now nuanced rather than restated.** There are two exceptions, `export` and `sync`, and they share one reason — so the line now says a context becomes a crate exactly when it must carry a dependency `leitner-core` may not have. Stating the rule flatly with two live exceptions is worse than stating the rule that generates them.

## Checks

- `cargo check --workspace` passes.
- No stale "five crates" / "seven contexts" strings remain outside ADR-0009 §1's heading, which is deliberate.
- Relative links in all four touched files resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)