### PR TITLE
Note Authoring / Keep Ordinal Position and Make the Dormant Entry a Line

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -92,14 +92,14 @@ Read the ADR sections in your row. Read the whole ADR only if you are changing t
 
 | Context | Binding ADRs | Also bound by |
 |---|---|---|
-| `content` | [0002](./docs/adr/0002-the-card-model.md), [0005](./docs/adr/0005-the-deck-model.md), [0017](./docs/adr/0017-card-slots.md) | 0011 §7, 0012 §3 |
+| `content` | [0002](./docs/adr/0002-the-card-model.md), [0005](./docs/adr/0005-the-deck-model.md), [0017](./docs/adr/0017-card-slots.md) | 0011 §7, 0012 §3, 0018 §3 |
 | `log` | [0004](./docs/adr/0004-the-review-event-log.md) | 0002 §7, 0001 §6, 0010 §5, 0011 §5, 0013 §12, 0014 §6 |
 | `scheduling` | [0001](./docs/adr/0001-scheduling-algorithm-and-grade-scale.md) | 0004 §4, 0004 §5, 0014 §6 |
-| `replay` | *none of its own* | 0001 §7, 0002 §7, 0004 §9, 0007 §2, 0010 §2, 0011 §8, 0012 §5, 0017 §1, 0017 §5 |
+| `replay` | *none of its own* | 0001 §7, 0002 §7, 0004 §9, 0007 §2, 0010 §2, 0011 §8, 0012 §5, 0017 §1, 0017 §5, 0018 §2 |
 | `store` | [0007](./docs/adr/0007-the-local-store.md) | 0004 §11, 0003 §5, 0013 §9, 0016 §3, 0016 §7 |
 | `export` | [0008](./docs/adr/0008-the-deck-export-format.md), [0016](./docs/adr/0016-backup-and-restore.md) | 0005, 0002 §9, 0004 §11, 0011 §7 |
 | `sync` | [0013](./docs/adr/0013-the-sync-transport.md) | 0004 §2, 0004 §7, 0004 §10, 0007, 0014 §7, 0015 §2, 0015 §4, 0016 §10 |
-| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md), [0010](./docs/adr/0010-leeches.md), [0011](./docs/adr/0011-new-card-rate-and-daily-limits.md), [0012](./docs/adr/0012-the-note-authoring-experience.md), [0014](./docs/adr/0014-when-parameter-optimisation-runs.md), [0015](./docs/adr/0015-the-sync-experience.md) | 0002 §4, 0016 §6, 0016 §11, 0016 §12, 0017 §5, 0017 §6 |
+| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md), [0010](./docs/adr/0010-leeches.md), [0011](./docs/adr/0011-new-card-rate-and-daily-limits.md), [0012](./docs/adr/0012-the-note-authoring-experience.md), [0014](./docs/adr/0014-when-parameter-optimisation-runs.md), [0015](./docs/adr/0015-the-sync-experience.md), [0018](./docs/adr/0018-the-card-pane-ordering.md) | 0002 §4, 0016 §6, 0016 §11, 0016 §12, 0017 §5, 0017 §6 |
 | *the workspace itself* | [0009](./docs/adr/0009-crate-and-workspace-layout.md) | 0013 §11, 0013 §12, 0015 §15, 0016 §5 |
 
 **`replay` having no ADR of its own is why it is a context.** Its rules were each written for another

--- a/crates/app/src/CONTEXT.md
+++ b/crates/app/src/CONTEXT.md
@@ -7,7 +7,10 @@ through, and both platform entry points.
 [ADR-0006](../../../docs/adr/0006-the-review-session-experience.md),
 [ADR-0010](../../../docs/adr/0010-leeches.md) and
 [ADR-0011](../../../docs/adr/0011-new-card-rate-and-daily-limits.md), the last of which **amends
-ADR-0006 §1 and §2** — read those amendments before touching the session; also by
+ADR-0006 §1 and §2** — read those amendments before touching the session;
+[ADR-0012](../../../docs/adr/0012-the-note-authoring-experience.md) and
+[ADR-0018](../../../docs/adr/0018-the-card-pane-ordering.md), the second of which **amends ADR-0012 §1
+and §5** — read those amendments before touching the authoring pane; also by
 [ADR-0002 §4](../../../docs/adr/0002-the-card-model.md) (layout is data, stored once per kind) and
 [ADR-0015](../../../docs/adr/0015-the-sync-experience.md) (everything the user sees about sync — the
 `sync` crate holds the mechanism and none of the surface).
@@ -47,6 +50,31 @@ seen rather than described.
 **Backlog**:
 More cards due than the user will get through. Always *framed* ("pick a comfortable size, the rest
 will keep"), never reported as a bare number.
+
+**Card pane**:
+The authoring editor's second pane: **the cards this note currently generates**, answering "what will
+I be asked" (ADR-0012 §1). Ordered by **raw slot number**, live and dormant alike — never grouped by
+dormancy, and **never sorted on `ordinal & 0x7FFF`**, which would interleave cloze blanks among
+fixed-arity slots and assert an adjacency ADR-0017 §3 partitioned the namespaces to deny (ADR-0018
+§1). The mask is a *name*, never a sort key. On a phone the two panes are a `Write | Cards` toggle.
+_Avoid_: Preview pane — it is not a rendering of the fields, which is the whole result of ADR-0012's
+round 1.
+
+**Dormant entry**:
+How a **dormant card** (see `replay`) appears in the card pane: a **single line** — its name, the word
+*dormant*, its history — never a card and never a greyed card, because a dormant card is the absence
+of a generated card and usually has nothing left to draw (ADR-0018 §2). Named by field roles from the
+collection-wide slot lookup, by masked blank number when the high bit is set, and **by bare slot number
+when neither resolves — shown, never hidden**, since an omission is the header counter that failed
+round 1 (ADR-0018 §3). The history reads *kept*, never *lost*.
+_Avoid_: Dormant card *for the on-screen row* — the card is the domain object, the entry is its line.
+
+**The card pane demonstrates; the form pane warns**:
+Ordinal position **cannot** guarantee a dormant entry is on screen — blank 18 of 20 lands below the
+fold on desktop too — so ADR-0012 §5's form-pane warning is **primary on both platforms**, not
+redundancy for the phone (ADR-0018 §4). Never add a third speaker: a pinned header indicator is the
+counter that failed, and auto-scrolling to a newly-dormant entry needs a before-state that dormancy's
+per-frame recomputation does not have.
 
 **Last caught up**:
 The only resting statement the app makes about sync — *when* it last completed one, a fact.

--- a/crates/core/src/replay/CONTEXT.md
+++ b/crates/core/src/replay/CONTEXT.md
@@ -38,6 +38,8 @@ unprovable is discarded.
 **Dormant card**:
 A `CardRef` with events in the log that the current content no longer generates. **Not a stored
 state** — it is the absence of a generated card, and it reattaches by itself if the content returns.
+Being an absence, it usually has **no content left to render**, which is why its on-screen form in the
+authoring pane is a one-line **dormant entry** rather than a card — see `ui` (ADR-0018 §2).
 _Avoid_: Retired, deleted, orphaned, tombstoned — all of which imply a stored lifecycle that
 deliberately does not exist.
 

--- a/docs/adr/0012-the-note-authoring-experience.md
+++ b/docs/adr/0012-the-note-authoring-experience.md
@@ -39,6 +39,12 @@ follows is D plus the corrections made while driving it.
 The editor is a form on one side and, on the other, **the cards this note currently generates**,
 drawn the way review draws them (ADR-0006) — prompt, separator, answer, with a history badge.
 
+> **Amended by [ADR-0018 §2](0018-the-card-pane-ordering.md): that is true of *live* entries only.**
+> A dormant entry is a **single line** — its name, the word *dormant*, its history — never a card and
+> never a greyed card, because a dormant card is the *absence* of a generated card and so usually has
+> nothing left to draw. The pane therefore holds three entry shapes rather than one: a card, a dormant
+> line, and ADR-0018 §6's statement for a note that currently generates none.
+
 The pane is not a rendering of the *fields*. That distinction is the whole result of round 1:
 a field-rendering preview answers "did I get the markup right", which matters only while typing
 markup, whereas the card preview answers "what will I be asked", which is the question a note
@@ -120,9 +126,29 @@ Three rules:
 > position" sorts **both dormant cards above the live one**. For a pane whose job §1 defines as *"what
 > will I be asked"*, leading with two dormant cards is arguably wrong. Recorded so the rule does not
 > quietly produce it unnoticed.
+>
+> **Settled by [ADR-0018](0018-the-card-pane-ordering.md), which kept this rule.** Ordinal position
+> stands, on the **raw slot number** — no masking, no grouping by dormancy. The defect was never
+> cloze's (a `basic` note switched to `vocab` leads with a dormant card too, with no cloze in sight),
+> and it was never an ordering defect: it assumed a full-size dormant card, which §2 above never
+> specified. As a **line** (ADR-0018 §2), leading costs two lines rather than two screens. What kept
+> ordinal position is a case neither ADR looked at — a deleted cloze blank shows its dormant entry
+> **in its gap**, which is §3's "gaps are shown as normal" delivered by the ordering rule itself, and
+> every partition rule destroys it.
 - **The warning also appears in the form pane**, because on a phone the card pane is behind a
   toggle and an ambient warning that lives only there is invisible exactly when it matters. On
   desktop it therefore appears twice, deliberately.
+
+> **Reason corrected by [ADR-0018 §4](0018-the-card-pane-ordering.md); the rule is unchanged.** The
+> form-pane warning is **primary on both platforms**, and not as redundancy for the phone's benefit:
+> **ordinal position cannot guarantee the card-pane entry is on screen at all.** A twenty-blank cloze
+> note losing blank 18 puts that entry eighteenth — below the fold on desktop too. So the constraint
+> this ADR set, *position is the mechanism*, is not satisfiable by any position rule; visibility is a
+> property of the edit. The card-pane entry **demonstrates**, the form-pane warning **warns**.
+>
+> This also re-reads round 1. Its finding was recorded as *position is the mechanism*; what it showed
+> is that **a count is not a warning** — variant B carried two defects at once, a counter in the header
+> *and* the card below the fold, and the repair was credited to position alone.
 - **It offers Undo**, and the copy says what is true: nothing is deleted, the reviews stay in the
   log, and they reattach by themselves if the content returns.
 
@@ -234,6 +260,10 @@ one-frame deferral to a second reason.
 - **ADR-0002 §9** — its argument for deferring audio is amended by §8 above: it rests on a text
   `Pronunciation` field, which requires a face with IPA coverage.
 
+*(§1 and §5 are in turn amended by [ADR-0018](0018-the-card-pane-ordering.md) — a dormant entry is a
+line rather than a card, and the form-pane warning is primary on both platforms. Both amendments are
+recorded inline above.)*
+
 ## Consequences
 
 - **The authoring surface is the only place two ADR-0002 hazards can be caught.** §5's blank
@@ -255,3 +285,5 @@ one-frame deferral to a second reason.
 - **A soft-keyboard pass on the handset** (§9) — the one question desktop cannot answer.
 - **Saving semantics** (§9) — autosave versus explicit save.
 - **Visual design** — still ADR-0006 §10's open item, now with a second screen waiting on it.
+  Narrowed by [ADR-0018](0018-the-card-pane-ordering.md) for this pane: what a dormant line *says*,
+  where it *sits* and when it appears are settled; only how it *looks* is still that pass's.

--- a/docs/adr/0017-card-slots.md
+++ b/docs/adr/0017-card-slots.md
@@ -130,6 +130,14 @@ answer)`. That converts the most dangerous edit in the repository from a documen
 red build, which matters disproportionately here: the destination fixes that **agents implement this**,
 and an agent reads a failing test far more reliably than a prohibition in an ADR nobody pointed it at.
 
+> **Widened by [ADR-0018 §3](0018-the-card-pane-ordering.md): the golden `slot → (prompt, answer)` list
+> is also a *runtime* lookup**, not only a test fixture. Naming a dormant card requires it — the note's
+> current kind does not declare the slot, so the pane resolves the name across every definition the
+> collection holds, and that is answerable **only** because §1 makes a slot mean one question
+> collection-wide. The price of a slot missing from the table rises accordingly: it broke a test, and
+> now also degrades a user-visible name to ADR-0018 §3's bare-number case, which fails silently where
+> the test fails loudly.
+
 ### 5. The kind change stops being a special case
 
 [ADR-0012 §6](0012-the-note-authoring-experience.md)'s bespoke warning — *"changing kind must state
@@ -155,6 +163,16 @@ switched to `cloze` has dormant cards at slots 2 and 3 and its live blank at 327
 [ADR-0012 §1](0012-the-note-authoring-experience.md) defines as *"what will I be asked"*, leading with
 two dormant cards is arguably wrong. The ordering is a layout question, not an identity one; it is
 recorded so that §5's rule does not quietly produce it unnoticed.
+
+> **Discharged by [ADR-0018](0018-the-card-pane-ordering.md), and it was not a layout question.**
+> ADR-0012 §5's rule **stands**, sorting on the raw slot number. Two corrections to the paragraph
+> above: the case is not cloze's — `basic` → `vocab` leads with a dormant card with no cloze in it, the
+> general shape being any change whose old slots sort below its new ones — and "leading with two
+> dormant cards" assumed a full-size dormant card, which ADR-0012 §5 never specified and which the
+> model usually cannot produce, a dormant card being the *absence* of a generated card. Rendered as a
+> **line**, it costs two lines. The masked value `ordinal & 0x7FFF` was rejected as a sort key for
+> asserting an adjacency §3 partitioned these namespaces precisely to deny — **the mask is a name,
+> never a sort key**.
 
 ### 6. An imported file imposes nothing on the registry
 
@@ -248,7 +266,9 @@ definition.
 
 ## Open items handed onward
 
-- **Card-pane ordering when dormant cards outrank live ones** (§5) — the visual design pass, which
-  ADR-0006 §10 opened and ADR-0010 and ADR-0015 have since joined.
+- ~~**Card-pane ordering when dormant cards outrank live ones** (§5) — the visual design pass, which
+  ADR-0006 §10 opened and ADR-0010 and ADR-0015 have since joined.~~ **Discharged by
+  [ADR-0018](0018-the-card-pane-ordering.md)**, which kept the ordering and fixed the rendering
+  instead. What remains with the visual design pass is only what a dormant line *looks* like.
 - **The slot registry's home in the codebase** — implementation, not a decision: the definition table
   is `leitner-core`'s and the tests sit beside it.

--- a/docs/adr/0018-the-card-pane-ordering.md
+++ b/docs/adr/0018-the-card-pane-ordering.md
@@ -1,0 +1,248 @@
+# ADR-0018: The card pane's ordering, and what a dormant entry is
+
+- **Status**: Accepted
+- **Date**: 2026-07-31
+- **Resolves**: [Decide: card-pane ordering when dormant cards outrank live ones](https://github.com/amin-bf/leitner/issues/57)
+- **Map**: [Map: local-first Leitner app spec](https://github.com/amin-bf/leitner/issues/1)
+- **Related**: [ADR-0002 §4 §7](0002-the-card-model.md) (kind definitions, replay and dormancy),
+  [ADR-0006](0006-the-review-session-experience.md) (how review draws a card),
+  [ADR-0012 §1 §3 §5](0012-the-note-authoring-experience.md) (the card pane, blank numbering, the
+  ambient dormancy warning), [ADR-0017 §1 §3 §4 §5](0017-card-slots.md) (slots, the high-bit
+  partition, the golden slot list, the handoff this ADR discharges)
+
+## Context
+
+[ADR-0012 §5](0012-the-note-authoring-experience.md) holds a dormant card **in ordinal position** in
+the authoring pane — *card 1, dormant card 2, card 4* — rather than appended after the live cards.
+Round 1 of that prototype was read as proving position is the mechanism: appended last, the dormant
+card fell below the fold and a counter in the header did all the warning.
+
+[ADR-0017 §3](0017-card-slots.md) then partitioned cloze blanks above the high bit (`0x8000 | n`) and
+recorded the consequence rather than settling it: a `vocab` note switched to `cloze` has dormant cards
+at slots 2 and 3 and its live blank at 32769, so "in ordinal position" sorts **both dormant cards
+above the live one**. For a pane whose job [ADR-0012 §1](0012-the-note-authoring-experience.md) defines
+as *"what will I be asked"*, leading with two dormant cards is arguably wrong. Both ADRs handed it to
+the visual design pass.
+
+It is settled here instead, because it is not a styling question. It is a behavioural rule about what a
+specified pane shows first, answerable without knowing a single colour, and §5's rule as written
+produces the bad ordering silently.
+
+**Two things were wrong with the question before it could be answered.**
+
+**The defect is not cloze's doing.** Working the shipped registry's transitions out gives a second case
+with no cloze in it: a `basic` note (slot 0) switched to `vocab` (slots 2 and 3) has its dormant card at
+slot 0 and both live cards above it. The general shape is *any kind change where the old kind's slots
+sort below the new kind's*, and the high-bit partition merely makes cloze the extreme instance. A fix
+aimed at cloze would have left the defect standing.
+
+**And the complaint assumed a rendering that was never specified.** "Leading with two dormant cards" is
+only a problem if a dormant card costs a screen. `replay/CONTEXT.md` defines a dormant card as **the
+absence of a generated card** — a `CardRef` with events in the log that the current content no longer
+generates — so in the general case there is nothing to draw: a deleted cloze blank has no text, an
+emptied field has no answer. What is always available is the **slot**.
+
+## Decision
+
+### 1. Ordinal position stands, sorting on the raw slot number
+
+The card pane orders every entry, live and dormant alike, by its raw `u16` slot. No masking, no
+grouping by dormancy, no partition of any kind. ADR-0012 §5's rule is confirmed rather than replaced.
+
+What decided it is a case neither source ADR looked at — a `cloze` note whose blank 3 was deleted:
+
+| note | pane, in raw slot order |
+|---|---|
+| `vocab` → `cloze` | *line* Term→Meaning · *line* Meaning→Term · **card** blank 1 |
+| `basic` → `vocab` | *line* Front→Back · **card** Term→Meaning · **card** Meaning→Term |
+| `cloze`, blank 3 deleted | **card** 1 · **card** 2 · *line* 3 · **card** 4 |
+| `basic` → `basic-reverse` | **card** Front→Back · **card** Back→Front (nothing dormant) |
+
+Row three puts the dormant entry **in its gap**, between blanks 2 and 4. That is
+[ADR-0012 §3](0012-the-note-authoring-experience.md)'s *"gaps are therefore normal and are shown as
+normal"* delivered by the ordering rule itself, with no sentence written to explain it — the same shape
+as §1's `shown-with` demonstration, where the layout does the explaining. **Every partition rule
+destroys it**, because grouping by dormancy moves the entry away from the gap that is the whole point
+of showing it.
+
+Rejected: **live cards first, dormant appended.** This is round 1's failure, and §2's compact rendering
+does not rescue it — it puts the entry below the fold on a phone, where the pane is already behind a
+`Write | Cards` toggle, and it breaks row three.
+
+Rejected: **sorting on the masked value (`ordinal & 0x7FFF`)**, so blank 1 sorts as 1. It fixes row one
+and is wrong twice over. It would interleave cloze blanks among fixed-arity slots — blank 1 sorting
+*between* slot 0 and slot 2 — asserting an adjacency between two namespaces
+[ADR-0017 §3](0017-card-slots.md) partitioned **precisely because they are not comparable**. And it only
+ever fixes cloze, leaving `basic` → `vocab` exactly as it was.
+
+**The mask is a name, never a sort key.** §3 uses it for the first and this section forbids it for the
+second, and that split is the whole of this ADR's relationship with the high bit.
+
+### 2. A dormant entry is a line, not a card
+
+A live entry is a card, drawn the way review draws it
+([ADR-0012 §1](0012-the-note-authoring-experience.md), [ADR-0006](0006-the-review-session-experience.md))
+— prompt, separator, answer, history badge. A **dormant entry is a single line**: its name, the word
+*dormant*, and its history. It is never a full card rendering, and never a greyed one.
+
+Three grounds, in descending weight.
+
+**Full fidelity is not available in general.** A dormant card is the absence of a generated card, so
+the content that would be drawn is usually the content whose removal caused the dormancy. Rendering it
+"when we can" would give the pane two entry heights whose selection depends on *which kind* of
+dormancy the user caused — a card for a kind change that retained its fields, a line for a deleted
+blank. The fold behaviour would then vary by edit.
+
+**It does not weaken round 1's finding, because fidelity was never the variable round 1 tested.**
+Variant B's dormant card was full-fidelity and still failed; it was below the fold. A line in position
+is emphatically not the header counter that failed either, because it names the question and its
+history where a counter reports a quantity.
+
+**It dissolves the complaint rather than resolving it.** Two dormant lines above a live card do not
+cost the pane its job. The live card is still the first card you see, and the ticket's objection —
+that the pane leads with what you will *not* be asked — stops applying at the point where leading
+costs two lines.
+
+**Accepted cost, stated because it is a real loss**: where the content *does* survive a kind change,
+you can no longer read what the dormant card used to ask. That is the right thing to lose. §1 defines
+the pane's job as "what will I be asked", and a dormant card is precisely what you will not be asked;
+its identity and its history are what the warning needs, and both are on the line.
+
+**The word is *dormant*.** `replay/CONTEXT.md` rules out retired, deleted, orphaned and tombstoned,
+each implying a stored lifecycle that deliberately does not exist. ADR-0012 §5 records that the
+prototype's own copy broke this twice.
+
+### 3. Naming a dormant entry makes the golden slot list a runtime artifact
+
+The note is `cloze`; the dormant entries are slots 2 and 3, which `cloze` does not declare. So the
+pane cannot get their names from the note's own kind. It looks them up across **every kind definition
+the collection holds** — shipped, and acquired via [ADR-0008 §7](0008-the-deck-export-format.md).
+
+That works, and it works only because of [ADR-0017 §1](0017-card-slots.md): one namespace, a slot
+never reused for a different question, so whichever definition declares slot 2 gives the same answer
+as any other. **A lookup keyed on a number that meant different things in different kinds would be
+unanswerable**, which is worth stating because it is the first consumer of §1's global uniqueness
+outside the transition safety it was argued for.
+
+ADR-0017 §4 specified the `slot → (prompt, answer)` list as a **checked-in golden fixture** guarding
+slot immutability. It is now also a **runtime lookup**. The same table serves both, which is the
+reason this costs nothing.
+
+Three cases, in order of precedence:
+
+1. **Slot declared in a held definition** — name it by its **field roles**: *"Term → Meaning · dormant
+   · 23 reviews kept"*. Roles rather than content, because the content is exactly what may be gone.
+2. **High bit set** — a cloze blank, in no definition at all, since blank numbers are authored and
+   unbounded ([ADR-0002 §5](0002-the-card-model.md)). Name it by the masked number: *"blank 3 ·
+   dormant · 6 reviews kept"*.
+3. **Neither** — name it by the bare slot: *"card 7 · dormant · 12 reviews kept"*. Reachable when a row
+   was written by a build shipping a kind this one does not, because a log row carries a `CardRef` and
+   no kind ([ADR-0004 §5](0004-the-review-event-log.md)).
+
+**Case 3 is shown, never hidden**, and this is the load-bearing part of the section. The tempting
+alternative is to omit what cannot be named, and omission is the header-counter failure taken to its
+limit: an unnameable dormant card is still history attached to this note, and the entry exists to say
+so. A bare slot number is honest about exactly what the build knows.
+
+The word is **kept**, not lost. ADR-0012 §5's copy rule is that nothing is deleted, the reviews stay
+in the log, and they reattach by themselves if the content returns.
+
+### 4. The form-pane warning is the warning, on both platforms
+
+Ordinal position cannot guarantee the entry is on screen. A `cloze` note with twenty blanks where
+blank 18 is deleted puts that line eighteenth — below the fold on desktop as well as on a phone. This
+is round 1's exact failure mode, and §1's rule does not prevent it; it prevented it only for slots
+that happened to sort early.
+
+So the constraint this decision inherited — *position is the mechanism, and any replacement must keep
+the warning visible* — **is not satisfiable by any position rule**. Visibility under an ordering rule
+is a property of the edit, not of the rule.
+
+[ADR-0012 §5](0012-the-note-authoring-experience.md)'s second bullet already specifies the warning
+that does the job, and already puts it on both platforms. Only its reason changes. §5 says the warning
+appears in the form pane *because on a phone the card pane is behind a toggle*, and that "on desktop
+it therefore appears twice, deliberately". The real reason is stronger and platform-independent: **the
+card pane cannot guarantee its own entry is on screen**, so the form-pane warning is not redundancy
+for the phone's benefit — it is the only warning that is always visible. Nothing is added. A rule that
+was right for a partial reason is given its whole one.
+
+**This re-reads round 1.** Its finding was recorded as *position is the mechanism*; what it showed is
+that **a count is not a warning**. Variant B carried two defects at once — a counter in the header and
+the card below the fold — and the ADR credited the repair to position alone.
+
+The card-pane entry keeps the job §1 gives it, which is **demonstration**: it shows *which* card and
+*how much* history, in the place the pane already puts that card.
+
+Rejected: **a pinned indicator in the card pane's header.** It is the counter that failed, and it would
+be a third thing speaking about one edit.
+
+Rejected: **auto-scrolling the pane to a newly-dormant entry.** It needs "newly". §5 recomputes
+dormancy from the draft every frame and holds no before-state, so there is no frame in which *just
+became dormant* is a fact the pane possesses.
+
+### 5. The layout jump is accepted, unreserved
+
+Dormancy is recomputed every frame, so an entry that is a line at one keystroke is a card at the next:
+filling an empty `Back` field grows a line into a card and pushes everything below it down. Under a
+full-size greyed rendering this was a colour change in place; under §2 it is a resize. No height is
+reserved and nothing is animated.
+
+It happens only at **discrete boundaries** — a field crossing empty↔non-empty, a `{{n::…}}` being
+closed, the kind dropdown changing — never continuously, because
+[ADR-0012 §3](0012-the-note-authoring-experience.md)'s *"a half-typed `{{1::` stays literal"* already
+removes the one case that would churn per keystroke. It is also **desktop-only in practice**: on a
+phone you are in `Write` while typing, so the flip happens behind the toggle and the user meets the
+result rather than the movement.
+
+And the growth is the demonstration §1 asks for. Reserving card height for a dormant entry would
+return exactly what §2 bought.
+
+### 6. A pane with nothing live in it is its own state
+
+Switch a reviewed `vocab` note to `cloze` and type nothing, and every entry is dormant. The pane's
+answer to "what will I be asked" is *nothing*, and it says so: the dormant entries in slot order, plus
+a plain statement that this note currently generates no cards.
+
+It does **not** fall back to the empty-note state. A new note generates nothing *yet*; this note
+generates nothing *and has history*, and the second is the one worth seeing. The distinction costs a
+sentence and is reachable by an ordinary edit.
+
+## Amendments to accepted ADRs
+
+- **ADR-0012 §1** — the pane draws **live** entries the way review draws them. A dormant entry is a
+  line (§2 above), so "drawn the way review draws them" is no longer true of every entry in the pane.
+- **ADR-0012 §5** — its first bullet's "in ordinal position" is **confirmed and made precise**: the
+  sort key is the raw slot number, and the dormant entry is a line rather than a card held in the
+  stack. Its second bullet's **reason is corrected** — the form-pane warning is primary on both
+  platforms because position cannot guarantee visibility, not because a phone hides the pane (§4). Its
+  third bullet, the Undo copy, is unchanged.
+- **ADR-0017 §4** — the golden `slot → (prompt, answer)` list is **also a runtime lookup**, not only a
+  test fixture. Its consumer set grows by one, and §3 above is why.
+- **ADR-0017 §5** — its handoff, *"handed to the visual design pass, rather than settled here"*, is
+  **discharged**. The ordering was not a layout question after all; it was a rendering question wearing
+  an ordering question's clothes.
+
+## Consequences
+
+- **No persisted artifact changes and no new state.** The log, `CardRef`, the fuzz seed and the
+  `.ldeck` format are untouched, and nothing is stored to support any rule here — dormancy stays
+  recomputed per frame, and §4 explicitly declines the one rule that would have needed a before-state.
+- **The visual design pass loses an item and keeps a smaller one.** What a line *looks like* — its
+  type, weight and spacing — is still that pass's. What it *says*, where it *sits* and when it appears
+  are settled here.
+- **The slot registry gains a second consumer, and that raises the price of an unnameable slot.** Under
+  ADR-0017 §4 a slot missing from the table broke a test; it now also degrades a user-visible string to
+  §3's case 3. Both point the same way — do not let the table fall behind the definitions — but the
+  second failure is silent where the first is a red build.
+- **A note with several dormant cards stays readable**, which was not true before: four dormant lines
+  cost four lines, where four greyed cards cost a screen. This is what makes §1's decision to leave
+  them interleaved affordable.
+- **The pane now has three entry shapes** — card, dormant line, and §6's no-cards statement — where
+  ADR-0012 §1 described one. That is the cost of the pane answering two questions at once, and §4
+  keeps them from competing by moving the warning out.
+
+## Open items handed onward
+
+- **The visual design pass** ([ADR-0006 §10](0006-the-review-session-experience.md)) — the typography,
+  weight and spacing of a dormant line, and how *dormant* reads against a live card without becoming a
+  second warning.


### PR DESCRIPTION
Resolves [#57](https://github.com/amin-bf/leitner/issues/57), on [Map: local-first Leitner app spec](https://github.com/amin-bf/leitner/issues/1). Adds **ADR-0018**.

[ADR-0017 §5](https://github.com/amin-bf/leitner/blob/main/docs/adr/0017-card-slots.md) recorded that a `vocab` note switched to `cloze` sorts **both dormant cards above the live one** under [ADR-0012 §5](https://github.com/amin-bf/leitner/blob/main/docs/adr/0012-the-note-authoring-experience.md)'s "in ordinal position" rule, and handed it to the visual design pass. It is settled here instead: it is a behavioural rule about what a specified pane shows first, answerable without knowing a single colour.

**Two corrections came before the answer.** The defect is not cloze's — a `basic` note switched to `vocab` leads with a dormant card too, the general shape being any kind change whose old slots sort below its new ones. And the complaint assumed a rendering that was never specified: "leading with two dormant cards" only bites if a dormant card costs a screen, and `replay/CONTEXT.md` defines a dormant card as *the absence of a generated card*, so it usually has nothing left to draw.

## What it decides

1. **Ordinal position stands, on the raw slot number** — no masking, no grouping by dormancy. Decided by a case neither source ADR looked at: a deleted cloze blank shows its dormant entry **in its gap**, which is ADR-0012 §3's "gaps are shown as normal" delivered by the ordering rule itself. Every partition rule destroys it. Sorting on `ordinal & 0x7FFF` is rejected for asserting an adjacency ADR-0017 §3 partitioned the namespaces to deny — **the mask is a name, never a sort key**.
2. **A dormant entry is a line, not a card.** Full fidelity is not available in general, and round 1 never tested fidelity — its dormant card was full-size and still failed, below the fold.
3. **Naming it makes ADR-0017 §4's golden slot list a runtime lookup.** Answerable only because §1 makes a slot mean one question collection-wide. An unnameable slot is shown by bare number, **never hidden** — omission is the header-counter failure at its limit.
4. **The form-pane warning is primary on both platforms.** Ordinal position cannot guarantee the entry is on screen — blank 18 of 20 lands below the fold on desktop too — so *position is the mechanism* is not satisfiable by any position rule. ADR-0012 §5's rule is unchanged; only its reason is corrected. This also re-reads round 1, whose real finding is that **a count is not a warning**.
5. **The layout jump is accepted unreserved** — discrete boundaries only, and desktop-only in practice.
6. **A pane with nothing live in it is its own state**, distinct from a new note's empty pane.

## Amends

- **ADR-0012 §1** — the pane draws *live* entries the way review draws them; it now holds three entry shapes.
- **ADR-0012 §5** — "in ordinal position" confirmed and made precise; the form-pane bullet's reason corrected.
- **ADR-0017 §4** — the golden slot list is also a runtime lookup, which raises the price of a missing slot from a red build to a silently degraded name.
- **ADR-0017 §5** — its handoff to the visual design pass is **discharged**.

`CONTEXT-MAP.md` indexes ADR-0018 against `content`, `replay` and `ui`; the `ui` glossary gains *card pane*, *dormant entry*, and the rule that the card pane demonstrates while the form pane warns. Also fixes an existing gap where ADR-0012 was absent from the `ui` context's *Bound by* list despite the map indexing it there.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)