### PR TITLE
Sync / Decide the Sync Experience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,31 @@ remote costs one republish and no data.
 6. **Never present the sync folder as a backup.** It is hidden, it is deleted when the user removes
    the app's data, and backup is [#37](https://github.com/amin-bf/leitner/issues/37)'s to specify.
 
+### What the user sees
+
+[ADR-0015](./docs/adr/0015-the-sync-experience.md) settles the surface. Four of its rules fail
+silently, three of them because the reasoning is invisible from the code that would break them.
+
+1. **Exactly two things may speak about sync: a dead grant, and ADR-0004 §8's clock-skew warning.**
+   A network failure never speaks — offline is normal and nagging about it is the defect. There is
+   **no status icon, no badge, no success toast, and no "in sync"**: after a sync the app knows every
+   writer's highest *published* sequence and never whether another device has reviewed since, so
+   claiming devices agree is unknowable. The resting statement is the fact *"last caught up ⟨when⟩"*.
+   Every future feature will have a reason to want a third speaker; each one is a defect.
+2. **Never start a sync while the review screen is up; let one in flight finish.** This is not a lock
+   on reviewing — the app never blocks that, ever — it is what stops a merge recomputing every
+   `(S, D)` mid-session, which ADR-0014 called locally unfixable. **It works only because there is no
+   background sync**, so that absence is load-bearing and not a limitation to lift.
+3. **There is no delete-remote-data control, and adding one destroys other devices' rows.** The
+   `drive.appdata` grant reaches the whole app folder, so a delete from one device removes namespaces
+   whose rows a device that never fetched them will never see again. It looks like a courtesy and
+   there is nothing to reclaim — a few hundred objects, ~47.5 MB per decade. Disconnect drops the
+   local grant and deletes nothing.
+4. **A wrong-account enrolment is undetectable, and one sentence is the entire defence.** A second
+   device pointed at the wrong account gets an empty folder, which is indistinguishable from being
+   the first device to enrol. That is why enrolment *ends by stating what it found* — "the first
+   device here" versus the devices it met. Removing that line as redundant removes the only guard.
+
 ## Agent skills
 
 ### Issue tracker

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -95,9 +95,9 @@ Read the ADR sections in your row. Read the whole ADR only if you are changing t
 | `replay` | *none of its own* | 0001 §7, 0002 §7, 0004 §9, 0007 §2, 0010 §2, 0011 §8, 0012 §5, 0012 §6 |
 | `store` | [0007](./docs/adr/0007-the-local-store.md) | 0004 §11, 0003 §5, 0013 §9 |
 | `export` | [0008](./docs/adr/0008-the-deck-export-format.md) | 0005, 0002 §9, 0004 §11, 0011 §7 |
-| `sync` | [0013](./docs/adr/0013-the-sync-transport.md) | 0004 §2, 0004 §7, 0004 §10, 0007, 0014 §7 |
-| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md), [0010](./docs/adr/0010-leeches.md), [0011](./docs/adr/0011-new-card-rate-and-daily-limits.md), [0012](./docs/adr/0012-the-note-authoring-experience.md), [0014](./docs/adr/0014-when-parameter-optimisation-runs.md) | 0002 §4 |
-| *the workspace itself* | [0009](./docs/adr/0009-crate-and-workspace-layout.md) | 0013 §11, 0013 §12 |
+| `sync` | [0013](./docs/adr/0013-the-sync-transport.md) | 0004 §2, 0004 §7, 0004 §10, 0007, 0014 §7, 0015 §2, 0015 §4 |
+| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md), [0010](./docs/adr/0010-leeches.md), [0011](./docs/adr/0011-new-card-rate-and-daily-limits.md), [0012](./docs/adr/0012-the-note-authoring-experience.md), [0014](./docs/adr/0014-when-parameter-optimisation-runs.md), [0015](./docs/adr/0015-the-sync-experience.md) | 0002 §4 |
+| *the workspace itself* | [0009](./docs/adr/0009-crate-and-workspace-layout.md) | 0013 §11, 0013 §12, 0015 §14 |
 
 **`replay` having no ADR of its own is why it is a context.** Its rules were each written for another
 purpose and sit scattered across four documents; its `CONTEXT.md` is the only place they appear as

--- a/crates/app/src/CONTEXT.md
+++ b/crates/app/src/CONTEXT.md
@@ -8,7 +8,9 @@ through, and both platform entry points.
 [ADR-0010](../../../docs/adr/0010-leeches.md) and
 [ADR-0011](../../../docs/adr/0011-new-card-rate-and-daily-limits.md), the last of which **amends
 ADR-0006 §1 and §2** — read those amendments before touching the session; also by
-[ADR-0002 §4](../../../docs/adr/0002-the-card-model.md) (layout is data, stored once per kind).
+[ADR-0002 §4](../../../docs/adr/0002-the-card-model.md) (layout is data, stored once per kind) and
+[ADR-0015](../../../docs/adr/0015-the-sync-experience.md) (everything the user sees about sync — the
+`sync` crate holds the mechanism and none of the surface).
 
 ## Language
 
@@ -46,6 +48,24 @@ seen rather than described.
 More cards due than the user will get through. Always *framed* ("pick a comfortable size, the rest
 will keep"), never reported as a bare number.
 
+**Last caught up**:
+The only resting statement the app makes about sync — *when* it last completed one, a fact.
+**Never "in sync"**: after a sync the app knows every writer's highest *published* sequence, and
+never whether another device has reviewed since. Claiming agreement between devices is unknowable
+(ADR-0015 §4), the same shape as the box badge claiming something about the queue.
+_Avoid_: In sync, up to date, synced, a status icon or checkmark anywhere in the chrome.
+
+**Set up sync**:
+Granting this device access, once, via the device flow. Ends with the user naming **this** device
+(ADR-0015 §8) and with the app stating what it found — *"the first device here"* or the devices it
+met — because a wrong-account enrolment is otherwise undetectable (ADR-0015 §7).
+_Avoid_: Login, sign-in, pairing, connecting an account.
+
+**The notice channel**:
+The persistent, non-modal line for the **only two things permitted to speak about sync**: a dead
+grant, and ADR-0004 §8's clock-skew warning. A network failure never speaks — offline is normal
+(ADR-0015 §5).
+
 ## Rules that are easy to break silently
 
 - **All user-visible text goes through `bidi`.** egui places text runs left-to-right in logical
@@ -64,7 +84,17 @@ will keep"), never reported as a bare number.
 - **Fonts are installed on the first frame, never in `CreationContext`**, and every added face must
   be registered in **every** family including `Monospace`, or text silently renders as boxes.
 - **Android text input is ASCII-only and cannot be fixed here.** winit's Android backend has no IME
-  path. Never design a feature that requires typing non-Latin text on Android.
+  path. Never design a feature that requires typing non-Latin text on Android. Because we receive no
+  events, the failure is *silence* — so the editor states it in advance, off a compile-time
+  capability constant (ADR-0015 §9). That constant is the one sanctioned exception to the
+  no-`#[cfg(target_os)]` rule, and it exists to make a limitation visible, never to vary behaviour.
+- **Never start a sync while the review screen is up**, and let one already in flight finish. This
+  is not a lock on review — the app never blocks reviewing (ADR-0015 §1) — it is what stops a merge
+  recomputing every `(S, D)` mid-session, which ADR-0014 called locally unfixable. It works only
+  because there is no background sync, so treat that absence as load-bearing (ADR-0015 §6).
+- **Only two things may speak about sync**, and every future feature will have a reason to want a
+  third. A badge, a toast on success, a "syncing…" indicator in the chrome — each is a defect
+  against ADR-0015 §4, not a UX improvement.
 - **Verify on the real handset.** The emulator is x86_64; the Pixel 8 Pro is arm64-v8a only.
 
 ## Why this crate has no `main.rs`

--- a/crates/sync/src/CONTEXT.md
+++ b/crates/sync/src/CONTEXT.md
@@ -1,8 +1,11 @@
 # Sync
 
 Publishing this device's rows to storage nobody here owns, and reading back what other devices
-published. The mechanism only — *when* sync runs and how divergence is shown to the user belong to
-[#40](https://github.com/amin-bf/leitner/issues/40) and live in `ui`.
+published. The mechanism only — *when* sync runs and how divergence is shown to the user are settled
+by [ADR-0015](../../../docs/adr/0015-the-sync-experience.md) and live in `ui`. Two of its answers
+reach back into this crate's assumptions: **there is no background sync on either platform** (§2), so
+nothing here is ever entered from a scheduler; and **the app never rests in a "behind" state** (§4),
+because the handshake that discovers it and the fetch that fixes it are one operation.
 
 Depends on `log` for row identity and the version summary, and on `content` transitively. Does not
 depend on `replay` or `ui`: nothing here knows what a card is.

--- a/docs/adr/0004-the-review-event-log.md
+++ b/docs/adr/0004-the-review-event-log.md
@@ -160,6 +160,22 @@ Labels are not replay inputs, so they are **not log rows**. They live on the mut
 settle by §7. They are also what makes the deferred sync work expressible at all: *"you are behind
 your laptop"* is a sentence; *"you are behind `7f3a-b21c`"* is not.
 
+> **Amended by [ADR-0015 §14](0015-the-sync-experience.md) — devices label themselves, and the
+> justification above no longer holds.** Two changes, and the identity split itself — machine-owned
+> writer ids, human-owned labels, never adopted — is untouched by both.
+>
+> **The default is inverted.** A device is labelled **by its user at enrolment**, and the label syncs
+> on the mutable surface, so every other device already knows it. Asking a user to name a *stranger*
+> is a puzzle they cannot solve; naming the device in their hand is trivial. The paragraph above
+> becomes the exception — a writer whose label never arrived, and the reinstall case, where typing
+> the same name is what groups several writer ids under one label.
+>
+> **And the sentence that justifies labels is one the app is never entitled to say.** ADR-0015 §4
+> finds *"you are behind"* transient by construction: reachable remote means the handshake *is* the
+> listing, so discovering it and fixing it are one operation; unreachable remote means the device
+> does not know. Labels are retained on two other grounds — the device list in sync settings, and
+> **§8's clock-skew warning, which must name a device to be actionable at all.**
+
 Rejected: **requiring every device to be online at sync time**, which would make adoption safe by
 guaranteeing the true highest sequence is visible. It fails on three counts. Presence requires a
 rendezvous point, which is a server; the realistic transport for a serverless app is a dumb store

--- a/docs/adr/0009-crate-and-workspace-layout.md
+++ b/docs/adr/0009-crate-and-workspace-layout.md
@@ -134,6 +134,22 @@ not to add it.
 > under the same three-arm discipline, `compile_error!` included. What must *not* happen is a third
 > function landing here because the handoff table said so.
 
+> **Amended by [ADR-0015 §15](0015-the-sync-experience.md) — the prohibition is on behaviour, not on
+> capability.** #40 is the next ticket the note above predicted, and it met the rule from an angle
+> that note did not anticipate: not a *function*, and not in this crate. The Android editor must
+> state that non-Latin text cannot be typed there — winit has no IME path, so the failure reaching
+> the user is **silence**, and it can only be said in advance.
+>
+> **What is permitted**: a compile-time constant naming a platform *capability*, so an interface can
+> state a limitation. **What is not**: platform-conditional behaviour, and a growing function seam —
+> both unchanged, and the sentence above still governs them. The distinction is the one
+> [ADR-0003](0003-client-stack.md) won the stack decision with, *a `#[cfg]` the compiler checks beats
+> a runtime `if` nobody checks*: this rule exists to stop divergence becoming **invisible**, and a
+> capability constant exists to make a limitation **visible**.
+>
+> **This does not discharge the contradiction above**, which is about a platform capability *function*
+> for a non-storage crate. That is still open, and its recorded fix still stands.
+
 The two arms are not symmetric in one respect worth recording: `store`'s Android arm reads the JVM
 handle from `ndk_context`, which `android-activity` populates inside `leitner-app`. So the store
 cannot be opened before the activity exists, **`leitner-store` is not independently runnable on

--- a/docs/adr/0013-the-sync-transport.md
+++ b/docs/adr/0013-the-sync-transport.md
@@ -157,6 +157,13 @@ A third joins them in §8: **the client must be registered as the "TVs and Limit
 type.** All three are console settings that nothing in this repository can validate, and each fails
 by making sync mysteriously unavailable rather than by producing an error anyone can act on.
 
+> **A fourth, added by [ADR-0015 §16](0015-the-sync-experience.md): the consent screen's application
+> name.** §9's revocation and ADR-0015 §10's *"delete the hidden data yourself"* route both end at a
+> list in the user's account settings, where our application appears under **that** name. The folder
+> is hidden, so there is no path to give and the name is the whole of the instruction — get it wrong
+> and *"find it in the list"* fails with nothing anyone can act on. Same class as the three above,
+> and same remedy: check it in the console, because no code path here can.
+
 **Rejected: Dropbox**, on the ceiling above. Its unauthenticated long-poll — the only push-shaped
 mechanism anywhere in the research, blocking up to 480 seconds with no credential in flight — is
 genuinely elegant and buys less than it appears to, because Android lists network as **Disabled** in
@@ -493,6 +500,18 @@ an unrelated reason gets its own module under the same three-arm discipline.
    adversely affected, which a few-kilobyte sync cannot claim. So the promise available is: **sync
    when the user opens the app, and opportunistically before that.** Anything stronger is
    overpromising, and #33 established it applies identically to every candidate.
+
+   > **Corrected by [ADR-0015 §16](0015-the-sync-experience.md): the binding ceiling is ours, not the
+   > platform's.** Every limit above is real and **none is ever reached**, because nothing schedules.
+   > A periodic job or a foreground service needs Java, a `classes.dex` and a Gradle project —
+   > [ADR-0003](0003-client-stack.md)'s measured prize, which
+   > [ADR-0014 §3](0014-when-parameter-optimisation-runs.md) already declined to spend on a 4.3 s
+   > job. **There is no background sync on either platform**, so the promise narrows to *"your
+   > devices catch up when you open the app"*, with *"and opportunistically before that"* withdrawn.
+   > ADR-0015 §2 accepts that on the ground that **a device not being used has nothing to publish and
+   > nobody waiting to read from it** — and ADR-0015 §6 then makes the absence **load-bearing**,
+   > because it is what allows sync to be deferred during a review session, fixing the mid-session
+   > queue shift [ADR-0014](0014-when-parameter-optimisation-runs.md) called locally unfixable.
 2. **"Am I behind?" is answered by a listing and costs one round trip** (§6). Whatever the UI says
    about divergence, it is not paying for the answer.
 3. **A device that has been away for months may need to re-enrol** (§3). That is a UI moment, and it

--- a/docs/adr/0015-the-sync-experience.md
+++ b/docs/adr/0015-the-sync-experience.md
@@ -1,0 +1,499 @@
+# ADR-0015: The sync experience
+
+- **Status**: Accepted
+- **Date**: 2026-07-31
+- **Resolves**: [Decide: the sync experience](https://github.com/amin-bf/leitner/issues/40)
+- **Map**: [Map: local-first Leitner app spec](https://github.com/amin-bf/leitner/issues/1)
+- **Related**: [ADR-0013](0013-the-sync-transport.md) (the transport, and the four requirements it
+  placed here), [ADR-0014](0014-when-parameter-optimisation-runs.md) (the mid-session queue shift,
+  handed here whole), [ADR-0004](0004-the-review-event-log.md) (row identity, device labels, the
+  clock-skew residual), [ADR-0003](0003-client-stack.md) (the Gradle-free APK, no Android IME),
+  [ADR-0006](0006-the-review-session-experience.md) (the session, derived position),
+  [ADR-0009](0009-crate-and-workspace-layout.md) (the platform seam),
+  [ADR-0010](0010-leeches.md) (detect and surface, never intervene),
+  [ADR-0008](0008-the-deck-export-format.md) (the Android intent filter for a deck file)
+
+## Context
+
+[ADR-0013](0013-the-sync-transport.md) settled the **mechanism** — a key-value namespace on a
+personal cloud drive's application data folder, one writer per namespace, nothing ever rewritten,
+the listing as the version summary — and deliberately left everything the user sees to this ticket,
+naming four requirements. [ADR-0014](0014-when-parameter-optimisation-runs.md) added a fifth, and
+called it structurally unfixable where it stood.
+
+Two things about this decision are worth stating before the decisions themselves.
+
+**Almost nothing here is a data problem.** [ADR-0004 §2](0004-the-review-event-log.md) makes merging
+set union on `(writer, sequence)`; there is no conflict resolution because two rows with the same
+pair are the same row. Everything below is therefore about what a person is told and when — which is
+why it took a conversation rather than a measurement.
+
+**Two of the ticket's questions dissolved rather than resolving**, and both dissolutions are load
+bearing. The ticket asked how a device presents *"you are behind"*; §4 finds that state is transient
+by construction and the app is never entitled to rest in it. And [ADR-0013](0013-the-sync-transport.md)'s
+handoff asked how long a handset left alone goes between background syncs; §2 finds there are none,
+so the question has no subject.
+
+## Decision
+
+### 1. Divergence is accepted, always, and nothing is ever locked
+
+> **There is no state in which the application declines to let the user review.**
+
+The alternative carried on the map since charting was pessimistic single-writer: sync on open and on
+close with the UI locked while it runs, so two devices never diverge. It loses on four counts, in
+descending strength.
+
+**A lock needs a lock-holder, and this transport structurally cannot be one.**
+[ADR-0013 §1](0013-the-sync-transport.md) is four operations wide — put, get, list, delete — with no
+locking, no transaction and no server-side computation of any kind. A lock is a *shared* key, and
+[§1](0013-the-sync-transport.md)'s single-author-per-key property is what removes every need for a
+conditional write. Introducing one key with two writers would reopen, for a UI nicety, the exact
+hazard #33 measured: two of three servers returning `201 Created` while silently ignoring the
+precondition.
+
+**An offline device cannot be locked at all**, so the guarantee is not merely weaker than it looks —
+it is unenforceable. The map fixes offline-by-default as the operating mode rather than a feature,
+which makes the unenforceable case the *normal* one.
+
+**There is no conflict to prevent.** Two devices reviewing simultaneously produce a union, not a
+collision.
+
+**And it trades a non-problem for a real one.** A user in a drawer, on a plane, or with a broken
+grant would be blocked from the application's only function.
+
+**The accepted cost, stated rather than glossed: two diverged devices can review the same card on the
+same day, and replay sees both.** [ADR-0001 §5](0001-scheduling-algorithm-and-grade-scale.md) already
+makes same-session re-shows real logged rows with `delta_t = 0`, so the second grading is absorbed as
+a re-show rather than corrupting anything. It perturbs one card's stability slightly and later
+reviews pull it back — **bounded and self-limiting**, the same shape as
+[ADR-0004 §8](0004-the-review-event-log.md)'s clock-skew residual, and a dividend of the same
+replay-not-migrate property that created the exposure.
+
+This also settles the ticket's *plane case* outright. There is nothing left of it: you cannot sync
+before use, so you diverge, and diverging is cheap.
+
+### 2. Sync runs on three foreground triggers, and there is no background sync at all
+
+[ADR-0013](0013-the-sync-transport.md)'s first requirement gave this ticket the promise *"sync when
+the user opens the app, and opportunistically before that,"* bounded by Android listing network as
+**Disabled** in the Rare and Restricted app-standby buckets.
+
+**The ceiling is one step earlier than that, and it is ours rather than the platform's.** A scheduled
+job or a foreground service needs Java, a `classes.dex` and a Gradle project — precisely what
+[ADR-0003](0003-client-stack.md) measured as its prize (an APK that is a manifest plus one `.so`,
+against 44 committed generated files for each alternative stack) and what
+[ADR-0014 §3](0014-when-parameter-optimisation-runs.md) already refused to spend on a 4.3 s job. The
+standby-bucket ceiling would only bite if we had a scheduler to be throttled. We do not, and we have
+now twice decided not to build one. **So the *"opportunistically before that"* half of the promise is
+not ours to make.**
+
+That is not a loss worth reopening, on one argument: **a device that is not being used has nothing to
+publish, and nobody is waiting to read from it.** Background sync's entire value is a device that is
+*in use but not open*, which is not a state this application has. The drawer phone's user opens the
+app when they return to it; its local log was complete the whole time.
+
+> **Three triggers, and nothing else: the app becoming active, session end, and explicit user
+> action.**
+
+1. **The app becomes active** — launch, or the window or app regaining focus — subject to a
+   **recency floor** so that alt-tabbing does not hammer the remote. This is the trigger that
+   matters, because it puts the queue in front of the user already current. The floor is a
+   *debounce*, not a schedule; [ADR-0014 §7](0014-when-parameter-optimisation-runs.md) already
+   sanctions the notion, allowing its leading sync to be skipped when one is already recent.
+2. **Session end** — the first moment the local log holds something worth publishing.
+3. **Explicit user action** — a control in sync settings, and
+   [ADR-0014 §7](0014-when-parameter-optimisation-runs.md)'s leading step of Optimise.
+
+**Rejected: a timer while the app is open.** A clock in a codebase that has spent real effort keeping
+clocks out — [ADR-0004 §4](0004-the-review-event-log.md) freezes day numbers at write time precisely
+so nothing recomputes them — for marginal freshness. *Focus regained* covers the desktop
+sit-open-all-day case with a user-caused trigger and no schedule.
+
+**Rejected: publishing per graded card.** It multiplies exactly the object count
+[ADR-0013 §5](0013-the-sync-transport.md) exists to bound, for a latency nobody is waiting on.
+
+**Rejected: sync on close.** It is *safe* — an interrupted publish means the next one covers an
+overlapping range, and [ADR-0013 §5](0013-the-sync-transport.md)'s rule 1 makes overlap free because
+merge is set union — but on Android "close" means **frozen**
+([`AGENTS.md`](../../AGENTS.md) client-stack rule 10), so it may simply not complete, and it adds
+nothing over session end.
+
+**Rejected: a session-start trigger.** It puts a network round trip between the user's intent and
+their first card, and trigger 1 already covers it in the overwhelming case.
+
+**The consequence, recorded so it is not mistaken for an oversight**: a user who reviews and then
+force-quits without ending a session publishes on next launch instead. That is why the answer is not
+"on every write".
+
+### 3. The promise is "your devices catch up when you open the app"
+
+> **Never "automatic", never "always in sync", never "in the background".**
+
+This is a rule rather than a preference, because it is the kind of copy written later by someone who
+was not in this conversation. It appears on the enrolment screen and in sync settings, and nowhere
+else — a promise repeated in tooltips is a promise nobody reads.
+
+### 4. The resting surface states a fact, never a claim — and "you are behind" dissolves
+
+The ticket asked how a device presents *"you are behind"*, now that
+[ADR-0013 §6](0013-the-sync-transport.md) prices the answer at one listing and one round trip.
+**The application can never honestly rest in that state**:
+
+- If it can reach the remote, the handshake *is* the listing, so discovering it is behind and fixing
+  it are one operation separated by seconds. **"Behind" is a progress state, not a warning.**
+- If it cannot reach the remote, **it does not know** whether it is behind. Nothing has told it.
+
+So the sentence is one the app is either about to make untrue, or is not entitled to say.
+
+**"In sync" is a claim the app cannot back, and this is constraint 4's shape on a new surface.** After
+a successful sync it knows every writer's highest *published* sequence and that it holds all of them
+— that much is real. It does **not** know whether another device has reviewed since it last
+published, and it never can. A green checkmark would be read as *"all my devices agree"*, which is
+unknowable, exactly as a box badge would be read as a claim about the queue.
+
+> **The resting surface is one line in sync settings: "Last caught up ⟨when⟩." No checkmark, no "in
+> sync", no "up to date", and no persistent status indicator anywhere in the chrome.**
+
+A sync in flight shows transient, non-blocking progress where it was triggered, and gates nothing
+(§1). This follows [ADR-0010 §9](0010-leeches.md)'s leech pointer and
+[ADR-0014 §2](0014-when-parameter-optimisation-runs.md)'s optimisation nudge, each surfaced in
+exactly one place.
+
+**Accepted cost**: a user whose sync is merely offline for a month gets no signal, and *"Last caught
+up 4 weeks ago"* sits in settings where they are not looking. They are reviewing fine, their log is
+complete, and there is nothing for them to do — but this is a deliberate choice to let a long silence
+pass unremarked, not an omission.
+
+### 5. Silence on network failure, speech on auth failure — and only two things ever speak
+
+**The rule keys on the *kind* of failure, not its duration**, and the application can tell them
+apart: an expired grant is a specific response, not a timeout.
+
+| | Surface |
+|---|---|
+| **Network failure** — offline, timeout, DNS | **Nothing, ever.** Offline is normal and must never nag. |
+| **Auth failure** — the grant died | A **persistent, non-modal notice**. This is the one sync state the user must act on. |
+
+**No threshold and no failure counter anywhere in this**, for
+[ADR-0014 §2](0014-when-parameter-optimisation-runs.md)'s reason: there is no defensible number, and
+inventing one is worse than keying on something real.
+
+Exactly two things are permitted to use that notice channel: the dead grant above, and
+[ADR-0004 §8](0004-the-review-event-log.md)'s clock-skew warning (§11). Anything else that wants to
+speak about sync is a defect against §4.
+
+### 6. Sync never starts while the review screen is up
+
+[ADR-0014](0014-when-parameter-optimisation-runs.md)'s first requirement handed this over whole and
+called it locally unfixable: [ADR-0006 §2](0006-the-review-session-experience.md) derives session
+state from the log every frame, so a new parameter vector recomputes every `(S, D)` mid-session, and
+blocking review during an optimisation run cannot help because **a merge landing another device's
+vector is the identical event with no local trigger to gate on.**
+
+That reasoning was correct and was written before §2 existed. **§2's foreground-only triggers supply a
+local trigger after all** — not a gate on review, which §1 forbids, but a gate on *sync*:
+
+> **We never start a sync while the review screen is up. A sync already in flight finishes normally.**
+
+This costs nothing. The user was already made current by the becoming-active sync *before* the
+session started, so what is deferred is a *re*-sync; and
+[ADR-0006 §1](0006-the-review-session-experience.md) bounds a session at a chosen count with a
+ten-minute checkpoint, after which §2's session-end trigger fires immediately.
+
+The exposure then collapses to cases the user causes:
+
+- **Leaving the session, pressing Sync or Optimise, and returning** — possible because
+  [ADR-0006 §2](0006-the-review-session-experience.md) stores no session position.
+  [ADR-0014 §4](0014-when-parameter-optimisation-runs.md)'s completion message already states that
+  every due date moved. Their action, their answer.
+- **An in-flight sync landing in the first seconds of a session.** Accepted rather than fixed:
+  holding fetched rows unapplied makes the local log and what we have downloaded disagree, which is
+  real machinery for a window a few cards wide. **Only the *starting* of a sync is suppressed.**
+
+**Deliberately not suppressed: a sync landing while the count picker is up**, changing the cap that
+[ADR-0006 §1](0006-the-review-session-experience.md) derives from what is due. The user has committed
+to nothing, and picking from the true number is what syncing before a session is *for*.
+
+**The knock-on is worth recording because it inverts how §2 reads.** This answer exists only because
+§2 chose foreground-only triggers. Background sync would have made the deferral unenforceable, so a
+decision taken on packaging grounds turns out to buy the session's stability — and anyone later
+reading "no background sync" as a limitation to be lifted would not see that it is load-bearing.
+
+### 7. Enrolment is opt-in, lives in settings, and is surfaced by the empty state
+
+[ADR-0013 §8](0013-the-sync-transport.md) fixed the device flow and that sync never blocks first use.
+
+**No first-run prompt.** Someone installing a flashcard application should not meet an authorisation
+flow before their first card.
+
+**But burying it fails the second-device user, whose entire reason for installing is sync.** So it is
+surfaced in the **empty-collection state**, in [ADR-0006](0006-the-review-session-experience.md)'s
+style of explicit worded states: *"Nothing here yet — create a deck, import one, or set up sync to
+bring in another device's collection."* A worded empty state, not a wizard.
+
+**The screen states the scope in plain words.** Granting drive access is the friction point and the
+true answer is unusually good: `drive.appdata` reaches a hidden folder only this application can see,
+not the user's files. **Only `drive.appdata` is requested** — not `email` — so the consent screen asks
+for exactly one thing.
+
+**After enrolment, the application states what it found.** This is the most load-bearing part of §7,
+because **enrolling a second device against the wrong account is undetectable**:
+[ADR-0013 §10](0013-the-sync-transport.md) scopes the folder per (account, application), so a wrong
+account presents an **empty folder — identical to being the first device to enrol.** No collection
+identity fixes this; an empty folder carries no information. The only defence is a fact stated at the
+one moment the user could notice:
+
+> *"This is the first device here"* — versus — *"Found 2 other devices: Laptop, Pixel."*
+
+A user who expected to join an existing collection and reads the first sentence has caught it.
+Detect and surface, in [ADR-0010](0010-leeches.md)'s shape.
+
+**The words.** [`crates/sync/src/CONTEXT.md`](../../crates/sync/src/CONTEXT.md) already rules out
+*login*, *sign-in* and *pairing* — there is no account of ours and no device-to-device step. The
+action is **"Set up sync"**. The provider is named, because the user must recognise which account
+they are choosing; that is the interface requiring it, not a breach of the name-the-fact rule, which
+governs prose leaning on a product instead of explaining itself.
+
+### 8. Devices label themselves at enrolment
+
+[ADR-0004 §3](0004-the-review-event-log.md) says *"a device meeting an unfamiliar writer asks what to
+call it."* **Asking a user to name a stranger is a puzzle they cannot solve.** Asking them to name
+**the device in their hand** is trivial — and because labels ride
+[ADR-0004 §7](0004-the-review-event-log.md)'s mutable surface, every other device then already knows
+it.
+
+> **Each device is labelled by its user at enrolment, and the label syncs.**
+
+§3's ask-about-a-stranger path narrows to a writer whose label never arrived, and to §3's reinstall
+case, where typing the same name is exactly what groups several writer ids under one label.
+
+**No default derived from hostname or device model.** That would be a platform function, and
+[ADR-0009 §4](0009-crate-and-workspace-layout.md) calls a third function in the seam the tell that it
+is eroding. The user types it, once per device.
+
+**Labels needed a new justification and have one.** §4 removed the reason
+[ADR-0004 §3](0004-the-review-event-log.md) gave for their existence — *"'you are behind your laptop'
+is a sentence; 'you are behind `7f3a-b21c`' is not"* — and that sentence no longer gets said. They
+survive on two uses: the device list in sync settings (§12), and **§11's clock-skew warning, which
+must name the offending device.**
+
+### 9. The Android text-input limitation is stated in advance, at the point of failure
+
+[`AGENTS.md`](../../AGENTS.md) client-stack rule 8 records that winit's Android backend has no IME
+path, so composed text never reaches the application. **The failure mode is the problem, not the
+limitation**: a user switches to a non-Latin keyboard, types, and **nothing happens at all.** We
+receive no events, so we cannot detect the attempt and cannot report it when it occurs. It can only
+be stated **in advance**, or it reads as a bug.
+
+**One correction to the ticket's premise.** It holds that sync is the only route for non-Latin
+content and that *"there is no second route and no fallback."* That is true of **authoring** and
+false of **receiving**: [ADR-0008 §10](0008-the-deck-export-format.md) specifies an Android intent
+filter matching a `pathPattern` for the extension, so a deck file opens from a file manager or a mail
+attachment. An Android-only user with non-Latin content is locked out of writing their own, not out
+of the application.
+
+Stating it where it bites means the Android editor says something the desktop editor does not —
+**platform-varying UI**, which collides with [`AGENTS.md`](../../AGENTS.md) client-stack rule 3.
+[ADR-0012](0012-the-note-authoring-experience.md)'s phone layout dodges this by keying on width, but
+*"can this device type Persian"* is not a width property.
+
+> **A compile-time capability constant, and the note editor varies on it. The Android editor carries
+> a standing quiet line: this device types Latin text only; author other scripts on the desktop and
+> they sync here.**
+
+The argument is one this repository has already won once.
+[ADR-0003](0003-client-stack.md) chose its whole stack partly because *"a `#[cfg]` the compiler checks
+beats a runtime `if` nobody checks."* Rule 3 exists to stop **behaviour** diverging silently between
+platforms; a constant whose only job is to make a limitation **visible** is the inverse of what it
+guards. §15 amends [ADR-0009 §4](0009-crate-and-workspace-layout.md) to say so explicitly rather than
+leaving the next agent to weigh a rule against its purpose.
+
+**Rejected: stating it only where it is true on both platforms** (sync settings and enrolment). Zero
+platform code, and it leaves the silent-nothing failure fully intact — the Android user meets the
+explanation late or never.
+
+**Rejected: showing the line on both platforms.** No `cfg`, and on desktop it is a permanent
+statement about a limitation the reader does not have.
+
+**Nothing about sync changes for this user**, and they are the strongest case against §4's silence:
+the desktop-authors / phone-reviews user depends on sync more than anyone, and if it fails on the
+network for a month, new cards stop arriving with the application saying nothing. §4 holds anyway —
+they notice the absence, settings holds the answer, and adding a nag for one user class breaks a rule
+that is right for everyone.
+
+### 10. Disconnect is the only control; revocation is explained, not owned; nothing is deleted
+
+Three things a user might mean by "stop syncing", with different blast radii.
+
+**Disconnect drops the local grant and stops syncing. It deletes nothing and revokes nothing.** It is
+the only one of the three the application can do cleanly, and it is reversible: re-enrol and the
+device resumes under its existing writer id, since
+[ADR-0004 §3](0004-the-review-event-log.md) ties that id to the install rather than to the grant.
+
+**Revocation is not ours to offer, and its shape must be met before it is needed.**
+[ADR-0013 §9](0013-the-sync-transport.md): every device holds a token issued against one client id,
+so the account's security page lists this application once, with one button — **revoking for a lost
+phone logs out every device the user owns.** That is genuinely surprising, and the moment to learn it
+is not while replacing a stolen phone. Sync settings states it plainly and points at where it is
+done, rather than pretending to a control we do not have.
+
+**There is no "delete my synced data" control**, and this is a deliberate refusal:
+
+- The `drive.appdata` grant reaches the **whole** application folder, so a delete from one device
+  destroys **other writers' namespaces**. Every device holds the whole log — but only the rows it has
+  already fetched. A device that never fetched writer `A`'s rows loses them permanently if `A` is
+  also gone.
+- Its only conceivable benefit is reclaiming space, and there is none to reclaim:
+  [ADR-0013 §5](0013-the-sync-transport.md) bounds live objects at a few hundred per collection, and
+  #33 measured **47.5 MB per decade**.
+- The capability already exists on the user's side, and offering it here invites tidying up something
+  [ADR-0013 §2](0013-the-sync-transport.md) made disposable on purpose.
+
+**What we give instead is a name and a navigation path — not a folder path, because there is not
+one.** `appDataFolder` is hidden ([ADR-0013 §3](0013-the-sync-transport.md)), so it does not appear in
+the user's file view and cannot be navigated to. What exists is the drive's **connected-applications
+settings**, which carries a delete-hidden-application-data action per application. Sync settings names
+that route and **the name we appear under**.
+
+**That name is a fourth console trap** in [ADR-0013 §3](0013-the-sync-transport.md)'s series: it is
+the consent screen's application name, a setting no code path in this repository can validate. If it
+does not match what the user knows the application as, *"find it in the list"* fails with nothing
+anyone can act on. The exact menu wording is a third party's UI, expected to drift — **verified at
+implementation, never pinned in this document.**
+
+The tension, stated rather than buried: a privacy-minded user asking *"delete everything you have put
+in my drive"* is told to do it themselves. That is correct — it is their storage, the folder's
+documented purpose is to hold our data, and [ADR-0013 §2](0013-the-sync-transport.md) means nothing
+there is precious — but it is a refusal of a reasonable-sounding feature, not an oversight.
+
+### 11. The clock-skew warning names the device, and never offers the repair inline
+
+[ADR-0004 §8](0004-the-review-event-log.md) shipped *"guard on write, detect on merge and warn
+without blocking, collection-wide cutoff as the only repair"* and never assigned the warning a
+surface. It is a merge-time event, so it is this document's.
+
+> **It uses §5's persistent non-modal channel, names the device by its §8 label, states the fact, and
+> does not offer the cutoff.**
+
+The repair discards good history alongside bad — [ADR-0004 §8](0004-the-review-event-log.md)'s
+accepted residual in full — so it lives in sync settings behind an explanation of what it costs, and
+never one tap from a notice the user met by surprise. **Detect and surface, never intervene**: the
+third instance after [ADR-0010](0010-leeches.md) and
+[ADR-0014](0014-when-parameter-optimisation-runs.md).
+
+**It is dismissible and keyed to the rows that triggered it**, so it does not re-fire on every
+subsequent merge of a log that still contains them. A warning that returns forever is one the user
+learns to ignore, which is the failure mode this whole document has been avoiding.
+
+### 12. What the sync settings screen holds
+
+One screen, and everything sync-shaped is on it:
+
+| | Source |
+|---|---|
+| **"Last caught up ⟨when⟩"** | §4 |
+| **Sync now** | §2's third trigger |
+| **The device list** — labels grouped per [ADR-0004 §3](0004-the-review-event-log.md), several writer ids under one label, each with "last published ⟨when⟩" | §8; read straight off [ADR-0013 §6](0013-the-sync-transport.md)'s listing, so it costs no extra request |
+| **Disconnect** | §10 |
+| **How revocation works, and where** | §10 |
+| **The history cutoff**, behind its explanation | §11 |
+| **The desktop-authoring statement** | §9 |
+
+### 13. Cold start is a load, not a lock
+
+A freshly enrolled device fetching everything is the one genuinely long operation in the feature, and
+it does not violate §1. **On a fresh device there is nothing to review until it lands**, so a progress
+screen is the honest state rather than a block — nothing is being withheld. **On a device that
+already held content and then enrolled**, review continues and rows land as they arrive, which is
+§1's accepted divergence.
+
+[ADR-0013 §5](0013-the-sync-transport.md) is what makes this bounded: a few hundred objects rather
+than the ~43,800 that one-object-per-sync would have produced over a decade.
+
+**Roll-up remains invisible**, discharging [ADR-0013](0013-the-sync-transport.md)'s fourth
+requirement: it is not a user-facing operation, has no progress to report, and its failure mode is a
+retry.
+
+## Amendments to accepted ADRs
+
+### 14. [ADR-0004 §3](0004-the-review-event-log.md) — devices label themselves, and labels have a new justification
+
+§3 describes a device *"meeting an unfamiliar writer"* and asking the user what to call it. §8 above
+inverts the default: **a device is labelled by its user at enrolment and the label syncs**, so the
+ask-about-a-stranger path is the exception — a writer whose label never arrived, or §3's reinstall
+case.
+
+§3's stated reason for labels existing — *"'you are behind your laptop' is a sentence"* — **no longer
+holds**, because §4 finds that sentence is one the application is never entitled to rest on. Labels
+are retained on two different grounds: §12's device list, and §11's clock-skew warning, which must
+name a device to be actionable. The identity split itself (machine-owned writer ids, human-owned
+labels, never adopted) is untouched.
+
+### 15. [ADR-0009 §4](0009-crate-and-workspace-layout.md) — the platform prohibition is on behaviour, not on capability
+
+§4 and [`AGENTS.md`](../../AGENTS.md) client-stack rule 3 forbid a `#[cfg(target_os)]` outside
+`leitner-store::platform` and call a third function arriving there the tell that the seam is eroding.
+That rule stands, and its scope is now stated: **it prohibits platform-conditional *behaviour* and a
+growing function seam. A compile-time constant that names a platform *capability*, so the interface
+can state a limitation the user would otherwise meet as silence, is permitted.**
+
+The distinction is the one [ADR-0003](0003-client-stack.md) already won the stack decision on — a
+`#[cfg]` the compiler checks over a runtime `if` nobody checks. A capability constant makes a
+limitation visible; the rule exists to stop divergence becoming invisible. §9 is its first and, for
+now, only use.
+
+### 16. [ADR-0013](0013-the-sync-transport.md) — two corrections
+
+**Requirement 1's ceiling is ours, not the platform's.** It bounds the promise by Android's standby
+buckets, periodic-work floor and foreground-service caps. §2 finds the binding constraint one step
+earlier: **no background scheduling mechanism is available to us at all** without spending
+[ADR-0003](0003-client-stack.md)'s Gradle-free APK, which
+[ADR-0014 §3](0014-when-parameter-optimisation-runs.md) already declined to do. The platform ceilings
+are real and never reached, because nothing schedules. The promise narrows accordingly (§3).
+
+**§3 gains a fourth console trap**: the consent screen's application name is what the user must
+recognise in their drive's connected-applications list (§10). Like the Production publishing status
+and the *TVs and Limited Input devices* client type, it lives in a console, cannot be validated by
+anything in this repository, and fails by making a documented route un-followable rather than by
+producing an error.
+
+## Requirements this places on downstream tickets
+
+### [#37 — backup and restore](https://github.com/amin-bf/leitner/issues/37)
+
+1. **§10 refuses a delete-remote-data control**, on the reasoning that the sync namespace is
+   disposable. If #37 introduces an artifact that is *not* disposable, that reasoning does not
+   transfer to it, and the two must not share a control.
+2. **§7's "what we found" statement is the only guard against a wrong-account enrolment**, and it is
+   wording rather than detection. If #37's collection identity work makes an import distinguishable
+   from a restore, check whether it also makes this case detectable — it is the same shape, and §7
+   would rather be replaced by a mechanism than kept as a sentence.
+
+## Consequences
+
+- **Exactly two things are permitted to speak about sync** — a dead grant and a clock-skew warning.
+  Any third is a defect against §4, and this is the rule most likely to erode, because every future
+  feature has a reason to want a badge.
+- **The absence of background sync is load-bearing, not a limitation to lift.** §6's session
+  stability depends on it. Anyone reopening it inherits the mid-session queue shift
+  [ADR-0014](0014-when-parameter-optimisation-runs.md) called unfixable.
+- **The application never claims two devices agree**, because it cannot know. Any future surface that
+  implies it breaks §4.
+- **A wrong-account enrolment remains undetectable**, mitigated only by a sentence. This is the
+  weakest point in the document and is recorded as such.
+- **[`AGENTS.md`](../../AGENTS.md) gains sync-experience rules**, because three of the above fail
+  silently: the two-speakers rule, "never start a sync while the review screen is up", and the
+  no-delete-remote-data refusal, whose reasoning is invisible from the code that would implement it.
+- **A visual design pass now owes three surfaces it does not know about**: sync settings, the
+  non-modal notice channel, and the cold-start progress state.
+
+## Open items handed onward
+
+| Item | Owner |
+|---|---|
+| ~~How long a handset left alone goes between successful background syncs~~ — **dissolved in §2**: there are none | — |
+| The recency floor's value for §2's trigger 1 | Implementation; a debounce, not a compatibility constant |
+| Exact copy for the drive's connected-applications route (§10) — a third party's UI, expected to drift | Implementation |
+| Visual treatment of sync settings, the notice channel and cold-start progress | Map fog — *a visual design pass* |
+| Whether collection identity makes a wrong-account enrolment detectable | [#37](https://github.com/amin-bf/leitner/issues/37) |


### PR DESCRIPTION
Resolves [Decide: the sync experience](https://github.com/amin-bf/leitner/issues/40) on [the map](https://github.com/amin-bf/leitner/issues/1), as **ADR-0015**. [ADR-0013](https://github.com/amin-bf/leitner/blob/main/docs/adr/0013-the-sync-transport.md) settled the mechanism and left everything the user sees here, naming four requirements; [ADR-0014](https://github.com/amin-bf/leitner/blob/main/docs/adr/0014-when-parameter-optimisation-runs.md) added a fifth and called it structurally unfixable where it stood.

Almost nothing here is a data problem — ADR-0004 §2 makes merging set union — so this is about what the app is *entitled to say*, and it was settled by grilling rather than by measurement.

## Two questions dissolved rather than resolving

**"You are behind" is a sentence the app is never entitled to rest on.** If it can reach the remote, the handshake *is* the listing, so discovering it is behind and fixing it are one operation seconds apart — a progress state, not a warning. If it cannot, it does not know. The same reasoning kills the checkmark: **"in sync" is a claim the app cannot back**, since after a sync it knows every writer's highest *published* sequence and never whether another device has reviewed since. That is constraint 4's shape on a new surface. The resting surface is one fact in settings: **"last caught up ⟨when⟩."**

**There is no background sync at all**, so ADR-0013's handoff question about background intervals has no subject. That ADR bounded the promise by Android's standby buckets; the binding ceiling is one step earlier and **it is ours** — a scheduled job needs Java, a `classes.dex` and a Gradle project, ADR-0003's measured prize that ADR-0014 §3 already declined to spend. Accepted because **a device not being used has nothing to publish and nobody waiting to read from it.**

## The decisions

- **Divergence accepted always; nothing ever locked.** A lock needs a lock-holder this transport structurally cannot be — a lock is a *shared* key, and ADR-0013 §1's single-author-per-key property is exactly what removes every need for a conditional write. An offline device cannot be locked at all. **Settles the plane case outright.**
- **Three foreground triggers** — becoming active (debounced), session end, explicit action. A timer, per-card publishing, sync-on-close and a session-start trigger all rejected.
- **Sync never starts while the review screen is up.** ADR-0014 handed over the mid-session queue shift as locally unfixable, and it was — *before the trigger decision existed*. Foreground-only triggers supply a gate on *sync* rather than on review. **A choice taken on packaging grounds turns out to buy the session's stability**, making the absence of background sync load-bearing rather than a limitation to lift.
- **Exactly two things may ever speak about sync** — a dead grant, and ADR-0004 §8's clock-skew warning, whose surface was unassigned until now, which names the device and never offers the cutoff inline. Network failure never speaks.
- **Enrolment ends by stating what it found**, because a wrong-account enrolment is undetectable — an empty folder is identical to being the first device. That sentence is the whole defence and is **recorded as the weakest point in the ADR**.
- **Devices label themselves at enrolment**, inverting ADR-0004 §3, whose stated justification for labels the dissolution above destroyed.
- **Disconnect only, no delete-remote-data control** — the grant reaches the *whole* app folder, so a delete destroys other writers' namespaces, for nothing reclaimed.
- **The Android text-input limitation is stated in advance** via a compile-time capability constant, because we receive no events and the failure is *silence*.

## Amends three accepted ADRs

- **ADR-0004 §3** — devices label themselves; labels re-justified on the device list and the skew warning.
- **ADR-0009 §4** — the prohibition is on platform-conditional *behaviour* and a growing function seam, not on a capability constant. §4 already carried ADR-0013 §12's note that *"the next ticket to need one will meet it with no equivalent escape"* — this is that ticket, from an angle the note did not anticipate. **It does not discharge the original contradiction**, which is about a capability *function* for a non-storage crate.
- **ADR-0013** — requirement 1's ceiling is ours not the platform's; §3 gains a **fourth console trap**, the consent screen's application name.

`AGENTS.md` gains a *what the user sees* section for four silently-failing rules.

## Also corrects this ticket's own premise

*"No second route and no fallback"* for non-Latin content is true of **authoring** and false of **receiving** — ADR-0008 §10's Android intent filter opens a deck file from a file manager or mail attachment.

## Verification

`cargo check --workspace` clean; `cargo test --workspace` **17 passed, 0 failed**. ADR-0015 confirmed free against `origin/main` immediately before committing. All three commits signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)