### PR TITLE
Backup and Restore / Specify the Collection Archive and Settle Collection Identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,19 +164,22 @@ A `.ldeck` file is a **zip archive** carrying deck content and never review prog
    definition is used only for kinds this build does not ship. Break this and an import becomes a
    remote path to reordering a kind's `cards` list, which silently retypes every accumulated review
    onto the wrong card and cannot be repaired from the log.
-2. **Never write an ADR-0004 §7 stamp into an export.** A stamp is a counter plus a **writer id**,
-   which is a device fingerprint, and its counter is meaningless outside its own collection. Import
-   assigns fresh local stamps — and only to values whose content actually differs, or every import
-   floods the user's own devices with edits.
+2. **Never write an ADR-0004 §7 stamp into a *deck* export.** A stamp is a counter plus a **writer
+   id**, which is a device fingerprint, and its counter is meaningless outside its own collection.
+   Import assigns fresh local stamps — and only to values whose content actually differs, or every
+   import floods the user's own devices with edits. The **`collection` profile is the exact opposite**
+   and carries stamps byte for byte, because a restore does not cross a collection boundary; the
+   profile is what selects the rule, which is why it is a profile and not a flag.
 3. **Import branches on deck id, and the branches have opposite rules.** Id already held → the file
    wins and may move notes into that deck (ADR-0005 §9). Id new → notes already held are never touched
    or moved (ADR-0005 §2). Applying one rule everywhere lets a stranger's file take notes out of decks
    the user already has.
 4. **The importer accepts only the known member names and the `media/` prefix**, rejecting absolute
    paths, `..` segments and symlink entries. Zip path traversal is this container's classic defect.
-5. **Export must be byte-for-byte deterministic** — fixed member order, pinned timestamps, fixed
-   deflate level, no extra fields. Zip's per-member timestamps otherwise make identical content export
-   as different bytes, which leaks build time and breaks "same revision, same file".
+5. **A *deck* export must be byte-for-byte deterministic** — fixed member order, pinned timestamps,
+   fixed deflate level, no extra fields. Zip's per-member timestamps otherwise make identical content
+   export as different bytes, which leaks build time and breaks "same revision, same file". This binds
+   the `deck` profile only: a collection archive carries a creation date instead (ADR-0016 §11).
 6. **The revision advances only when the content digest changes**, not on every export. Incrementing
    per export inflates the counter and makes relaying an unmodified deck emit a phantom revision that
    competes with the original author's next one.
@@ -213,7 +216,48 @@ remote costs one republish and no data.
    fixed-width zero-padded range in the key may not, because the listing *is* ADR-0004 §2's version
    summary and it works by lexicographic sort.
 6. **Never present the sync folder as a backup.** It is hidden, it is deleted when the user removes
-   the app's data, and backup is [#37](https://github.com/amin-bf/leitner/issues/37)'s to specify.
+   the app's data, and backup is the separate `.lcoll` archive specified in
+   [ADR-0016](./docs/adr/0016-backup-and-restore.md).
+
+## Backup and restore
+
+A **collection archive** is a `.lcoll` file — the same zip container as a deck file, carrying a
+different profile — holding the log verbatim plus everything that settles, and written only when the
+user asks. Chosen in [ADR-0016](./docs/adr/0016-backup-and-restore.md). Sync does **not** discharge
+it: sync is opt-in, so a never-enrolled user has nothing, and sync propagates a deletion rather than
+archiving against it.
+
+### Rules that are easy to break silently
+
+1. **Restore is a merge and never removes anything, and a replace is not implementable.** Every
+   device holds the whole log and merge is set union, so a wipe-then-install is undone by the next
+   sync — the peers still hold every row. It follows that backup protects against **loss, not against
+   unwanted change**: an overwritten field carries a newer stamp and must win, or ADR-0004 §7's
+   causality rule breaks. Say this to users; "restore" universally implies replacement.
+2. **A writer id is never adopted; a collection id is never re-minted.** The two halves of identity
+   take *opposite* rules, and swapping them is silent in both directions — adopt a writer id and two
+   devices become one writer with reviews dropped on merge; re-mint a collection id and the check
+   that tells an archive of yours from a stranger's stops working. The gate is one rule at both the
+   restore and the enrolment seam: **an empty collection adopts, a non-empty one refuses.** "Empty"
+   means no log rows under this device's own writer id and nothing on the mutable surface — *not* "no
+   notes", or a fresh install can never join an existing account.
+3. **The `collection` profile does not inherit ADR-0008 §12's byte-for-byte determinism.** That rule
+   exists so an artifact sent to strangers does not leak build time; a personal archive needs the
+   creation date it forbids, or a user cannot tell two backups apart. **Minimal disclosure still
+   binds both profiles** — never auto-populate an author name, a device label, or any ambient
+   identity.
+4. **`derived.db` stays outside the backup set**, beside the writer marker. It is disposable by
+   design, so backing it up protects nothing while spending the 25 MB platform quota and hastening
+   the cutoff — which arrives after roughly **nine months** of heavy use, not the two years ADR-0007
+   §6 states (it read that ADR's raw-interchange row where Auto Backup covers files on disk).
+5. **No file picker, on either platform, and no text field for a filename or a passphrase.** Activity
+   *results* need a Java subclass and therefore a dex, spending ADR-0003's Gradle-free APK; launch
+   intents and dropped files need neither and are fine. And rule 8 of the client stack makes Android
+   text input ASCII-only, so a passphrase set on the desktop in the user's own language cannot be
+   typed on the phone — which is why **archives are never encrypted**.
+6. **The platform seam rule is per crate.** `leitner-store::platform` keeps exactly two functions;
+   a crate needing the platform for an unrelated reason gets its own module under the same three-arm
+   discipline. `leitner-export` has one — put, get, list.
 
 ## Agent skills
 

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -30,7 +30,7 @@ Six crates. Two of the boundaries are forced by the toolchain; see ADR-0009 §1.
 |---|---|---|
 | `leitner-core` | [`crates/core/`](./crates/core) | The domain, entire and pure. **Zero dependencies**, permanently. |
 | `leitner-store` | [`crates/store/`](./crates/store) | SQLite persistence and the whole platform seam. |
-| `leitner-export` | [`crates/export/`](./crates/export) | The `.ldeck` container and the import policy. Holds the zip dependency. |
+| `leitner-export` | [`crates/export/`](./crates/export) | The `.ldeck` and `.lcoll` containers, the import policy, and the user-files platform seam. Holds the zip dependency. |
 | `leitner-sync` | [`crates/sync/`](./crates/sync) | Publishing to the remote and reading it back. Holds the network dependencies. |
 | `leitner-app` | [`crates/app/`](./crates/app) | The egui application, the bidi helper, the Android entry point. |
 | `leitner-desktop` | [`crates/desktop/`](./crates/desktop) | A twenty-line shim. Forced by `cargo-apk`; keep it empty. |
@@ -53,7 +53,7 @@ Two rules about this table that are easy to break:
 | Scheduling | [`crates/core/src/scheduling/`](./crates/core/src/scheduling/CONTEXT.md) | FSRS arithmetic, grades, memory state, boxes |
 | Replay | [`crates/core/src/replay/`](./crates/core/src/replay/CONTEXT.md) | The join: what exists, what state it is in, what is due |
 | Store | [`crates/store/src/`](./crates/store/src/CONTEXT.md) | The two databases, device identity, the platform seam |
-| Export | [`crates/export/src/`](./crates/export/src/CONTEXT.md) | Deck files, profiles, revisions, import policy |
+| Export | [`crates/export/src/`](./crates/export/src/CONTEXT.md) | Deck files, collection archives, profiles, revisions, import policy |
 | Sync | [`crates/sync/src/`](./crates/sync/src/CONTEXT.md) | The remote, namespaces, objects, roll-up, enrolment |
 | UI | [`crates/app/src/`](./crates/app/src/CONTEXT.md) | Screens, the session, the bidi helper |
 
@@ -75,8 +75,11 @@ content ──┬──> scheduling ──┐
   due, what box is this card in, record this grade — sit the log, the content, the scheduler and the
   cache.
 - **`export` is a crate, not a module, for the same reason `replay` is a context**: it spans content
-  and (once #37 specifies the progress profile) the log, so it belongs inside neither — and it holds
-  the zip dependency that `leitner-core` cannot.
+  and — now that [ADR-0016](./docs/adr/0016-backup-and-restore.md) has specified the `collection`
+  profile — the log, so it belongs inside neither, and it holds the zip dependency that
+  `leitner-core` cannot. It is also **the second crate with a platform seam**: ADR-0016 §5 puts
+  put/get/list for user-visible files here, three `#[cfg]` arms with a `compile_error!` third, so
+  that `leitner-store::platform` stays at exactly two functions. **The seam rule is per crate.**
 - **`sync` is a crate for the reason this file predicted**: it needs HTTP, TLS and OAuth, which
   `leitner-core` cannot hold. [ADR-0013](./docs/adr/0013-the-sync-transport.md) realised the
   anticipated sixth crate rather than overturning anything. It depends on `log` and knows nothing
@@ -93,11 +96,11 @@ Read the ADR sections in your row. Read the whole ADR only if you are changing t
 | `log` | [0004](./docs/adr/0004-the-review-event-log.md) | 0002 §7, 0001 §6, 0010 §5, 0011 §5, 0013 §12, 0014 §6 |
 | `scheduling` | [0001](./docs/adr/0001-scheduling-algorithm-and-grade-scale.md) | 0004 §4, 0004 §5, 0014 §6 |
 | `replay` | *none of its own* | 0001 §7, 0002 §7, 0004 §9, 0007 §2, 0010 §2, 0011 §8, 0012 §5, 0012 §6 |
-| `store` | [0007](./docs/adr/0007-the-local-store.md) | 0004 §11, 0003 §5, 0013 §9 |
-| `export` | [0008](./docs/adr/0008-the-deck-export-format.md) | 0005, 0002 §9, 0004 §11, 0011 §7 |
-| `sync` | [0013](./docs/adr/0013-the-sync-transport.md) | 0004 §2, 0004 §7, 0004 §10, 0007, 0014 §7 |
-| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md), [0010](./docs/adr/0010-leeches.md), [0011](./docs/adr/0011-new-card-rate-and-daily-limits.md), [0012](./docs/adr/0012-the-note-authoring-experience.md), [0014](./docs/adr/0014-when-parameter-optimisation-runs.md) | 0002 §4 |
-| *the workspace itself* | [0009](./docs/adr/0009-crate-and-workspace-layout.md) | 0013 §11, 0013 §12 |
+| `store` | [0007](./docs/adr/0007-the-local-store.md) | 0004 §11, 0003 §5, 0013 §9, 0016 §3, 0016 §7 |
+| `export` | [0008](./docs/adr/0008-the-deck-export-format.md), [0016](./docs/adr/0016-backup-and-restore.md) | 0005, 0002 §9, 0004 §11, 0011 §7 |
+| `sync` | [0013](./docs/adr/0013-the-sync-transport.md) | 0004 §2, 0004 §7, 0004 §10, 0007, 0014 §7, 0016 §10 |
+| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md), [0010](./docs/adr/0010-leeches.md), [0011](./docs/adr/0011-new-card-rate-and-daily-limits.md), [0012](./docs/adr/0012-the-note-authoring-experience.md), [0014](./docs/adr/0014-when-parameter-optimisation-runs.md) | 0002 §4, 0016 §6, 0016 §11, 0016 §12 |
+| *the workspace itself* | [0009](./docs/adr/0009-crate-and-workspace-layout.md) | 0013 §11, 0013 §12, 0016 §5 |
 
 **`replay` having no ADR of its own is why it is a context.** Its rules were each written for another
 purpose and sit scattered across four documents; its `CONTEXT.md` is the only place they appear as

--- a/crates/export/src/CONTEXT.md
+++ b/crates/export/src/CONTEXT.md
@@ -24,8 +24,31 @@ handed to another person.
 _Avoid_: Export, bundle, package — all of which also name the act rather than the thing.
 
 **Profile**:
-Which payload a container carries: `deck` (specified) or `progress` (reserved for #37). Declared in
-the manifest, and distinguished to the operating system by extension.
+Which payload a container carries: `deck` or `collection`. Declared in the manifest, and
+distinguished to the operating system by extension. The **profile is the discriminator that selects
+the stamp rule** — import restamps, restore preserves — which is why it is a profile and not a flag.
+
+**Collection archive**:
+A `.lcoll` zip archive carrying the whole collection: the log verbatim, plus everything that settles,
+minus device identity and credentials. The artifact a user keeps for themselves.
+_Avoid_: Backup file — the artifact is not a backup until the user moves it off the device.
+
+**Collection profile**:
+The `collection` payload. Its selection rule is *everything that settles, plus the log, minus device
+identity and credentials* — **not** "all decks". It carries what the deck profile deliberately drops:
+unfiled notes, stamps byte for byte, per-deck revisions, suspensions, the new-card rate, device
+labels.
+
+**Collection id**:
+A UUIDv4 identifying a collection across devices and files. Minted once, **adopted and never
+re-minted** — the exact opposite of a writer id's never-adopt rule. Of record in
+[`store`](../../store/src/CONTEXT.md), where it is minted; named here because it is what the
+container carries.
+
+**User-files seam**:
+`leitner-export`'s own `platform` module: **put, get, list**, three `#[cfg]` arms with a
+`compile_error!` third. How an artifact reaches a place the user can see. Deliberately
+[ADR-0013](../../../docs/adr/0013-the-sync-transport.md) §1's shape reused.
 
 **Revision**:
 A per-deck monotonic integer declared by the file, advancing only when the deck's content digest
@@ -56,3 +79,16 @@ deck id, never a user's choice.
   itself; do not add a policy to contain it, and do not add a log member to the deck profile.
 - **One container, not two.** A backup artifact reuses this container with a different profile.
   Two containers means two parsers, two versioning stories and two sets of path-traversal rules.
+- **Restore is a merge and never removes anything.** A replace cannot stick: every device holds the
+  whole log, merge is set union, so the next sync re-merges whatever a wipe removed. It follows that
+  backup protects against **loss, not against unwanted change** — an overwritten field carries a
+  newer stamp and must win.
+- **The `collection` profile does not inherit byte-for-byte determinism.** That rule exists for an
+  artifact sent to strangers; a personal archive needs the creation date it forbids. **Minimal
+  disclosure still binds both** — never auto-populate an author name, a device label or any ambient
+  identity.
+- **Never put a credential in an archive**, and never put `writer_id` or `seq_highwater` in one. A
+  restored device must mint a fresh writer id, or two devices become one writer and the union drops
+  reviews.
+- **No file picker, on either platform.** Activity *results* need a Java subclass and therefore a
+  dex, which spends the Gradle-free APK. Launch intents and dropped files are fine; results are not.

--- a/crates/store/src/CONTEXT.md
+++ b/crates/store/src/CONTEXT.md
@@ -26,6 +26,24 @@ _Avoid_: Max seq, last seq — the names that invite the `MAX(seq) WHERE writer 
 The copy of the writer id held outside the backup set. Its absence or disagreement means this
 collection was copied here, and a fresh writer id must be minted.
 
+**Collection id**:
+A UUIDv4 naming *this collection*, held in `local`, minted once at first launch beside the writer
+marker. **Adopted and never re-minted** — the exact opposite of the writer id, and the two rules must
+never be swapped:
+
+| | Writer id | Collection id |
+|---|---|---|
+| On finding one you did not mint | **never adopt** — mint fresh | **always adopt** — never re-mint |
+| Why | a sequence number promises sole authorship | every device of one collection must agree |
+
+It is **not** on the mutable surface — it must never settle — and **not** in the log, since it is not
+an input to replay.
+
+**Empty collection**:
+One that has authored **no log rows under this device's own writer id and nothing on the mutable
+surface**. The test that decides whether a device adopts a collection id it meets or refuses it. Not
+"has no notes" — an imported deck with no reviews is still empty by this test.
+
 **Line**:
 The `log.line` column: the interchange row exactly as received. **The only authoritative column** —
 every other column in the table, and everything in `derived.db`, is derived from it and may be
@@ -41,6 +59,10 @@ dropped and rebuilt.
   deferred transaction loses updates between two processes.
 - **Derived columns do not have to round-trip. Only `line` does.**
 - **The writer marker lives outside the backup set** — never move it into the data directory.
+- **`derived.db` lives outside the backup set too.** It is disposable by design, so backing it up
+  protects nothing while burning the 25 MB platform quota and hastening the silent cutoff.
+- **A writer id is never adopted; a collection id is never re-minted.** Applying either rule to the
+  other identity is silent and destructive in opposite directions.
 - **WAL on both files; `synchronous=FULL` on the collection, `OFF` on the cache.**
 
 ## The platform seam
@@ -52,3 +74,11 @@ target fails the build rather than silently taking the desktop path.
 **A third function appearing here means the seam is eroding.** Everything else in this crate is
 portable — `rusqlite` with `bundled` compiles unchanged for desktop and Android, proven on the
 handset in #7.
+
+**The seam rule is per crate, not per workspace.** [ADR-0013 §12](../../../docs/adr/0013-the-sync-transport.md)
+recorded a contradiction — ADR-0009's handoff sends every platform capability *here*, while the rule
+above forbids a third arriving — and [ADR-0016 §5](../../../docs/adr/0016-backup-and-restore.md)
+resolved it: a crate that must touch the platform for an unrelated reason gets **its own** `platform`
+module under the same three-arm discipline. `leitner-export` has one (put/get/list for user-visible
+files). **This module still stays at two functions**, and that limit is now load-bearing rather than
+merely tidy — it is the reason the erosion signal still means anything.

--- a/crates/sync/src/CONTEXT.md
+++ b/crates/sync/src/CONTEXT.md
@@ -68,8 +68,22 @@ snapshot and change stream are the same thing paid for at different times.
 
 **Enrolment**:
 Granting one device access to the remote, once. Uses the device flow: a short code entered on
-whatever device the user likes, so no credential is ever typed into this application.
+whatever device the user likes, so no credential is ever typed into this application. Enrolment also
+runs the **identity check** below.
 _Avoid_: Login, sign-in, pairing — there is no account of ours and no device-to-device step.
+
+**Identity check**:
+One rule, run identically at enrolment and at restore
+([ADR-0016 §10](../../../docs/adr/0016-backup-and-restore.md)): **an empty collection adopts the
+collection id it meets; a non-empty one refuses any but its own.** A brand-new install has already
+minted an id, so a plain "ids differ → refuse" would stop a fresh device ever joining an existing
+account — the commonest path there is. A refusal must name the mismatch *and* state the way out
+(archive, clear data, restore, enrol), or the user is left holding a device that will not sync.
+
+This is what upgrades [ADR-0013 §10](../../../docs/adr/0013-the-sync-transport.md) from a structural
+accident to a real check: "one account is one collection" holds because a device cannot *see* another
+collection's folder, which stops being true the moment a user has two accounts and picks the wrong
+one.
 
 **Grant**:
 What enrolment obtains and what revocation removes. **Revocation is all-or-nothing**: every device

--- a/docs/adr/0004-the-review-event-log.md
+++ b/docs/adr/0004-the-review-event-log.md
@@ -320,6 +320,17 @@ bytes. **Accepted cost**: undeleting restores the schedule but not the text, whi
 backup or an export. Delete means gone, which is also the right answer for a user deleting something
 they want rid of.
 
+> **Discharged by [ADR-0016 §4](0016-backup-and-restore.md)**, which specifies the backup this
+> sentence spends. The mechanism is worth knowing because it looks as though it should not work: the
+> content above is **discarded, not superseded by a competing value**, so an archive predating the
+> delete carries those field values with old stamps and meets nothing to lose to under the counter
+> rule. Undelete the note, restore, and the text returns — ADR-0002 §7's *"history reattaches by
+> itself"* applied to content instead of schedule.
+>
+> **The limit that follows from the same rule**: a note whose text was *overwritten* rather than
+> deleted cannot be recovered this way, because the newer stamp must win or the causality rule above
+> is broken. Backup protects against loss, not against unwanted change.
+
 > **Amended by [ADR-0008 §5 and §8](0008-the-deck-export-format.md)**: a deleted note also retains its
 > `deck` reference — id, flag, deck reference, stamp, roughly sixteen bytes above the figure quoted
 > here. Without it a retraction cannot be attributed to a deck, so a deck-scoped export cannot select

--- a/docs/adr/0007-the-local-store.md
+++ b/docs/adr/0007-the-local-store.md
@@ -310,6 +310,22 @@ costing about 24 bytes in the version summary, which §2 already budgets for.
   doesn't back up data to the cloud."* At §10's projections we cross that in about two years of
   heavy use. This is a fact for the map's **Backup and restore** fog, not something this ADR solves.
 
+  > **Amended twice by [ADR-0016 §7](0016-backup-and-restore.md).**
+  >
+  > **The figure is wrong: the crossing is about nine months of heavy use, not two years.** This
+  > bullet reads the wrong row of §10's own table — it used the **raw interchange** projection
+  > (11 MB/yr → 2.3 years), but Auto Backup covers *files on disk*, which is §10's other row at
+  > **~33 MB/yr → ~0.76 years**. The hazard identified here is roughly 2.5× more urgent than stated.
+  >
+  > **And `derived.db` moves out of the backup set**, to `getNoBackupFilesDir()` beside the writer
+  > marker above. §3 makes the cache disposable and rebuildable by design, yet this section puts it
+  > where Auto Backup collects it — so it is uploaded, counts against the 25 MB quota, and
+  > accelerates this very cutoff, in order to protect a file whose defining property is that losing
+  > it costs nothing. `ATTACH` is indifferent to the path, so this needs no new mechanism.
+  >
+  > ADR-0016 keeps Auto Backup **on**: the writer marker above already made restore safe, and for a
+  > user who never enrols sync and never makes an archive it is the only recovery there is.
+
 ### 7. Durability: WAL on both files, `FULL` on the collection, `OFF` on the cache
 
 ```

--- a/docs/adr/0008-the-deck-export-format.md
+++ b/docs/adr/0008-the-deck-export-format.md
@@ -43,6 +43,14 @@ full. A **progress** profile — ADR-0004 §11 interchange lines — is *reserve
 and [#37](https://github.com/amin-bf/leitner/issues/37) decides whether and how a whole-collection
 artifact is offered.
 
+> **Amended by [ADR-0016 §2](0016-backup-and-restore.md): the reserved profile is specified as
+> `collection`, not `progress`.** It carries content *and* the log — unfiled notes, the whole mutable
+> surface with its stamps intact, per-deck revisions and suspensions, none of which the deck profile
+> exports — so the reserved name understates the payload by half. That matters beyond naming: the
+> selection rule is *everything that settles, plus the log, minus device identity and credentials*,
+> and a profile named for half its contents is how the wrong rule gets implemented. The extension is
+> `.lcoll` (ADR-0016 §9), discharging §10's handoff.
+
 Rejected: **one artifact with progress as an inclusion choice** ("export deck ☑ include my progress").
 Not on privacy grounds, though those apply, but because the option is **not expressible**:
 
@@ -308,6 +316,11 @@ A distinct extension per profile, sharing one container format, is how the opera
 user tell a deck file from a whole-collection artifact **before** opening it. Naming the progress
 profile's extension belongs to [#37](https://github.com/amin-bf/leitner/issues/37).
 
+> **Discharged by [ADR-0016 §9](0016-backup-and-restore.md)**: the extension is **`.lcoll`**, with
+> `application/vnd.leitner.collection+zip` in a `stored` `mimetype` member first in the archive, by
+> the mechanism above unchanged. ADR-0016 §5 also supplies what this ADR never had — **how a file
+> reaches the user's filesystem at all**, which was unowned for `.ldeck` too.
+
 ### 11. Authority follows deck id
 
 Read literally, ADR-0005 §2 and §9 disagree, and an implementer meeting a file that names a note held
@@ -346,6 +359,15 @@ is typed deliberately or it is absent.
 **Export is byte-for-byte deterministic**: fixed member order, all member timestamps pinned to a
 constant, a fixed deflate level, no extra fields, and no platform-dependent creator or attribute
 variance.
+
+> **Amended by [ADR-0016 §11](0016-backup-and-restore.md): determinism binds the `deck` profile
+> only.** The reasoning above is entirely about an artifact **sent to strangers** — build time must
+> not leak, and §9's "same revision, same file" must be a property rather than an approximation. The
+> `collection` profile is the opposite artifact: it goes to nobody, it has no revision, and a backup
+> without a date is close to useless, since a user with three archives in a folder must tell them
+> apart before restoring the wrong one. It therefore **carries a creation timestamp in its manifest**
+> and does not inherit this paragraph. **Minimal disclosure above still binds both profiles** — no
+> author name, no device label, no ambient identity ever auto-populated.
 
 > **Amended by [ADR-0011 §7](0011-new-card-rate-and-daily-limits.md): `notes.jsonl` lines are
 > emitted in `(position, note id)` order.** Determinism above fixes the order of zip *members* but

--- a/docs/adr/0013-the-sync-transport.md
+++ b/docs/adr/0013-the-sync-transport.md
@@ -429,6 +429,15 @@ which is the form [#37](https://github.com/amin-bf/leitner/issues/37) actually m
 crosses a collection boundary so ADR-0004 §7 stamps reset, a restore re-enters the same collection so
 they must travel byte for byte. Nothing here settles that.
 
+> **Completed by [ADR-0016 §3](0016-backup-and-restore.md), which mints a collection id** — adopted
+> and never re-minted, the exact opposite of the writer id's never-adopt rule. Two consequences for
+> this section. Import versus restore is settled by the **profile** (`deck` versus `collection`), not
+> by this scoping. And **§10's guarantee is upgraded from a structural accident to a checked
+> invariant**: "cannot merge two collections" here really means *cannot see the other one*, which
+> stops being true the moment a user has two accounts and picks the wrong one. ADR-0016 §10 makes it
+> an actual check — an empty collection adopts the identity it meets, a non-empty one refuses any but
+> its own, at both the restore and the enrolment seam.
+
 ### 11. `leitner-sync` is the sixth crate
 
 Anticipated rather than new: `CONTEXT-MAP.md` already records that *"a `sync` context is anticipated,
@@ -481,6 +490,13 @@ as a surprise. The shape of the fix, when it is needed: the seam rule is per cra
 workspace — `leitner-store` keeps exactly two functions, and a crate that must touch the platform for
 an unrelated reason gets its own module under the same three-arm discipline.
 
+> **Resolved by [ADR-0016 §5](0016-backup-and-restore.md), which adopted exactly that fix.** It was
+> the next ticket, and it had no escape: an archive that cannot leave the device is not a backup, and
+> a file picker was unavailable because activity *results* need a Java subclass and therefore a dex.
+> Its put/get/list seam lives in a `platform` module **inside `leitner-export`**, three arms, third a
+> `compile_error!` — so `leitner-store::platform` keeps exactly two functions and §4's erosion signal
+> survives intact. **The seam rule is per crate.**
+
 ## Requirements this places on downstream tickets
 
 ### [#40 — the sync experience](https://github.com/amin-bf/leitner/issues/40)
@@ -509,6 +525,16 @@ an unrelated reason gets its own module under the same three-arm discipline.
    transport*; distinguishing an import from a restore still needs the answer #37 owns.
 3. **A restore re-enters the same collection**, so ADR-0007's writer-marker exclusion still governs
    the fork, and §9's decision to let the *token* ride the backup set does not weaken it.
+
+> **All three discharged by [ADR-0016](0016-backup-and-restore.md).** (1) is honoured: §1 there
+> specifies a separate archive and names the three failures sync does not cover, and the sync folder
+> is never offered as one. (2) is completed by §3's collection id — see the note in §10 above. (3) is
+> confirmed and restated in §12: a restored device mints a fresh writer id and is a **clean fork
+> rather than a resurrection**, and the archive carries no credential at all.
+>
+> ADR-0016 also places two requirements back on **[#40](https://github.com/amin-bf/leitner/issues/40)**:
+> enrolment must run §10's identity check and both outcomes are UI moments, and the collection id is
+> published as one small immutable object per writer prefix under §4's never-rewritten rule.
 
 ### [#42 — when parameter optimisation runs](https://github.com/amin-bf/leitner/issues/42)
 

--- a/docs/adr/0016-backup-and-restore.md
+++ b/docs/adr/0016-backup-and-restore.md
@@ -1,0 +1,532 @@
+# ADR-0016: Backup and restore
+
+- **Status**: Accepted
+- **Date**: 2026-07-31
+- **Resolves**: [Decide: backup and restore](https://github.com/amin-bf/leitner/issues/37)
+- **Map**: [Map: local-first Leitner app spec](https://github.com/amin-bf/leitner/issues/1)
+- **Related**: [ADR-0004 §7](0004-the-review-event-log.md) (the mutable surface, deletion, the stamp
+  rule), [ADR-0007 §6](0007-the-local-store.md) (the writer marker, Auto Backup),
+  [ADR-0008](0008-the-deck-export-format.md) (the container, the reserved profile, determinism),
+  [ADR-0009 §4](0009-crate-and-workspace-layout.md) (the platform seam),
+  [ADR-0013](0013-the-sync-transport.md) (the transport, one account is one collection),
+  [ADR-0014 §2](0014-when-parameter-optimisation-runs.md) (the nudge form),
+  [ADR-0015](0015-the-sync-experience.md) (what the app is entitled to say; the two questions §13
+  answers)
+
+## Context
+
+The ticket asked how a user gets their collection back after losing, replacing or wiping a device,
+and it was blocked deliberately: [#33](https://github.com/amin-bf/leitner/issues/33) and
+[#39](https://github.com/amin-bf/leitner/issues/39) had to land first, because a transport that keeps
+a full copy somewhere the user controls would make backup a side effect and dissolve the question.
+
+That transport landed. [ADR-0013 §7](0013-the-sync-transport.md) publishes not only the log but the
+**mutable surface** per writer — and note content lives on that surface
+([ADR-0004 §7](0004-the-review-event-log.md)) — so an enrolled account holds content *and* progress,
+and a fresh install signing in rebuilds everything. The dissolution case is stronger than the ticket
+anticipated.
+
+It still fails, for reasons §1 sets out. Three earlier decisions then constrain every answer below.
+**The container is not open**: [ADR-0008 §1](0008-the-deck-export-format.md) rejected "letting a
+backup artifact invent its own container later" and reserved a profile slot for this ticket.
+**Restore is already safe**: [ADR-0007 §6](0007-the-local-store.md)'s writer marker turns a restored
+collection into a clean fork rather than a duplicate writer. And **the platform seam is already
+contradictory**: [ADR-0013 §12](0013-the-sync-transport.md) recorded that ADR-0009's two instructions
+about platform capabilities cannot both be followed, routed around it, and predicted that *"the next
+ticket to need one will hit it head on with no equivalent escape."* This is that ticket — §5.
+
+Two arithmetic findings turned up in the sources rather than in the reasoning, and both are recorded
+as amendments: ADR-0007 §6 reads the wrong row of its own table, and `derived.db` is spending the
+backup quota it warns about.
+
+## Decision
+
+### 1. The archive exists; sync does not discharge this ticket
+
+> **A whole-collection archive is a specified artifact, separate from sync.**
+
+Sync covers device loss for an enrolled user, and covers it well. Three failures survive it, and they
+are different in kind:
+
+- **The never-enrolled user.** [ADR-0013 §8](0013-the-sync-transport.md) makes sync opt-in and says it
+  "never blocks first use," because offline-by-default is the map's operating mode rather than a
+  feature. Reviewing for years with no account is a **supported configuration**, and for that user
+  sync is not a weak backup story — it is the absence of one.
+- **Loss of the account or the grant.** Revocation is all-or-nothing (§9 there), the folder is deleted
+  if the user removes the app's data, and §2's *"losing the remote costs one republish rather than any
+  data"* is true only while a local copy survives. The device-lost-and-account-lost path takes both.
+- **Deletion.** Sync propagates a delete to every device in seconds, and
+  [ADR-0004 §7](0004-the-review-event-log.md) accepts that the content is gone — *"undeleting restores
+  the schedule but not the text, which must come from a backup or an export."* An accepted ADR already
+  spends this artifact by name.
+
+**And the sync folder must not be presented as a backup**, which [ADR-0013 §3](0013-the-sync-transport.md)
+fixed as a constraint rather than an option: it is hidden, it holds a published projection, and it is
+deleted when the user removes the app's data.
+
+**The honest limit is recorded in §4**: this protects against loss, not against unwanted change.
+
+### 2. The archive is a third profile in the `.ldeck` container: `collection`
+
+[ADR-0008 §1](0008-the-deck-export-format.md) reserved a **`progress`** profile for this ticket. The
+slot is used and the name is wrong: the artifact carries content as well, and a name describing half a
+payload is how the wrong selection rule gets implemented. It is the **`collection`** profile.
+
+**The selection rule is not "all decks."** It is *everything that settles, plus the log, minus device
+identity and credentials* — a different rule, not a wider one, because the deck profile deliberately
+drops most of what a restore needs:
+
+| | Deck profile | `collection` profile |
+|---|---|---|
+| Unfiled notes | never exported ([§8](0008-the-deck-export-format.md)) | **carried** — else backup silently drops notes |
+| ADR-0004 §7 stamps | do not travel ([§3](0008-the-deck-export-format.md)) | **carried byte for byte** |
+| `{revision, digest}` per deck | never exported ([§9](0008-the-deck-export-format.md)) | **carried** — else the next export emits a phantom revision |
+| Suspension ([ADR-0010 §5](0010-leeches.md)) | never exported | **carried** |
+| New-card rate ([ADR-0011 §5](0011-new-card-rate-and-daily-limits.md)) | not content | **carried** |
+| Device labels ([ADR-0004 §3](0004-the-review-event-log.md)) | never exported | **carried** |
+| The log | absent | **carried verbatim**, as received |
+| `writer_id`, `seq_highwater` | absent | **never** — [ADR-0007 §6](0007-the-local-store.md) requires a fresh id |
+| The sync credential | absent | **never** |
+
+**A distinct profile rather than a flag, because the rule that differs is destructive in one
+direction.** [ADR-0008 §3](0008-the-deck-export-format.md) calls import and restore *"same container,
+opposite rule"* — import restamps, restore preserves. A flag inside one profile is ignorable, and
+ignoring it produces a restored device whose fresh counters outrank genuinely later edits still held
+on another device: silent, and unrecoverable. As a **profile**, a reader that does not understand
+`collection` refuses at [§7](0008-the-deck-export-format.md)'s hard gate instead of half-reading the
+file.
+
+**The rule is "the log verbatim, plus everything that settles" — not "everything we cannot
+reconstruct."** [ADR-0014](0014-when-parameter-optimisation-runs.md) supplies the reason by name: its
+**fitted-over count** rides inside a `config-set` row and is stated to be *"not… a derived column that
+a restore may recompute,"* because §6 there establishes that recomputing it reports a fit that never
+happened. The set of things that *look* derivable but are not is exactly where a selection rule fails
+silently, so the rule is stated positively.
+
+### 3. A collection has an identity, adopted and never re-minted
+
+> **A collection id, minted once as a UUIDv4, carried in the `collection` profile.**
+
+This is the map's *Collection identity* fog, which
+[ADR-0008 §3](0008-the-deck-export-format.md) called load-bearing — telling an import from a restore
+"requires knowing which collection a payload came from" — and which
+[ADR-0013 §10](0013-the-sync-transport.md) half-answered and explicitly declined to finish.
+
+§2's profile answers *which rule*. It cannot answer *whose collection*, and the gap is one case: a
+device holding collection X is handed a `collection` archive from collection Y. The profile says
+"restore", so Y's stamps travel byte for byte — and Y's counters are meaningless in X, precisely the
+comparison [ADR-0005 §9](0005-the-deck-model.md) spends a paragraph forbidding. Nothing corrupts; the
+user silently acquires a stranger's collection. With an id it is a refusal, not a judgement.
+
+**Identity now has two halves, and they behave oppositely.** This is worth stating together because
+each is a rule an agent will otherwise apply to the wrong one:
+
+| | Writer id ([ADR-0004 §3](0004-the-review-event-log.md), [ADR-0007 §6](0007-the-local-store.md)) | Collection id |
+|---|---|---|
+| On finding one you did not mint | **never adopt** — mint fresh | **always adopt** — never re-mint |
+| Why | a sequence number promises sole authorship, which only continuous possession establishes | every device of one collection must agree, or the check is worthless |
+
+**Where it lives.** Minted at first launch beside the writer marker, held in `local`. It is **not** on
+the mutable surface — it must never settle, since two devices settling on different ids for one
+collection is the failure it exists to prevent — and **not** in the log, since it is not an input to
+replay. Through sync it rides as one small immutable object under each writer's own prefix,
+consistent with [ADR-0013 §1](0013-the-sync-transport.md)'s single-author-per-key property and §4's
+never-rewritten rule. Every writer publishes the same value; two different values is an alarm that
+[ADR-0013 §10](0013-the-sync-transport.md) says this transport cannot produce.
+
+**Rejected: a confirmation prompt instead.** Cheaper, and it asks the user to know something they
+cannot know — which is how the wrong stamp rule gets applied with a click.
+
+### 4. Restore is a merge, never a replace
+
+> **Restore adds. It never removes anything the device already holds.**
+
+**A replace cannot stick, and that is structural.** Every device holds the whole log, it is never
+compacted ([ADR-0004 §10](0004-the-review-event-log.md)), and merge is set union on `(writer, seq)`.
+So a device that wipes its collection and installs an archive has the **next sync re-merge everything
+it just removed** — the remote and every peer still hold those rows, and nothing in this design can
+propagate a deletion of log rows. The mutable surface goes the same way: the peers' newer stamps win,
+so a deletion flag returns with them.
+
+[ADR-0013 §2](0013-the-sync-transport.md) states this pointing the other way — losing the remote
+"costs one republish rather than any data at all." The symmetric consequence is that **losing data on
+purpose does not work either**. A restore that silently undoes itself on the next sync is worse than
+no restore at all.
+
+**Merge-restore discharges [ADR-0004 §7](0004-the-review-event-log.md), and the mechanism is worth
+spelling out** because it looks like it should not work:
+
+> A deleted note *"keeps only its marker, not its content."* The content is **discarded, not
+> superseded by a competing value**. So an archive predating the delete carries those field values
+> with old stamps and meets nothing to lose to — they land. Undelete the note, restore, and the text
+> is back. It is [ADR-0002 §7](0002-the-card-model.md)'s *"history reattaches by itself"* applied to
+> content instead of schedule, and it needs no new mechanism.
+
+**Accepted cost: this protects against loss, not against unwanted change.** A bad edit — right text
+typed over with wrong text — is a settled value carrying a newer stamp, and the archive's older stamp
+must lose or [ADR-0004 §7](0004-the-review-event-log.md)'s causality rule is broken. The same is true
+of a regretted import. Recorded plainly because "backup" invites the belief that any past state can be
+recovered, and here only *destroyed* state can be.
+
+**Rejected: offering replace for the unsynced case**, where it is genuinely safe because no peer
+exists to re-merge from. An operation that is correct in one configuration and silently self-reversing
+in another is the conditional rule this specification has refused repeatedly.
+
+### 5. Artifacts reach the filesystem through a put/get/list seam, and this resolves ADR-0013 §12
+
+Nobody owned this. [ADR-0008](0008-the-deck-export-format.md) specifies the container's bytes and
+never says how a file reaches the user's filesystem, so the deck file has the same gap; it simply
+never had to be faced. A backup that cannot leave the device is not a backup.
+
+**A file picker is unavailable at a price this specification has already refused.**
+`ACTION_CREATE_DOCUMENT` and `ACTION_OPEN_DOCUMENT` deliver through an activity *result*.
+`android.app.NativeActivity` does not forward results to native code and the native glue has no path
+for one, so catching it requires our own Java subclass — which requires a dex, a build system and
+`res/`, overturning [ADR-0003 §2](0003-client-stack.md)'s measured *"manifest plus one `.so`"*
+property that [ADR-0009](0009-crate-and-workspace-layout.md) and
+[ADR-0014 §3](0014-when-parameter-optimisation-runs.md) both lean on.
+
+> **The seam is three operations: put a named file, get a named file, list the files we recognise.
+> Nothing else. No picker, no dialog, no path typed by a user.**
+
+This is deliberately [ADR-0013 §1](0013-the-sync-transport.md)'s shape — *"put an object, get an
+object, list a prefix, delete an object. Nothing else"* — reused rather than reinvented. This
+specification has already priced an opaque, minimal, enumerable seam once and liked the result; using
+one idea twice is cheaper than two. **Three operations, not four: there is deliberately no delete**,
+for the reason §13 gives.
+
+| Target | Put | List / get |
+|---|---|---|
+| Desktop | write into the user's documents directory | scan documents and downloads |
+| Android | insert into `MediaStore` `Downloads` via `ContentResolver`, write to the returned URI | query `MediaStore` for our extensions |
+
+The Android side needs **no activity result and no permission at API 29+**, and is reachable by JNI
+from the Context the existing shim already obtains. It is not verified on the handset — see *Open
+items*, and `AGENTS.md` rule 9.
+
+**Three additional entry points, each costing nothing:**
+
+- **Desktop drag-and-drop.** egui surfaces dropped files directly, with no operating-system dialog and
+  no seam function. A laptop user's archive lives in `~/backups` or on a stick, not in a downloads
+  folder, so the symmetric list is genuinely worse there —
+  [ADR-0014 §8](0014-when-parameter-optimisation-runs.md) refused "softer divergence" because the
+  premise was refuted by measurement, and here the premise is true. It is **additive**: Android has
+  nothing to drag, so it degrades to the list rather than diverging.
+- **Android launch intent.** An intent filter on the extension lets a file manager open an archive,
+  and a *launch* intent is readable from the activity with no result callback and no dex — unlike the
+  picker above. [ADR-0008 §10](0008-the-deck-export-format.md) already requires such a filter for
+  `.ldeck`; this adds the second extension to the same mechanism.
+- **Text is never typed.** No filename field, no path field. `AGENTS.md` rule 8 makes Android text
+  input ASCII-only, so any such field is broken for the users this application exists for.
+
+**On the seam rule, this ticket resolves the contradiction
+[ADR-0013 §12](0013-the-sync-transport.md) recorded** rather than routing around it, by adopting the
+fix that ADR's own text sketched: *"the seam rule is per crate rather than per workspace."* These three
+functions live in a `platform` module **inside `leitner-export`**, under the same discipline —
+three `#[cfg]` arms, the third a `compile_error!`. **`leitner-store::platform` keeps exactly two
+functions**, so [ADR-0009 §4](0009-crate-and-workspace-layout.md)'s erosion signal is preserved
+intact and means what it says.
+
+### 6. The archive is written when the user asks, and the nudge states a fact
+
+> **No schedule, no automatic write. An action in settings, and a subtitle beneath it.**
+
+**The argument that decides it is specific to backup.** An archive written to the device's own
+downloads folder is **not a backup until the user moves it off the device** — that folder dies with
+the phone. So automating the write automates the half with no value, while the half that matters is
+irreducibly a human act. Worse, it would manufacture exactly the false belief
+[ADR-0007 §6](0007-the-local-store.md) warns about: files accumulating, nothing protected.
+
+A real scheduler is disqualified independently.
+[ADR-0014 §3](0014-when-parameter-optimisation-runs.md) rejected a foreground service or scheduled job
+because [ADR-0003](0003-client-stack.md)'s prize is a Gradle-free APK, and a weekly background backup
+spends it outright.
+
+**The nudge takes [ADR-0014 §2](0014-when-parameter-optimisation-runs.md)'s form** — an action that is
+never conditioned, and beneath it a subtitle carrying no threshold, no badge, no colour and no verb:
+
+> Last backup 3 March. 1,240 reviews since.
+
+and where none exists:
+
+> No backup yet. 4,200 reviews across 812 notes.
+
+**It appears in settings and nowhere else — specifically not at the end of a session.**
+[ADR-0010 §9](0010-leeches.md) placed a pointer there and
+[ADR-0014 §2](0014-when-parameter-optimisation-runs.md) already refused the slot on the ground that
+"a second one competing for it devalues both." A third is not arguable.
+
+**Where the precedent does not transfer, stated so it is not borrowed:**
+[ADR-0014 §1](0014-when-parameter-optimisation-runs.md)'s deciding argument was **contention** — every
+device crossing a threshold, training, and writing a competing `config-set` row. Backup writes nothing
+to the log and nothing that settles, so no contention argument exists here. This rests entirely on the
+off-device point above.
+
+**Accepted cost, and it is the strongest objection in this ADR: a backup nobody makes is not a
+backup.** [ADR-0014 §1](0014-when-parameter-optimisation-runs.md) accepted the same for optimisation,
+but could afford to because the floor was a good one. Here the floor is §7's Auto Backup and nothing
+else. The judgement is that an automatic local write does not raise that floor — it makes the nothing
+feel like something.
+
+### 7. Auto Backup stays on, and the application states the size fact
+
+**Kept on.** For one user it is the only thing between them and total loss: never enrolled, never made
+an archive, phone in a puddle. [ADR-0007 §6](0007-the-local-store.md) already paid the entire cost of
+making that restore *safe* — the writer marker turns it into a clean fork — and
+[ADR-0013 §9](0013-the-sync-transport.md) deliberately routes the refresh token through it so a
+replaced phone arrives already authorised. Disabling it to prevent a false belief would punish exactly
+the users it protects, and `android:allowBackup="false"` is a free manifest attribute, so this is a
+choice rather than a constraint.
+
+**The cutoff is stated, because it is observable by us.** `onQuotaExceeded()` needs a backup agent
+class, which needs a dex; we do not need it. We know our own file sizes and the quota is a documented
+platform constant, so on Android the subtitle gains one line once it is true:
+
+> Your collection is 31 MB. Android's automatic backup stops above 25 MB.
+
+Two facts, no verb, no colour. [ADR-0014 §2](0014-when-parameter-optimisation-runs.md) refuses
+thresholds in a nudge, and the distinction defended here is that it refused them because *"there is no
+defensible number to use"* — a documented platform constant is the one case where there is.
+
+**How urgent this is: see the ADR-0007 §6 amendment below.** The crossing is roughly nine months of
+heavy use, not two years.
+
+### 8. The archive is not encrypted
+
+**Not even optionally.** This is the one artifact designed to leave the device and land on storage we
+do not control, so the case for encryption is the strongest anywhere in this specification. It loses
+on a repo-specific correctness argument:
+
+> `AGENTS.md` rule 8 — **Android text input is ASCII-only and cannot be fixed here.** A user who sets
+> a passphrase in their own language on the desktop **cannot type it on the phone**, so the archive
+> becomes unopenable on the platform that most needs it. That is a correctness failure, not an
+> inconvenience, and it lands on precisely the users this application exists for.
+
+Three supporting grounds. **A passphrase-protected backup is the most reliable way to lose data
+permanently**, and this design has nowhere to recover from — no server, no account, no escrow, by
+construction. **The archive carries no credential** (§2), so the worst case is disclosure of the
+user's own study material, not account takeover. And
+[ADR-0008 §10](0008-the-deck-export-format.md) makes inspectability a feature — *"renaming a deck file
+to `.zip` and looking inside is intended"* — which encryption forfeits for the artifact most likely to
+need forensic recovery.
+
+**Accepted cost, recorded rather than argued away.**
+[ADR-0013 §9](0013-the-sync-transport.md)'s *"encrypting the token while the data it guards lies in
+plaintext beside it is theatre"* does **not** transfer here, and this ADR declines to borrow it: that
+argument works because both objects sit in the same app-private directory. **This archive travels and
+`collection.db` does not**, so a plaintext archive in a downloads folder is genuinely more exposed than
+anything else in the design. The map's *Local encryption / device passcode* fog is the honest home for
+the general question, and if it lands it must cover the local store and the travelling archive
+together.
+
+### 9. `.lcoll`, self-identifying from its first bytes
+
+The extension is **`.lcoll`**. The first member of the archive is `mimetype`, `stored` with no
+compression, containing `application/vnd.leitner.collection+zip`.
+
+This is [ADR-0008 §10](0008-the-deck-export-format.md)'s mechanism unchanged, for the reason it gives:
+a zip archive's header says nothing about what it contains, so a type marker at a fixed byte offset is
+what lets content sniffing identify a file whose extension was mangled or stripped. §10 states that a
+distinct extension per profile is *"how the operating system and the user tell a deck file from a
+whole-collection artifact **before** opening it"*, and hands the naming here.
+
+**Rejected: `.leitner`.** Friendlier to a user staring at a downloads folder, and actively wrong in a
+design with two file types that §10 spent its length making distinguishable.
+
+### 10. Mismatched collection ids: an empty collection adopts, a non-empty one refuses
+
+One rule, applied identically at both seams — restoring an archive, and enrolling a transport:
+
+> **A collection that has authored nothing adopts the identity it meets. A collection that has
+> authored something refuses any identity but its own.**
+
+"Authored nothing" is sharp on purpose: **no log rows under this device's own writer id, and nothing
+on the mutable surface.** Not "no notes" — a user who imported a deck and reviewed nothing has
+authored nothing and must still be able to adopt.
+
+| Device holds | Meets | Outcome |
+|---|---|---|
+| nothing | archive X | adopt X |
+| X | archive X | merge; stamps byte for byte |
+| X | archive Y | **refuse**, naming the mismatch |
+| X | empty remote folder | publish; that account now holds X |
+| X | remote folder holding X | normal sync |
+| X | remote folder holding **Y** | **refuse**, naming the mismatch |
+| fresh install, minted Z, authored nothing | remote folder holding X | **adopt X** |
+
+That last row is the trap this rule exists for. §3 mints an id at first launch, so a brand-new install
+already has one, and a naive "ids differ → refuse" would mean **a fresh install can never enrol into
+an existing account** — the most common real path there is.
+
+**This upgrades [ADR-0013 §10](0013-the-sync-transport.md) from a structural accident to a checked
+invariant.** Its guarantee — one account is one collection — rests on the application data folder
+being scoped per account and application, which really means *"you cannot merge two collections
+because you cannot see the other one."* That stops being true the moment a user has two accounts and
+picks the wrong one. The id makes it a check rather than a property of what happens to be visible.
+
+**The way out of a refusal is always available and must be stated in the interface**, or a user is
+left holding a device that will not talk to their account: make an archive, clear the app's data,
+restore, enrol.
+
+### 11. The manifest carries a creation date, and determinism is not inherited
+
+[ADR-0008 §12](0008-the-deck-export-format.md) makes export **byte-for-byte deterministic** — member
+timestamps pinned to a constant, no extra fields — so that build time does not leak and *"same
+revision, same file"* is a property rather than an approximation. **That reasoning is entirely about an
+artifact sent to strangers.**
+
+The `collection` profile is the opposite artifact in every respect. It goes to nobody, it has no
+revision, and **a backup without a date is close to useless**: §6's subtitle needs one, and a user
+with three archives in a downloads folder needs to tell them apart before restoring the wrong one.
+Determinism buys this profile nothing and costs it the one piece of metadata it needs.
+
+> **The `collection` profile carries a creation timestamp in its manifest and does not inherit
+> [ADR-0008 §12](0008-the-deck-export-format.md)'s determinism.**
+
+Stated as an explicit non-inheritance rather than by silence, because §12 reads as a container-wide
+rule and the next agent will assume it applies. **The disclosure half of §12 is inherited unchanged**:
+no author name, no device label, no ambient identity ever auto-populated.
+
+**Restore previews before it acts**, which [ADR-0008 §2](0008-the-deck-export-format.md) already
+bought — the manifest is readable from the zip central directory *"without inflating the payload, so
+an import can be previewed."* Before anything merges:
+
+> Collection archive, 3 March 2026. 812 notes, 4,200 reviews.
+
+This is also where §10's gate fires: a mismatched collection id is reported here, by name, rather than
+after the fact.
+
+### 12. What a restore restores, stated plainly
+
+- **Comes back**: every review ever recorded; all note content and tags; decks and membership;
+  suspensions; the new-card rate; acquired kind definitions; per-deck revisions; and the scheduler
+  parameters including [ADR-0014](0014-when-parameter-optimisation-runs.md)'s fitted-over count.
+- **Does not come back**: **this device's identity.** It mints a fresh writer id
+  ([ADR-0007 §6](0007-the-local-store.md)), so a restored device is a **clean fork rather than a
+  resurrection** — deliberate, and the thing that stops two devices silently becoming one writer.
+- **Is not removed**: anything the device already held. Restore is a merge (§4); it only ever adds.
+
+**The last line is the one the interface must say**, because "restore" universally implies replacement
+and here it does not.
+
+### 13. Answering ADR-0015's two handoffs, one of them negatively
+
+[ADR-0015](0015-the-sync-experience.md) landed in a parallel session and handed this ticket two
+questions by name. Both are answered here, and the first is answered **no**.
+
+**"Does collection identity make a wrong-account enrolment detectable?" — No, and the reason is
+structural rather than a gap in §3.** ADR-0015 anticipated this correctly: a wrong account presents
+an **empty folder identical to being first to enrol**, and an empty folder carries no information to
+compare an id against. But the sharper statement is worth recording, because it explains why no
+mechanism of this shape could have worked:
+
+> **In a wrong-account enrolment every collection id agrees.** The devices on the right account and
+> the device on the wrong one all hold the *same* collection — they simply cannot see each other. The
+> failure is one of **reachability, not identity**, so an identity check was never going to detect
+> it. §3 answers "is this the same collection?", and here the answer is *yes*.
+
+So ADR-0015's sentence — the app states what it found after enrolling — **stands as the whole
+defence**, and this ADR does not replace it. The one thing that would detect the case is naming the
+**account** on the enrolment screen, which costs an `email` or `profile` scope that
+[ADR-0013 §8](0013-the-sync-transport.md) deliberately did not request. That is a live trade, owned
+by neither ADR, and it is recorded in *Open items* rather than decided here.
+
+**"The no-delete reasoning does not transfer to an artifact that is not disposable." — Correct, and
+it is already honoured.** ADR-0015 refuses a delete-remote-data control partly because the sync
+namespace is disposable and there is nothing to reclaim. An archive is the opposite: for the
+never-enrolled user of §1 it may be the only copy in existence. §5's seam is therefore **put, get,
+list — and deliberately no delete**, unlike [ADR-0013 §1](0013-the-sync-transport.md)'s four
+operations which this ADR otherwise copies.
+
+> **The application never deletes a user's archive.** It writes into a user-visible folder, and
+> removing files from a user-visible folder is the file manager's job. A delete in this seam would
+> let the application destroy the one artifact that exists to survive the application.
+
+The divergence from ADR-0013 §1's shape is one operation, in the safe direction, for a reason that is
+the exact inverse of that ADR's: **there, deletion is safe because the objects are disposable; here,
+deletion is refused because the artifact is not.**
+
+## Amendments to accepted ADRs
+
+| ADR | What changes | Why |
+|---|---|---|
+| [ADR-0007 §6](0007-the-local-store.md) | The Auto Backup quota is crossed in **about nine months** of heavy use, not "about two years". | §6 reads the wrong row of [§10](0007-the-local-store.md)'s own table: it used the **raw interchange** figure (11 MB/yr → 2.3 years) where Auto Backup covers **files on disk** (~33 MB/yr → ~0.76 years). The hazard it identified is roughly 2.5× more urgent than it states. |
+| [ADR-0007 §6](0007-the-local-store.md) | **`derived.db` moves out of the backup set**, to `getNoBackupFilesDir()` beside the writer marker. | §3 makes it disposable and rebuildable by design, and §6 puts it where Auto Backup collects it — so the cache is uploaded, counts against the 25 MB quota, and accelerates the silent cutoff, to protect a file whose defining property is that losing it costs nothing. `ATTACH` is indifferent to the path, so this needs no new mechanism. |
+| [ADR-0008 §1](0008-the-deck-export-format.md) | The reserved **`progress`** profile is specified as **`collection`**. | §2 above: it carries content as well as the log, so the reserved name understates the payload by half — and a name describing half a payload is how the wrong selection rule gets implemented. |
+| [ADR-0008 §12](0008-the-deck-export-format.md) | Byte-for-byte determinism binds the **`deck`** profile only; the `collection` profile carries a creation date. Minimal disclosure still binds both. | §11 above: determinism exists so an artifact sent to strangers does not leak build time and keeps "same revision, same file". A personal archive has no revision, goes to nobody, and needs the date §12 forbids. |
+| [ADR-0013 §12](0013-the-sync-transport.md) | The recorded contradiction is **resolved for platform *functions***, by adopting the fix its own text sketched: the seam rule is **per crate**. `leitner-export` gets its own three-arm `platform` module; `leitner-store::platform` keeps exactly two functions. | §5 above. ADR-0013 routed around it via the device flow and predicted the next ticket would meet it head on. It did. |
+
+**Two ADRs resolved ADR-0013 §12 in parallel, on different facets, and they compose.**
+[ADR-0015](0015-the-sync-experience.md) amends [ADR-0009 §4](0009-crate-and-workspace-layout.md) to
+say the prohibition is on *behaviour and a growing function seam, rather than on a capability
+constant*; this ADR says the *function* seam is per crate. Neither weakens
+`leitner-store::platform`'s two-function limit, which is the property both are protecting, and
+between them §12's contradiction is now discharged from both sides. Recorded because two independent
+resolutions of one recorded contradiction is exactly the situation a later reader would otherwise
+mistake for a conflict.
+
+**No amendment is needed elsewhere.** [ADR-0004 §7](0004-the-review-event-log.md) is **discharged
+rather than changed** — its *"must come from a backup or an export"* now names a specified artifact,
+and §4 above shows the mechanism works because deletion discards rather than supersedes.
+[ADR-0013 §3](0013-the-sync-transport.md)'s "the sync folder is not a backup" is honoured, not
+revisited. [ADR-0009 §4](0009-crate-and-workspace-layout.md)'s two-function limit on
+`leitner-store::platform` is **preserved intact**, which is the point of §5's per-crate reading.
+
+## Requirements this places on downstream tickets
+
+### [#40 — the sync experience](https://github.com/amin-bf/leitner/issues/40)
+
+1. **Enrolment carries §10's identity check**, and both outcomes are UI moments: an empty collection
+   adopting silently, and a non-empty one refusing. A refusal must name the mismatch and state the way
+   out (archive, clear data, restore, enrol) or the user is stuck.
+2. **The collection id is published as one small immutable object per writer prefix** (§3), under
+   [ADR-0013 §4](0013-the-sync-transport.md)'s never-rewritten rule. It is not on the mutable surface
+   and must never be made to settle.
+
+### Implementation
+
+1. **Verify the `MediaStore` path on the real handset before building on it** — `AGENTS.md` rule 9.
+   §5's claim that an insert plus a `ContentResolver` write needs no activity result and no permission
+   at API 29+ is reasoned from the platform's documented scoped-storage behaviour and **has not been
+   run on the Pixel 8 Pro**. If it fails, §5's seam is unchanged and only its Android arm is in
+   question.
+2. **The `.lcoll` intent filter needs a `pathPattern` alongside the media type**, exactly as
+   [ADR-0008 §10](0008-the-deck-export-format.md) records for `.ldeck` — custom extensions have no
+   reliable extension-to-type mapping on Android.
+
+## Glossary
+
+New terms are of record in the `CONTEXT.md` files, per
+[ADR-0009 §6](0009-crate-and-workspace-layout.md): **collection archive**, **collection profile** and
+**collection id** in [`export`](../../crates/export/src/CONTEXT.md), which owns the container; the
+collection id's *storage* is noted in [`store`](../../crates/store/src/CONTEXT.md) beside the writer
+marker it is minted with.
+
+## Consequences
+
+- **The `export` crate gains a dependency on `log`**, which `CONTEXT-MAP.md` predicted in as many
+  words — *"will depend on `log` once #37 specifies the progress profile"* — and which is why it is a
+  peer of `replay` rather than a module inside `content`.
+- **`leitner-store::platform` stays at two functions**, and the erosion signal
+  [ADR-0009 §4](0009-crate-and-workspace-layout.md) attached to a third still means what it says.
+  Every future platform capability now has a home that does not require breaking it.
+- **The deck file gains a delivery mechanism it never had.** §5's seam was specified for the archive
+  and answers `.ldeck` identically; ADR-0008 had specified bytes with no way to write them anywhere a
+  user could reach.
+- **Two file types now exist**, and both are self-identifying from their first bytes. Any third pays
+  the same cost.
+- **Nothing in this ADR makes the remote authoritative for anything**, so
+  [ADR-0013 §2](0013-the-sync-transport.md)'s disposability property — which most of that ADR's
+  reasoning rests on — is untouched.
+- **`AGENTS.md` gains a backup section**, because four of the rules above fail silently: restore is a
+  merge, the two identity halves behave oppositely, the collection profile does not inherit
+  determinism, and `derived.db` must stay outside the backup set.
+
+## Open items handed onward
+
+| Item | Owner |
+|---|---|
+| Running an archive write and a restore on the real handset, including the `MediaStore` path | Implementation |
+| **Whether the enrolment screen should name the account it connected as**, which is the only thing that would detect [ADR-0015](0015-the-sync-experience.md)'s wrong-account case (§13) — it costs an `email` or `profile` scope [ADR-0013 §8](0013-the-sync-transport.md) deliberately did not request, and both are on that flow's allowlist. Owned by neither ADR | Not scheduled |
+| Whether the archive should ever be encrypted — must be answered together with the local store, never alone | Map fog: *Local encryption / device passcode* |
+| Media, if audio on cards is ever built: the archive inherits the size, and §6's manual write becomes a much larger ask | Map fog |


### PR DESCRIPTION
Resolves [#37](https://github.com/amin-bf/leitner/issues/37) on [map #1](https://github.com/amin-bf/leitner/issues/1). Settled by `/grilling` over twelve decisions; the [resolution comment](https://github.com/amin-bf/leitner/issues/37#issuecomment-5146321870) carries the full reasoning.

## What this decides

A whole-collection **`.lcoll` archive** — the same zip container as a deck file, carrying a third `collection` profile — written **only when the user asks**, and **restore is a merge that never removes anything**.

**Sync came closer to dissolving this ticket than it expected.** ADR-0013 §7 publishes the mutable surface as well as the log, and note content lives there, so an enrolled account holds content *and* progress. Three failures survive it: the **never-enrolled user** (sync is opt-in and offline-by-default is the operating mode, so years with no account is a *supported configuration*), loss of the account or grant, and **deletion** — which sync propagates in seconds, and which ADR-0004 §7 already spent this artifact on by name.

**The sharpest finding: a replace cannot stick, and it is structural.** Every device holds the whole log and merge is set union, so a wipe-then-reinstall is undone by the next sync — the peers still hold every row. That is ADR-0013 §2 read backwards: losing data *on purpose* does not work either. Merge-restore then discharges ADR-0004 §7 exactly, because a deleted note's content is **discarded, not superseded**, so an archive predating the delete meets nothing to lose to. **Recorded as an accepted cost:** this protects against loss, not against unwanted change.

**Collection identity is settled** — the map's oldest fog patch, open since the local-store ticket. A UUIDv4, **adopted and never re-minted**, the exact opposite of the writer id's never-adopt rule, with one rule at both the restore and enrolment seams: an empty collection adopts, a non-empty one refuses.

**This ticket met ADR-0013 §12's recorded contradiction head on, as that ADR predicted, and resolved it.** A picker needs an activity *result*, which needs a Java subclass and a dex, spending ADR-0003's Gradle-free APK — so no picker on either platform, and a **put/get/list** seam lives in `leitner-export`'s own platform module. **The seam rule is per crate**, and `leitner-store::platform` keeps exactly two functions.

## Amends five accepted ADRs, discharges three more

| ADR | Change |
|---|---|
| ADR-0007 §6 | The 25 MB Auto Backup cutoff arrives in **~nine months** of heavy use, not two years — §6 read its own table's *raw interchange* row where Auto Backup covers *files on disk* |
| ADR-0007 §6 | **`derived.db` moves out of the backup set** — disposable by design, yet spending the quota it warns about |
| ADR-0008 §1 | The reserved `progress` profile is specified as **`collection`** |
| ADR-0008 §12 | Determinism binds the `deck` profile only; disclosure still binds both |
| ADR-0013 §12 | The recorded contradiction is **resolved** for platform functions |
| ADR-0008 §10, ADR-0013 §10, ADR-0004 §7 | Discharged |

## Two things a reviewer should look at

- **This branch references `docs/adr/0015-the-sync-experience.md`, which is not on `main` yet.** A parallel session resolved [#40](https://github.com/amin-bf/leitner/issues/40) and took ADR-0015 while this was being written, so mine renumbered to **0016** and the link is a forward reference that resolves when that branch lands. Renumbering touched only this session's own files — a `0015` substring inside a research-note URL was deliberately left alone.
- **One of ADR-0015's two handoffs is answered `no`.** Collection identity does *not* make a wrong-account enrolment detectable: in that case **every collection id agrees**, because the failure is reachability rather than identity. That ADR's one-sentence defence stands rather than being replaced. Its no-delete point is honoured — the file seam has **no delete**, so the app can never destroy a user's archive.

## Verification

Docs only; no code changes. Every relative link checked to resolve, except the forward reference above. The `MediaStore` path in §5 is reasoned from documented scoped-storage behaviour and is **recorded as unverified on the handset**, per `AGENTS.md` rule 9 — it is an open item for implementation, not a claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
