### PR TITLE
Sync Experience / Name the Account at Enrolment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,8 +295,10 @@ archiving against it.
 
 ### What the user sees
 
-[ADR-0015](./docs/adr/0015-the-sync-experience.md) settles the surface. Four of its rules fail
-silently, three of them because the reasoning is invisible from the code that would break them.
+[ADR-0015](./docs/adr/0015-the-sync-experience.md) settles the surface and
+[ADR-0019](./docs/adr/0019-naming-the-account-at-enrolment.md) adds the account name to it. Five
+rules fail silently, four of them because the reasoning is invisible from the code that would break
+them.
 
 1. **Exactly two things may speak about sync: a dead grant, and ADR-0004 §8's clock-skew warning.**
    A network failure never speaks — offline is normal and nagging about it is the defect. There is
@@ -313,13 +315,28 @@ silently, three of them because the reasoning is invisible from the code that wo
    whose rows a device that never fetched them will never see again. It looks like a courtesy and
    there is nothing to reclaim — a few hundred objects, ~47.5 MB per decade. Disconnect drops the
    local grant and deletes nothing.
-4. **A wrong-account enrolment is undetectable, and one sentence is the entire defence.** A second
-   device pointed at the wrong account gets an empty folder, which is indistinguishable from being
-   the first device to enrol. That is why enrolment *ends by stating what it found* — "the first
-   device here" versus the devices it met. Removing that line as redundant removes the only guard.
-   **ADR-0016 §10's identity check does not cover this**, and reaching for it is the natural mistake:
-   in a wrong-account enrolment **every collection id agrees**, since all the devices hold the same
-   collection and merely cannot see each other. The failure is **reachability, not identity**.
+4. **A wrong-account enrolment cannot be checked by any code, and the defence is two sentences the
+   user reads.** A device pointed at the wrong account gets an empty folder, indistinguishable from
+   being the first to enrol — so enrolment *ends by stating what it found*, **prefixed with the
+   account it connected as**: *"Connected as you@example.com. This is the first device here"* versus
+   the devices it met ([ADR-0019 §1](./docs/adr/0019-naming-the-account-at-enrolment.md)). Delete
+   either half and you remove a guard that has no replacement. **No check can substitute**, and
+   reaching for one is the natural mistake in two directions: ADR-0016 §10's identity check does not
+   cover it, because **every collection id agrees** — all the devices hold the same collection and
+   merely cannot see each other — and neither would a check on the *account*, because there is no
+   peer, no namespace and no published byte to compare against. The failure is **reachability, not
+   identity**, and the only comparand that exists is the user's memory of the last enrolment.
+   The two halves do different jobs and neither is redundant: **the "first device here" sentence
+   detects, the account address diagnoses.** Without the address the user infers "wrong account" from
+   "first device here" — which almost nobody does, and every likelier hypothesis (folder cleared,
+   other device reset, sync broken) **routes to a repair that cannot work**, so each failed attempt
+   convinces them the collection is gone.
+5. **The account address lives with the credential and never on ADR-0004 §7's mutable surface.** It
+   is a property of the *grant*, not the collection, so it is never published and never enters either
+   export profile — [ADR-0016 §4](./docs/adr/0016-backup-and-restore.md)'s `collection` rule excludes
+   credentials, which is what keeps it out without a clause naming it. Put it on the mutable surface
+   and it lands in every `.lcoll` **and** on the remote, buying nothing: a published address is
+   unreadable by the device that needs it, which is looking at a different folder.
 
 ## Agent skills
 

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -96,10 +96,10 @@ Read the ADR sections in your row. Read the whole ADR only if you are changing t
 | `log` | [0004](./docs/adr/0004-the-review-event-log.md) | 0002 §7, 0001 §6, 0010 §5, 0011 §5, 0013 §12, 0014 §6 |
 | `scheduling` | [0001](./docs/adr/0001-scheduling-algorithm-and-grade-scale.md) | 0004 §4, 0004 §5, 0014 §6 |
 | `replay` | *none of its own* | 0001 §7, 0002 §7, 0004 §9, 0007 §2, 0010 §2, 0011 §8, 0012 §5, 0017 §1, 0017 §5, 0018 §2 |
-| `store` | [0007](./docs/adr/0007-the-local-store.md) | 0004 §11, 0003 §5, 0013 §9, 0016 §3, 0016 §7 |
+| `store` | [0007](./docs/adr/0007-the-local-store.md) | 0004 §11, 0003 §5, 0013 §9, 0016 §3, 0016 §7, 0019 §6 |
 | `export` | [0008](./docs/adr/0008-the-deck-export-format.md), [0016](./docs/adr/0016-backup-and-restore.md) | 0005, 0002 §9, 0004 §11, 0011 §7 |
-| `sync` | [0013](./docs/adr/0013-the-sync-transport.md) | 0004 §2, 0004 §7, 0004 §10, 0007, 0014 §7, 0015 §2, 0015 §4, 0016 §10 |
-| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md), [0010](./docs/adr/0010-leeches.md), [0011](./docs/adr/0011-new-card-rate-and-daily-limits.md), [0012](./docs/adr/0012-the-note-authoring-experience.md), [0014](./docs/adr/0014-when-parameter-optimisation-runs.md), [0015](./docs/adr/0015-the-sync-experience.md), [0018](./docs/adr/0018-the-card-pane-ordering.md) | 0002 §4, 0016 §6, 0016 §11, 0016 §12, 0017 §5, 0017 §6 |
+| `sync` | [0013](./docs/adr/0013-the-sync-transport.md) | 0004 §2, 0004 §7, 0004 §10, 0007, 0014 §7, 0015 §2, 0015 §4, 0016 §10, 0019 §4, 0019 §6 |
+| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md), [0010](./docs/adr/0010-leeches.md), [0011](./docs/adr/0011-new-card-rate-and-daily-limits.md), [0012](./docs/adr/0012-the-note-authoring-experience.md), [0014](./docs/adr/0014-when-parameter-optimisation-runs.md), [0015](./docs/adr/0015-the-sync-experience.md), [0018](./docs/adr/0018-the-card-pane-ordering.md), [0019](./docs/adr/0019-naming-the-account-at-enrolment.md) | 0002 §4, 0016 §6, 0016 §11, 0016 §12, 0017 §5, 0017 §6 |
 | *the workspace itself* | [0009](./docs/adr/0009-crate-and-workspace-layout.md) | 0013 §11, 0013 §12, 0015 §15, 0016 §5 |
 
 **`replay` having no ADR of its own is why it is a context.** Its rules were each written for another

--- a/crates/app/src/CONTEXT.md
+++ b/crates/app/src/CONTEXT.md
@@ -12,8 +12,10 @@ ADR-0006 §1 and §2** — read those amendments before touching the session;
 [ADR-0018](../../../docs/adr/0018-the-card-pane-ordering.md), the second of which **amends ADR-0012 §1
 and §5** — read those amendments before touching the authoring pane; also by
 [ADR-0002 §4](../../../docs/adr/0002-the-card-model.md) (layout is data, stored once per kind) and
-[ADR-0015](../../../docs/adr/0015-the-sync-experience.md) (everything the user sees about sync — the
-`sync` crate holds the mechanism and none of the surface).
+[ADR-0015](../../../docs/adr/0015-the-sync-experience.md) and
+[ADR-0019](../../../docs/adr/0019-naming-the-account-at-enrolment.md) (everything the user sees about
+sync — the `sync` crate holds the mechanism and none of the surface; the second **amends ADR-0015 §7
+and §12**, adding the connected account to enrolment and to sync settings).
 
 ## Language
 
@@ -85,9 +87,19 @@ _Avoid_: In sync, up to date, synced, a status icon or checkmark anywhere in the
 
 **Set up sync**:
 Granting this device access, once, via the device flow. Ends with the user naming **this** device
-(ADR-0015 §8), with ADR-0016 §10's identity check, and with the app stating what it found — *"the
-first device here"* or the devices it met.
+(ADR-0015 §8), with ADR-0016 §10's identity check, and with the app stating what it found —
+**prefixed with the account it connected as**: *"Connected as you@example.com. This is the first
+device here"*, or the devices it met (ADR-0019 §1).
 _Avoid_: Login, sign-in, pairing, connecting an account.
+
+**Connected account**:
+The address the grant was obtained against, shown at enrolment **and kept in sync settings** — those
+two places and nowhere else (ADR-0019 §1). **Not a third speaker**: it states a fact about
+configuration and makes no claim about sync state, which is what ADR-0015 §1 actually forbids. It is
+kept rather than shown once because the failure it diagnoses surfaces *months* later, and because two
+settings screens read side by side are **the only cross-device account comparison that exists** — the
+app itself can never make one.
+_Avoid_: Account status, signed in as, a checkmark beside it.
 
 **Identity refusal**:
 What a **non-empty** collection shows when it meets an id that is not its own (ADR-0016 §10). It
@@ -98,10 +110,18 @@ difference alone would block the commonest path there is. Not a counter-example 
 rule — it is the immediate result of an action just taken, not a resting notice (ADR-0015 §7).
 
 **Wrong-account enrolment**:
-Enrolling against the wrong account. **Undetectable, and structurally so** — every collection id
-agrees, because all the devices hold the same collection and merely cannot see each other, so the
-failure is *reachability, not identity* (ADR-0016 §13). The app stating what it found is the whole
-defence; deleting that line as redundant removes the only guard.
+Enrolling against the wrong account. **Uncheckable by any code, and structurally so** — there is no
+peer, no namespace and no published byte to compare against, so neither ADR-0016 §10's identity check
+(every collection id agrees) nor a check on the *account* can catch it; the failure is *reachability,
+not identity* (ADR-0016 §13, widened by ADR-0019 §3). The defence is two things the **user** reads,
+doing different jobs: *"this is the first device here"* **detects** (it is said to someone who knows
+they enrolled another device), and the **connected account** above **diagnoses**. Deleting either as
+redundant removes a guard with no replacement — without the address the user must infer "wrong
+account" from "first device here", and every likelier hypothesis routes to a repair that cannot work.
+
+**There is no wrong account in the absolute** — only one that differs from the account the other
+device used. A first device on an odd account is harmless; nothing breaks until a second disagrees.
+What is protected is **consistency across enrolments**.
 
 **The notice channel**:
 The persistent, non-modal line for the **only two things permitted to speak about sync**: a dead

--- a/crates/sync/src/CONTEXT.md
+++ b/crates/sync/src/CONTEXT.md
@@ -72,8 +72,26 @@ snapshot and change stream are the same thing paid for at different times.
 **Enrolment**:
 Granting one device access to the remote, once. Uses the device flow: a short code entered on
 whatever device the user likes, so no credential is ever typed into this application. Enrolment also
-runs the **identity check** below.
+runs the **identity check** below, and fetches the **connected account** — one `GET` to the UserInfo
+endpoint, because the device flow's token response carries no `id_token` (ADR-0019 §4).
 _Avoid_: Login, sign-in, pairing — there is no account of ours and no device-to-device step.
+
+**Connected account**:
+The address the grant was obtained against. Fetched once at enrolment, **stored beside the credential
+and never on ADR-0004 §7's mutable surface**, deleted with the grant on disconnect — it is a property
+of the *grant*, not of the collection, so another device derives its own and never needs telling
+(ADR-0019 §6). That placement is what keeps it out of both export profiles with no clause naming it:
+ADR-0016 §4 already excludes credentials. **Never publish it.** On the mutable surface it would ride
+into every `.lcoll` and onto the remote, and buy nothing — a device on the wrong account is looking at
+a different folder and cannot read it. Cached and never refreshed, so a later address change shows
+stale; that is the right answer to *"what did I enrol as"*.
+
+**Scope set**:
+`openid email drive.appdata` (ADR-0019 §4). `profile` is **declined** — display name and picture carry
+no diagnostic value and are exactly the ambient identity ADR-0016 §11 keeps out; `openid` is required
+before `email` may be requested. All three are **non-sensitive**, which is load-bearing rather than
+incidental: verification stays not mandatory, so there is no verification-time endpoint and therefore
+**no server** (ADR-0013 §3).
 
 **Identity check**:
 One rule, run identically at enrolment and at restore
@@ -86,7 +104,9 @@ account — the commonest path there is. A refusal must name the mismatch *and* 
 This is what upgrades [ADR-0013 §10](../../../docs/adr/0013-the-sync-transport.md) from a structural
 accident to a real check: "one account is one collection" holds because a device cannot *see* another
 collection's folder, which stops being true the moment a user has two accounts and picks the wrong
-one.
+one. **That residual case is uncheckable here and always will be** — with an empty folder there is
+nothing to compare against, so it is answered on the *screen* by the **connected account** above
+rather than by any code in this crate ([ADR-0019 §3](../../../docs/adr/0019-naming-the-account-at-enrolment.md)).
 
 **Grant**:
 What enrolment obtains and what revocation removes. **Revocation is all-or-nothing**: every device

--- a/docs/adr/0013-the-sync-transport.md
+++ b/docs/adr/0013-the-sync-transport.md
@@ -366,6 +366,17 @@ excluded, and the scope this ADR needs is on the list
 That the allowlist is *narrow* is itself reassuring: the flow is scoped to app-owned data by design,
 which is exactly what §3 chose it for.
 
+> **Amended by [ADR-0019 §4](0019-naming-the-account-at-enrolment.md): the requested set is `openid
+> email drive.appdata`, not `drive.appdata` alone** — so the account can be named at enrolment, which
+> [ADR-0015 §7](0015-the-sync-experience.md) left unowned. All three were already on the allowlist
+> checked above. `profile` is declined: it yields display name and picture, which carry no diagnostic
+> value. **The non-sensitive property §3 rests on is confirmed, not spent** — all three are
+> non-sensitive, so verification is still not mandatory and there is still no verification-time
+> endpoint and therefore no server. One consequence for the phishing shape below: with `email`
+> granted, the blast radius grows by the victim's address — **a fact the attacker already had**, since
+> the attack requires talking to them. The flow's token response carries no `id_token`, so the address
+> costs one `GET` to the UserInfo endpoint at enrolment and still no platform capability.
+
 **Two facts came with that check, and both are load-bearing:**
 
 - **The credential must be registered as the "TVs and Limited Input devices" client type**, not as a
@@ -406,6 +417,15 @@ carries it manufactures a duplicate writer, the silent-loss failure ADR-0004 §2
 exists to prevent. The refresh token has no such property: a restored phone arriving already
 authorised is simply convenient, and it mints a fresh writer id regardless, so the restore is still a
 clean fork. The two look inconsistent and are not.
+
+> **Amended by [ADR-0019 §6](0019-naming-the-account-at-enrolment.md): the credential file also holds
+> the account address**, fetched once at enrolment and deleted with the grant on disconnect, because
+> it is a property of the grant rather than of the collection. It is therefore **never** on
+> [ADR-0004 §7](0004-the-review-event-log.md)'s mutable surface, never published, and outside both
+> export profiles without needing a clause — [ADR-0016 §4](0016-backup-and-restore.md)'s
+> `collection` rule already excludes credentials. Riding *inside* the Android backup set with the
+> token is right here for the same reason the token is: a restored phone arrives already authorised
+> and already stating what it enrolled as.
 
 **Revocation is all-or-nothing, and cannot be made otherwise.** Every device holds a token issued
 against the same client ID, and the provider's revocation surface is per-application: the account's

--- a/docs/adr/0015-the-sync-experience.md
+++ b/docs/adr/0015-the-sync-experience.md
@@ -239,6 +239,16 @@ true answer is unusually good: `drive.appdata` reaches a hidden folder only this
 not the user's files. **Only `drive.appdata` is requested** — not `email` — so the consent screen asks
 for exactly one thing.
 
+> **Amended by [ADR-0019 §4](0019-naming-the-account-at-enrolment.md): the requested set is `openid
+> email drive.appdata`, so the consent screen asks for two things.** `profile` is declined — display
+> name and picture have no diagnostic value and are exactly the ambient identity
+> [ADR-0016 §11](0016-backup-and-restore.md) keeps out. `openid` is required before `email` may be
+> included. The plain-words rule above is unchanged and now covers both: *"see your email address"* is
+> a claim a user can evaluate. **The property this section's narrow scope was protecting survives** —
+> all three scopes are non-sensitive, so verification remains not mandatory and
+> [ADR-0013 §3](0013-the-sync-transport.md)'s *no verification-time endpoint, therefore no server*
+> still holds.
+
 **After enrolment, the application states what it found.** This is the most load-bearing part of §7,
 because **enrolling a second device against the wrong account is undetectable**:
 [ADR-0013 §10](0013-the-sync-transport.md) scopes the folder per (account, application), so a wrong
@@ -251,6 +261,11 @@ one moment the user could notice:
 A user who expected to join an existing collection and reads the first sentence has caught it.
 Detect and surface, in [ADR-0010](0010-leeches.md)'s shape.
 
+> **Amended by [ADR-0019 §1](0019-naming-the-account-at-enrolment.md): each sentence is prefixed with
+> the account.** *"Connected as `you@example.com`. This is the first device here."* The address is also
+> kept in §12's settings screen — **not shown once and discarded**, because the failure is discovered
+> months later, when a second device disagrees, and a once-only message is gone by then.
+
 **[ADR-0016 §13](0016-backup-and-restore.md) landed after this ADR and answered the handoff below
 `no`, with a sharper reason than the one above** — worth recording, because it explains why no
 mechanism of this shape could ever have worked. **In a wrong-account enrolment every collection id
@@ -260,6 +275,17 @@ so an identity check was never going to catch it. The sentence therefore stands 
 and the one thing that *would* detect it is naming the **account** on the enrolment screen — which
 costs the `email` or `profile` scope this section deliberately declines. That trade is live and owned
 by neither ADR; it is in *Open items* rather than reversed here.
+
+> **Amended by [ADR-0019 §2](0019-naming-the-account-at-enrolment.md), which took the trade — and
+> corrected this paragraph's premise while doing so.** Naming the account is **not** *"the one thing
+> that would detect it"*: the sentence above already detects it, in both cases that occur — a second
+> device told it is the first, and a re-enrolment after
+> [ADR-0013 §3](0013-the-sync-transport.md)'s 7-month token death told the same. **What the sentence
+> cannot do is diagnose.** The user must infer *"wrong account"* from *"first device here"*, and every
+> competing hypothesis — folder cleared, other device reset, sync broken — is more intuitive and
+> **routes to a repair action that cannot possibly work**, so each failed attempt raises their
+> confidence that the collection is gone. The account name is bought for **diagnosis**; detection was
+> already paid for. This sentence therefore stands, but is no longer the *whole* defence.
 
 **Enrolment also runs [ADR-0016 §10](0016-backup-and-restore.md)'s identity check**, and both
 outcomes are moments this ADR owns:
@@ -425,6 +451,7 @@ One screen, and everything sync-shaped is on it:
 | | Source |
 |---|---|
 | **"Last caught up ⟨when⟩"** | §4 |
+| **The connected account address** — *"Connected as `you@example.com`"* | [ADR-0019 §1](0019-naming-the-account-at-enrolment.md); a standing fact, and the only cross-device comparison available to a human |
 | **Sync now** | §2's third trigger |
 | **The device list** — labels grouped per [ADR-0004 §3](0004-the-review-event-log.md), several writer ids under one label, each with "last published ⟨when⟩" | §8; read straight off [ADR-0013 §6](0013-the-sync-transport.md)'s listing, so it costs no extra request |
 | **Disconnect** | §10 |
@@ -512,6 +539,9 @@ edited away, because the negative answer is the more useful of the two.
    each other; the failure is **reachability, not identity**. §7's sentence stands as the whole
    defence, and the live trade it leaves — naming the account, at the cost of a scope
    [ADR-0013 §8](0013-the-sync-transport.md) declined — is in *Open items*.
+   **Since taken by [ADR-0019](0019-naming-the-account-at-enrolment.md)**, which widened the
+   reachability finding to rule out *any* application-side check and bought the account name for
+   **diagnosis rather than detection**. §7's sentence stands, no longer alone.
 
 ## Consequences
 
@@ -543,4 +573,4 @@ edited away, because the negative answer is the more useful of the two.
 | Exact copy for the drive's connected-applications route (§10) — a third party's UI, expected to drift | Implementation |
 | Visual treatment of sync settings, the notice channel and cold-start progress | Map fog — *a visual design pass* |
 | ~~Whether collection identity makes a wrong-account enrolment detectable~~ — **answered `no` by [ADR-0016 §13](0016-backup-and-restore.md)**: every id agrees, so the failure is reachability rather than identity | — |
-| **Whether to name the account on the enrolment screen**, at the cost of the `email` or `profile` scope §7 and [ADR-0013 §8](0013-the-sync-transport.md) both decline. The only lever left on the wrong-account case, and a live trade owned by neither ADR | Unowned — needs a decision before enrolment ships |
+| ~~**Whether to name the account on the enrolment screen**, at the cost of the `email` or `profile` scope §7 and [ADR-0013 §8](0013-the-sync-transport.md) both decline~~ — **taken by [ADR-0019](0019-naming-the-account-at-enrolment.md)**: it is named, on the enrolment screen *and* in §12's settings, at the cost of `openid email` (not `profile`); *"the only lever left"* was **wrong** — §7's sentence already detects, and the name is bought for diagnosis | — |

--- a/docs/adr/0016-backup-and-restore.md
+++ b/docs/adr/0016-backup-and-restore.md
@@ -431,6 +431,16 @@ defence**, and this ADR does not replace it. The one thing that would detect the
 [ADR-0013 §8](0013-the-sync-transport.md) deliberately did not request. That is a live trade, owned
 by neither ADR, and it is recorded in *Open items* rather than decided here.
 
+> **Widened by [ADR-0019 §3](0019-naming-the-account-at-enrolment.md): the reachability finding rules
+> out *any* application-side check, not only an identity one.** In a wrong-account enrolment there is
+> no peer, no namespace and no published byte to compare against, so **a check on the account address
+> is void too** — publishing *"this device connected as X"* into the application data folder is
+> unreadable by the device that needs it, which is looking at a different folder. **The only comparand
+> that exists is the user's own memory of the previous enrolment.** ADR-0019 nonetheless takes the
+> trade, on a corrected premise: naming the account is not *"the one thing that would detect"* the
+> case — ADR-0015 §7's sentence already detects it — it is what lets a user **diagnose** it, instead of
+> reaching for repairs that cannot work.
+
 **"The no-delete reasoning does not transfer to an artifact that is not disposable." — Correct, and
 it is already honoured.** ADR-0015 refuses a delete-remote-data control partly because the sync
 namespace is disposable and there is nothing to reclaim. An archive is the opposite: for the
@@ -527,6 +537,6 @@ marker it is minted with.
 | Item | Owner |
 |---|---|
 | Running an archive write and a restore on the real handset, including the `MediaStore` path | Implementation |
-| **Whether the enrolment screen should name the account it connected as**, which is the only thing that would detect [ADR-0015](0015-the-sync-experience.md)'s wrong-account case (§13) — it costs an `email` or `profile` scope [ADR-0013 §8](0013-the-sync-transport.md) deliberately did not request, and both are on that flow's allowlist. Owned by neither ADR | Not scheduled |
+| ~~**Whether the enrolment screen should name the account it connected as**, which is the only thing that would detect [ADR-0015](0015-the-sync-experience.md)'s wrong-account case (§13)~~ — **decided by [ADR-0019](0019-naming-the-account-at-enrolment.md)**: it does, and it persists in sync settings; the scope is `openid email` (`profile` declined) and all three are non-sensitive, so [ADR-0013 §3](0013-the-sync-transport.md)'s *no verification, therefore no server* survives. *"The only thing that would detect"* is **corrected**: it diagnoses, and §13 above is widened accordingly | — |
 | Whether the archive should ever be encrypted — must be answered together with the local store, never alone | Map fog: *Local encryption / device passcode* |
 | Media, if audio on cards is ever built: the archive inherits the size, and §6's manual write becomes a much larger ask | Map fog |

--- a/docs/adr/0019-naming-the-account-at-enrolment.md
+++ b/docs/adr/0019-naming-the-account-at-enrolment.md
@@ -1,0 +1,293 @@
+# ADR-0019: Naming the account at enrolment
+
+- **Status**: Accepted
+- **Date**: 2026-07-31
+- **Resolves**: [Decide: whether the enrolment screen names the account](https://github.com/amin-bf/leitner/issues/59)
+- **Map**: [Map: local-first Leitner app spec](https://github.com/amin-bf/leitner/issues/1)
+- **Related**: [ADR-0013 §3 §8 §9 §10](0013-the-sync-transport.md) (the non-sensitive scope, the
+  device flow's scope allowlist, the credential file, the per-(account, application) folder),
+  [ADR-0015 §1 §4 §7 §12](0015-the-sync-experience.md) (what may speak about sync, the resting
+  surface, enrolment, the settings screen),
+  [ADR-0016 §10 §13](0016-backup-and-restore.md) (the identity check, and reachability-not-identity),
+  [ADR-0004 §7](0004-the-review-event-log.md) (the mutable surface, and what this value is kept off),
+  [ADR-0010](0010-leeches.md) (*detect and surface, never intervene*)
+
+## Context
+
+Two accepted ADRs record this item and both say it is owned by neither of them —
+[ADR-0015](0015-the-sync-experience.md) *Open items*: **"Unowned — needs a decision before enrolment
+ships"**; [ADR-0016](0016-backup-and-restore.md) *Open items*: **"Not scheduled"**. It is the only
+decision either ADR left standing with no owner.
+
+The setup is settled and not reopened here. [ADR-0013 §10](0013-the-sync-transport.md) scopes the
+application data folder per (account, application), so a device pointed at the **wrong account** gets
+an empty folder — indistinguishable from being the first device to enrol.
+[ADR-0015 §7](0015-the-sync-experience.md) makes enrolment end by stating what it found, and records
+that this one sentence is the whole defence and the weakest point in that ADR.
+[ADR-0016 §13](0016-backup-and-restore.md) then closed off the alternative structurally: in a
+wrong-account enrolment **every collection id agrees**, because all the devices hold the same
+collection and merely cannot see each other, so **the failure is reachability, not identity** and no
+identity check could ever have caught it.
+
+**What this ADR does not inherit is the framing all three documents put on what remains.** The
+ticket, ADR-0015's *Open items* row and ADR-0016's *Open items* row each describe naming the account
+as *"the only thing that would detect the case"* and *"the only lever left"*. §2 finds that false, and
+the correction is what makes the decision defensible rather than merely sympathetic.
+
+## Decision
+
+### 1. The enrolment screen and sync settings name the account
+
+> **Enrolment states the account it connected as, and sync settings keeps it. It appears on the
+> enrolment screen and in sync settings, and nowhere else.**
+
+[ADR-0015 §7](0015-the-sync-experience.md)'s closing sentence gains a clause:
+
+> *"Connected as `you@example.com`. This is the first device here."*
+>
+> *"Connected as `you@example.com`. Found 2 other devices: Laptop, Pixel."*
+
+And [ADR-0015 §12](0015-the-sync-experience.md)'s settings screen gains a row, beside the device list
+that already sits there.
+
+The **"and nowhere else"** clause is [ADR-0015 §3](0015-the-sync-experience.md)'s rule reused
+verbatim, for the same reason it gave: this is the kind of string later copied into a tooltip, a
+header and an about box by someone who was not in this conversation.
+
+### 2. The value is diagnosis, not detection — and three documents claim otherwise
+
+**ADR-0015 §7's sentence is a real lever, not a null one.** Walk the cases it actually covers:
+
+| case | what §7 says | caught? |
+|---|---|---|
+| Second device, wrong account | *"This is the first device here"* | **Yes** — said to a user who knows they enrolled another device |
+| Re-enrolment after [ADR-0013 §3](0013-the-sync-transport.md)'s 7-month refresh-token death, wrong account | *"This is the first device here"* | **Yes** — it demonstrably worked before |
+| Any account, folder non-empty | *"Found 2 other devices"* | **Not applicable** — the account is provably right, because the peers are visible |
+
+So §7 **detects**, at zero scope cost, in the cases that matter. Describing the account name as the
+only thing that would detect the case is wrong in all three documents that say it, and an ADR built on
+that premise would be arguing for a redundancy.
+
+**What §7 cannot do is diagnose.** The user has to translate *"this is the first device here"* into
+*"therefore I signed in on the wrong account"*, and that inference is not available to most people.
+Every competing hypothesis is more intuitive: the folder was cleared, the other device was reset, the
+application forgot, sync is broken.
+
+**This is where it stops being imperfect and becomes actively harmful.** Each of those wrong
+hypotheses routes to a **repair action** — sync again, disconnect and reconnect, reinstall, restore
+from an archive — and **not one of them can fix an account mismatch**. Every attempt fails. Every
+failure raises the user's confidence that the collection is actually gone. A misdiagnosis here does
+not merely delay the fix; it walks the user toward believing they have lost their data, on a system
+whose central promise ([ADR-0016 §2](0016-backup-and-restore.md)) is that they cannot.
+
+Naming the account collapses the diagnosis into something **read rather than inferred**: an address
+the user does not recognise, shown next to the sentence that puzzled them.
+
+> **The account name is bought for diagnosis. Detection was already paid for.**
+
+### 3. The application can never compare accounts; only a person can
+
+[ADR-0016 §13](0016-backup-and-restore.md)'s reachability argument generalises further than that ADR
+claimed. It concluded that no *collection identity* check can catch the case. The stronger statement
+is that **no check of any kind can**, including one on the account address itself:
+
+> In a wrong-account enrolment the device sees an empty folder. There is no peer, no namespace and no
+> published byte to compare against. **The only comparand that exists is the user's own memory of the
+> previous enrolment.**
+
+**Rejected, and structurally void rather than merely expensive: publishing the address so devices can
+cross-check.** Writing *"this device connected as X"* into the application data folder cannot help,
+because the device that needs to read it is looking at a **different folder**. It is unreadable
+exactly when it is needed. This is the tempting design and it fails on both axes at once — void
+benefit, and a real disclosure (§6).
+
+Two consequences follow, and both bound what the feature may become:
+
+- **The account name can never be an error, a block or a warning. It is a statement.** That places it
+  in *detect and surface, never intervene* — [ADR-0010](0010-leeches.md), then
+  [ADR-0014 §2](0014-when-parameter-optimisation-runs.md), then
+  [ADR-0015 §1](0015-the-sync-experience.md), and now the fourth time on this map.
+- **There is no wrong account in the absolute — only an account that differs from the one the other
+  device used.** A first device enrolled on an odd account is harmless; nothing is broken until a
+  second device disagrees. What is being protected is **consistency across enrolments**, not
+  correctness of one. That is why human recognition is not a weak substitute for a check here: it is
+  the only thing that can span two enrolments months apart on two devices.
+
+### 4. The scope is `openid email`, and it is `email` rather than `profile`
+
+Both source ADRs write *"the `email` or `profile` scope"* as though the two were interchangeable.
+**They are not, and the choice is not neutral.**
+
+- **`email`** yields the address — the entire diagnostic.
+- **`profile`** yields display name and picture. **Neither has any diagnostic value**, and both are
+  ambient identity of exactly the kind [ADR-0016](0016-backup-and-restore.md)'s minimal-disclosure
+  rule exists to keep out.
+
+> **The requested scope set is `openid email drive.appdata`. `profile` is declined.**
+
+`openid` is not optional padding: the provider's OpenID Connect specification requires the scope
+parameter to begin with `openid` before `email` or `profile` may be included
+([OpenID Connect](https://developers.google.com/identity/openid-connect/openid-connect)). All three
+are on the limited-input-device flow's published allowlist, which
+[ADR-0013 §8](0013-the-sync-transport.md) already verified — that allowlist is exactly `email`,
+`openid`, `profile`, `drive.appdata`, `drive.file` and two video scopes
+([OAuth 2.0 for TV and Limited-Input Device Applications](https://developers.google.com/identity/protocols/oauth2/limited-input-device)).
+
+**It costs one request, not zero, and that was worth checking.** The limited-input-device flow's
+documented token response carries `access_token`, `expires_in`, `refresh_token`, `scope` and
+`token_type` — **no `id_token`**. So the address does not arrive with the grant; it is fetched with a
+single `GET` to the UserInfo endpoint (`https://openidconnect.googleapis.com/v1/userinfo`) using the
+access token, once, at enrolment. That is one request on a screen that is already doing network, and
+it needs no platform capability, so [ADR-0013 §8](0013-the-sync-transport.md)'s prize — a flow with no
+platform surface, no `#[cfg(target_os)]`, no third function in a platform seam
+([ADR-0009 §4](0009-crate-and-workspace-layout.md)) — is untouched.
+
+### 5. The property ADR-0013 §3 chose the scope for survives, and this was checked rather than assumed
+
+[ADR-0013 §3](0013-the-sync-transport.md) chose this backend substantially because the scope is
+**non-sensitive**, and it was explicit that the value is not the saved paperwork: *"No verification
+means **no verification-time endpoint** — no domain-ownership proof, no hosted policy a reviewer
+fetches, no callback. Every one of those would have been a server, which the destination forbids."*
+
+**Adding scopes is exactly the move that could have destroyed that, which is why the ticket required
+it be established rather than assumed.** It does not:
+
+> *"If your app utilizes only **non-sensitive** scopes, it is not mandatory for your app to complete
+> the app verification process."*
+> — [OAuth app verification](https://support.google.com/cloud/answer/13463073)
+
+`openid`, `email` and `profile` are non-sensitive. The provider privileges that exact subset
+elsewhere, too: it is the one scope set whose presence exempts a project in *Testing* publishing
+status from the 7-day refresh-token expiry that
+[ADR-0013 §3](0013-the-sync-transport.md) records as a console trap
+([Using OAuth 2.0 to Access Google APIs](https://developers.google.com/identity/protocols/oauth2)).
+
+> **No verification, no verification-time endpoint, no server. ADR-0013 §3's load-bearing property is
+> confirmed rather than spent.** Its ceiling row — *none, because the scope is non-sensitive* — still
+> reads true with the wider set.
+
+**Honest addition to [ADR-0013 §8](0013-the-sync-transport.md)'s recorded phishing shape.** That
+section bounds the blast radius of a stolen device code at *"our own application data folder and
+nothing else"*. With `email` granted, the radius grows by the victim's address — **a fact an attacker
+running that attack already had**, since the attack requires talking to the person. Recorded because
+the section is an honesty commitment, not because it changes the assessment.
+
+### 6. The address lives with the credential, so it reaches no artifact
+
+**The address is a property of the grant, not of the collection.** It describes which account *this
+device* holds a token for. Another device on the same account derives its own from its own grant and
+never needs to be told. It fails [ADR-0004 §7](0004-the-review-event-log.md)'s membership test one
+level further out than [ADR-0010 §5](0010-leeches.md)'s suspension or
+[ADR-0011 §7](0011-new-card-rate-and-daily-limits.md)'s new-card rate did — those were at least
+collection state that did not belong in the log. This is not collection state at all.
+
+> **It is stored beside the credential, in [ADR-0013 §9](0013-the-sync-transport.md)'s plain file in
+> application-private storage. Never on [ADR-0004 §7](0004-the-review-event-log.md)'s mutable
+> surface. Disconnect deletes it with the grant, because it is part of the grant.**
+
+**The export question then dissolves rather than needing a policy**, which is this map's recurring
+shape — [ADR-0008](0008-the-deck-export-format.md) disposed of ADR-0004 §11's writer-id disclosure the
+same way. [ADR-0016 §4](0016-backup-and-restore.md)'s `collection` profile is *everything that
+settles, plus the log, **minus device identity and credentials***, so a value living with the
+credential is excluded **without a clause naming it**, in both profiles.
+
+**The trap this avoids is worth naming, because the mutable surface is where it would naturally have
+gone.** There, the address would be carried into every `.lcoll` (that surface is *"everything that
+settles"*) **and** published to the remote ([ADR-0013 §7](0013-the-sync-transport.md)) — for the
+benefit §3 already showed to be void.
+
+**And the distinction that resolves the apparent conflict with minimal disclosure:**
+[ADR-0016 §11](0016-backup-and-restore.md)'s rule — *"no author name, no device label, no ambient
+identity ever auto-populated"* — is about **artifacts that travel**. It governs *auto-populating a
+field in a file that goes somewhere*. **A user's own address on their own settings screen is not a
+disclosure surface.** The rule is untouched; it was never reaching this.
+
+### 7. It is not a third speaker, because it states a fact and makes no claim
+
+[ADR-0015 §1](0015-the-sync-experience.md)'s rule — exactly two things may speak about sync, a dead
+grant and [ADR-0004 §8](0004-the-review-event-log.md)'s clock-skew warning — is the rule that ADR
+itself predicted would erode first. It is not eroded here, and the test is
+[ADR-0015 §4](0015-the-sync-experience.md)'s own title: **the resting surface states a fact, never a
+claim.**
+
+Everything §1 forbids is a **claim about sync state the application cannot back** — a checkmark,
+*"in sync"*, *"up to date"*, a persistent status indicator. *"Connected as X"* makes **no claim about
+sync state whatsoever**. It is the same category as the standing configuration facts
+[ADR-0015 §12](0015-the-sync-experience.md) already holds: the device list with its per-writer *"last
+published ⟨when⟩"*, the disconnect control, the revocation explanation, the desktop-authoring
+statement.
+
+**Rejected: showing it once at enrolment and not persisting it** — which is how the ticket and both
+*Open items* rows framed the safe version, and which would have wasted the purchase. **The failure
+this feature exists to diagnose is discovered months later**, when a second device disagrees. A
+message shown once at enrolment is gone at exactly the moment of discovery, and would defend only
+against catching the mistake in the act — the case §2 shows ADR-0015 §7 already covers for free.
+
+It also destroys the **only comparison that exists anywhere in this design**. §3 established that the
+application can never compare accounts. A *person* can: open settings on the phone and on the laptop,
+read two different addresses. That comparison lives or dies on the address being in settings.
+
+### 8. Decided now because it is free now
+
+Adding a scope after enrolment ships is not a code change — it is a **re-consent for every device
+already enrolled**, each one walking the device flow again, including devices in drawers whose owners
+will read it as a fault. Nothing is implemented and no grant exists, so the wider scope set costs
+exactly one line in a constant today.
+
+This is [ADR-0017 §7](0017-card-slots.md)'s argument on a different surface, and the second time this
+map has taken a decision early on the ground that its cost is not constant over time.
+
+## Amendments to accepted ADRs
+
+- **[ADR-0015 §7](0015-the-sync-experience.md)** — *"**Only `drive.appdata` is requested** — not
+  `email` — so the consent screen asks for exactly one thing"* is **reversed**. The requested set is
+  `openid email drive.appdata`; the consent screen asks for two things and the screen still states the
+  scope in plain words. Its closing sentence gains the *"Connected as …"* clause (§1). Its claim that
+  naming the account is *"the one thing that **would detect** it"* is **corrected to diagnose** (§2).
+- **[ADR-0015 §12](0015-the-sync-experience.md)** — the settings screen gains a row: **the connected
+  account address**, sourced from §1 above.
+- **[ADR-0015](0015-the-sync-experience.md) *Open items*** — the row *"Whether to name the account on
+  the enrolment screen … Unowned — needs a decision before enrolment ships"* is **discharged** by this
+  ADR. Its §16 item 2 note, which ends *"the live trade it leaves … is in Open items"*, is likewise
+  discharged.
+- **[ADR-0016 §13](0016-backup-and-restore.md)** — its reachability finding is **widened**: it rules
+  out not only a collection-identity check but **any** application-side check, including one on the
+  account address (§3). Its conclusion that ADR-0015 §7's sentence stands is unchanged; what changes is
+  that the sentence is no longer the *whole* defence, having gained a diagnostic beside it.
+- **[ADR-0016](0016-backup-and-restore.md) *Open items*** — the row *"Whether the enrolment screen
+  should name the account it connected as … Not scheduled"* is **discharged**.
+- **[ADR-0013 §8](0013-the-sync-transport.md)** — the scope set this project requests is `openid email
+  drive.appdata` rather than `drive.appdata` alone; all three were already verified as on the flow's
+  allowlist there. Its phishing-shape blast radius gains the victim's address (§5).
+- **[ADR-0013 §9](0013-the-sync-transport.md)** — the credential file gains one field, the account
+  address, deleted with the grant on disconnect (§6).
+
+## Consequences
+
+- **A fourth *detect and surface, never intervene*.** The account name can never block, warn or error,
+  because §3 makes any check structurally impossible. Anything that later turns it into a warning is a
+  defect, and it will look like an improvement.
+- **The consent screen asks for two things instead of one**, at the friction point ADR-0015 §7 names as
+  the hardest moment in the feature. Accepted: the screen states the scope in plain words, and *"see
+  your email address"* is a claim a user can evaluate.
+- **The address is cached at enrolment and never maintained**, so an account that later changes its
+  address shows a stale one. This is correct rather than merely tolerable — the diagnostic answers
+  *"what did I enrol as"*, and the stale value is the true answer to that question.
+- **Brand verification is unaffected and is not a new cost.** The lighter *brand-verification* process
+  is what an application completes to display branding on the consent screen; it is independent of
+  scope sensitivity and applied equally before this decision.
+- **One more thing lives in the credential file**, which is outside both export profiles and — per
+  [ADR-0013 §9](0013-the-sync-transport.md) — deliberately **inside** the Android backup set, the
+  opposite side of the line from [ADR-0007 §5](0007-the-local-store.md)'s writer marker. That is the
+  right side here and improves the diagnostic rather than merely riding along: a restored phone arrives
+  already authorised *and* already stating what it enrolled as, and **replacing a device is one of the
+  likelier occasions for a wrong-account re-enrolment**.
+- **`leitner-sync` gains one request and one field.** No new crate, no new dependency, no platform
+  capability, no `#[cfg]`.
+
+## Open items handed onward
+
+| Item | Owner |
+|---|---|
+| Exact copy for the *"Connected as …"* line on both surfaces | Implementation; §1 fixes where it appears, not its wording |
+| Visual treatment of the account row in sync settings | Out of scope — *the visual design pass*, which [ADR-0006 §10](0006-the-review-session-experience.md) opened and ADR-0010, ADR-0015, ADR-0017 and [ADR-0018](0018-the-card-pane-ordering.md) have joined |


### PR DESCRIPTION
Resolves [Decide: whether the enrolment screen names the account](https://github.com/amin-bf/leitner/issues/59) on [the map](https://github.com/amin-bf/leitner/issues/1), as **ADR-0019**. This was the last decision either [ADR-0015](https://github.com/amin-bf/leitner/blob/main/docs/adr/0015-the-sync-experience.md) or [ADR-0016](https://github.com/amin-bf/leitner/blob/main/docs/adr/0016-backup-and-restore.md) left standing with no owner — flagged *"Unowned — needs a decision before enrolment ships"* and *"Not scheduled"* respectively.

**Decision: yes. Enrolment names the account and sync settings keeps it. The scope set becomes `openid email drive.appdata`; `profile` is declined.**

## The premise all three documents got wrong

The ticket and both *Open items* rows describe naming the account as **"the only lever left"** / **"the only thing that would detect the case"**. That is false, and an ADR built on it would have been arguing for a redundancy. ADR-0015 §7's sentence already *detects*, at zero scope cost, in both forms the failure takes:

| case | what §7 says | caught? |
|---|---|---|
| Second device, wrong account | *"This is the first device here"* | **yes** — said to someone who knows they enrolled another device |
| Re-enrolment after [ADR-0013 §3](https://github.com/amin-bf/leitner/blob/main/docs/adr/0013-the-sync-transport.md)'s 7-month token death | *"This is the first device here"* | **yes** — it demonstrably worked before |
| Folder non-empty | *"Found 2 other devices"* | n/a — the account is provably right; the peers are visible |

**What §7 cannot do is diagnose.** The user must infer *"wrong account"* from *"first device here"*, and every competing hypothesis — folder cleared, other device reset, sync broken — is more intuitive.

**That is where it turns harmful rather than merely imperfect.** Each wrong hypothesis routes to a **repair action** — sync again, disconnect and reconnect, reinstall, restore — and not one can fix an account mismatch. Every attempt fails; every failure raises the user's confidence that the collection is gone, on a system whose central promise is that it cannot be. **The account name is bought for diagnosis. Detection was already paid for.**

## The app can never compare accounts — only a person can

ADR-0016 §13's reachability finding is **widened**: it rules out not only a collection-identity check but **any** application-side check, including one on the account address. With an empty folder there is no peer, no namespace and no published byte to compare against, so publishing *"this device connected as X"* is **structurally void** — the device that needs to read it is looking at a different folder.

Two things follow, and both bound what this may become:

- **The name can only ever be a statement**, never a warning or a block — the fourth *detect and surface, never intervene* on this map, after ADR-0010, ADR-0014 and ADR-0015 §1.
- **There is no wrong account in the absolute**, only one differing from the account the other device used. What is protected is **consistency across enrolments**, which is why human recognition is not a weak substitute for a check: it is the only thing that spans two enrolments months apart on two devices.

## The scope, priced rather than assumed

The ticket required this be established, since it is what the trade turns on:

- **All three scopes are non-sensitive**, so **ADR-0013 §3's load-bearing property is confirmed, not spent** — *"If your app utilizes only non-sensitive scopes, it is not mandatory for your app to complete the app verification process"* ([source](https://support.google.com/cloud/answer/13463073)). **No verification, no verification-time endpoint, no server.** The provider privileges that exact subset elsewhere too: it is the one set exempting a Testing-status project from the 7-day refresh-token expiry ADR-0013 §3 records as a console trap.
- **`profile` is declined.** Both ADRs write *"`email` or `profile`"* as interchangeable; they are not. `profile` yields display name and picture — no diagnostic value, and exactly the ambient identity ADR-0016 §11 keeps out. `openid` is required before `email` may be requested.
- **It costs one request, not zero.** The limited-input-device flow's documented token response carries no `id_token`, so the address comes from one `GET` to the UserInfo endpoint at enrolment — **no platform capability, no `#[cfg]`, no third function in a platform seam**.

## It persists, and it is not a third speaker

Showing it once at enrolment — how the ticket framed the safe version — **would have wasted the purchase**. The failure is discovered *months* later, so a once-only message is gone at the moment of discovery, defending only the case §7 already covers free. It also destroys the **only cross-device comparison that exists anywhere in this design**: two settings screens read side by side.

ADR-0015 §1 does not forbid it, on ADR-0015 §4's own title — *the resting surface states a fact, never a claim*. Everything §1 bans is a **state claim the app cannot back**; *"Connected as X"* makes none. It reuses ADR-0015 §3's rule verbatim: **the enrolment screen and sync settings, and nowhere else.**

## Where it lives — the artifact question dissolves

**The address is a property of the grant, not of the collection**, failing ADR-0004 §7's membership test one level further out than ADR-0010's suspension or ADR-0011's new-card rate did. Stored **beside the credential**, **never on the mutable surface**, deleted with the grant on disconnect — so ADR-0016 §4's *minus device identity and **credentials*** excludes it from both export profiles **with no clause naming it**, the same structural move ADR-0008 used on ADR-0004 §11's writer-id disclosure. On the mutable surface it would instead ride into every `.lcoll` **and** onto the remote, for a benefit already shown void.

Minimal disclosure was never reaching this: that rule governs **auto-populating a field in an artifact that travels**, and a user's own address on their own settings screen is not a disclosure surface.

## Accepted costs

- The consent screen asks for **two things instead of one**, at the friction point ADR-0015 §7 calls the hardest moment in the feature.
- The address is **cached at enrolment and never refreshed**, so a later address change shows stale — correct, since the diagnostic answers *"what did I enrol as"*.
- ADR-0013 §8's recorded phishing blast radius grows by the victim's address — **a fact the attacker already had**, since the attack requires talking to them. Recorded because that section is an honesty commitment.

## Amends and discharges

**Amends** ADR-0015 (§7 twice, §12, §16 item 2), ADR-0016 (§13 widened), ADR-0013 (§8, §9). **Discharges** the *Open items* row in **both** ADR-0015 and ADR-0016. `AGENTS.md`'s *what the user sees* rule 4 is rewritten (it claimed one sentence was the entire defence) and a rule 5 added; `CONTEXT-MAP.md`, `crates/sync/src/CONTEXT.md` and `crates/app/src/CONTEXT.md` follow.

**Decided now because it is free now** — adding a scope after enrolment ships is a re-consent for every already-enrolled device. Second time this map has taken a decision early on that ground, after [ADR-0017 §7](https://github.com/amin-bf/leitner/blob/main/docs/adr/0017-card-slots.md).

---

Docs only; `cargo test --workspace` passes (17 tests, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Note on numbering:** this is **ADR-0019**, not 0018 — [ADR-0018 (the card pane's ordering)](https://github.com/amin-bf/leitner/blob/main/docs/adr/0018-the-card-pane-ordering.md) merged to `main` mid-session and took that number. The branch is rebased on it; the two decisions do not interact (that ADR never mentions sync, enrolment, account or scope).
