### PR TITLE
Note Authoring / Reorderable Notes, Autosave, and the Note List

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,50 @@ definition**, chosen in [ADR-0017](./docs/adr/0017-card-slots.md).
    switched *into* an acquired kind. Add acquired kinds to that dropdown and the importer suddenly owes
    a check it does not have.
 
+## Authoring and the note list
+
+The app has three top-level destinations — **Review, Notes, Settings** — and the **note list** is the
+browse surface all authoring hangs off, specified in
+[ADR-0021](./docs/adr/0021-note-ordering-saving-and-the-note-list.md). Until it existed, two ADRs were
+already leaning on a screen nobody had built.
+
+### Rules that are easy to break silently
+
+1. **Reordering a note writes exactly one value. Never renumber.** `position` is an **order key with
+   infill**, not an integer, precisely so a move costs one write. A bulk rewrite — a "tidy up
+   positions", a compaction, a migration that redistributes keys — is N independent writes on ADR-0004
+   §7's surface, and **order is a gestalt, so one lost value scrambles the whole list**: two devices
+   reordering concurrently agree on neither order and nothing reports it. The integer looks simpler and
+   is the trap; ADR-0011 §7's *"need not be dense"* was a permission its own high-water counter never
+   let anyone use.
+2. **The note list has one order and no sort control.** A sort makes reordering meaningless while it is
+   active — a drag inside an alphabetical view has no definable result — and nothing fails when someone
+   adds one. Filters narrow; nothing re-sorts. Text search is the answer to "find this note".
+3. **Never put schedule information on the note list — not even aggregated.** A note generates several
+   cards in several boxes, so any per-note figure is boxes **counted**, which ADR-0001 §3 forbids
+   outright. This is constraint 4 deciding a rendering, and it reads as a helpful addition every time.
+4. **Never bind a key to "the last field".** Which field is last is a property of the **kind
+   definition**, which is *data*, so a kind gaining a field silently changes what the key does with no
+   code change and nothing failing — and ADR-0008 §7 lets a note carry an *acquired* kind, putting that
+   in a stranger's hands. Enter is inert in every single-line field, the last included; the *New note*
+   rhythm is a modifier chord.
+5. **The editor holds no unsaved state, and that is a durability rule rather than a preference.**
+   Autosave is per field on blur or a short idle. Client-stack rule 10 means a backgrounded Android app
+   is **frozen, then possibly killed** — so under an explicit save, putting the phone down mid-note is
+   the standard way to lose work, with no error and no chance for the app to warn. Adding a Save button
+   also un-does ADR-0012 §5, which deliberately moved the only decision a save could carry onto the
+   ambient warning.
+6. **"Never sync while the review screen is up" does not mean "nothing may change the queue
+   mid-session".** A note edited from the review screen changes it immediately and correctly. That rule
+   (sync rule 2 below, ADR-0015 §6) bans an **unannounced** recompute caused by another device — not
+   the visible result of the user's own act on the card in front of them. Read broadly, it deletes
+   mid-review editing as a violation, which is the predictable mistake.
+7. **Opening the editor from the review screen counts as a reveal.** The editor shows the back, so
+   without this ADR-0006 §4's *"self-grading can't happen before the answer is seen"* is quietly false.
+   The alternatives both need state this design does not have: skipping a card ungraded needs an
+   in-session deferred set, which ADR-0006 §2 proved does not exist, and flagging it for later is the
+   stored *"since you last looked"* ADR-0010 §9 refused.
+
 ## The client stack
 
 **egui / eframe**, chosen in [ADR-0003](./docs/adr/0003-client-stack.md). One binary per platform,

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -92,14 +92,14 @@ Read the ADR sections in your row. Read the whole ADR only if you are changing t
 
 | Context | Binding ADRs | Also bound by |
 |---|---|---|
-| `content` | [0002](./docs/adr/0002-the-card-model.md), [0005](./docs/adr/0005-the-deck-model.md), [0017](./docs/adr/0017-card-slots.md) | 0011 §7, 0012 §3, 0018 §3 |
+| `content` | [0002](./docs/adr/0002-the-card-model.md), [0005](./docs/adr/0005-the-deck-model.md), [0017](./docs/adr/0017-card-slots.md) | 0011 §7, 0012 §3, 0018 §3, 0021 §3 |
 | `log` | [0004](./docs/adr/0004-the-review-event-log.md) | 0002 §7, 0001 §6, 0010 §5, 0011 §5, 0013 §12, 0014 §6 |
 | `scheduling` | [0001](./docs/adr/0001-scheduling-algorithm-and-grade-scale.md) | 0004 §4, 0004 §5, 0014 §6 |
 | `replay` | *none of its own* | 0001 §7, 0002 §7, 0004 §9, 0007 §2, 0010 §2, 0011 §8, 0012 §5, 0017 §1, 0017 §5, 0018 §2 |
 | `store` | [0007](./docs/adr/0007-the-local-store.md) | 0004 §11, 0003 §5, 0013 §9, 0016 §3, 0016 §7, 0019 §6, 0020 §3, 0020 §4 |
-| `export` | [0008](./docs/adr/0008-the-deck-export-format.md), [0016](./docs/adr/0016-backup-and-restore.md) | 0005, 0002 §9, 0004 §11, 0011 §7, 0020 §4 |
+| `export` | [0008](./docs/adr/0008-the-deck-export-format.md), [0016](./docs/adr/0016-backup-and-restore.md) | 0005, 0002 §9, 0004 §11, 0011 §7, 0020 §4, 0021 §3 |
 | `sync` | [0013](./docs/adr/0013-the-sync-transport.md) | 0004 §2, 0004 §7, 0004 §10, 0007, 0014 §7, 0015 §2, 0015 §4, 0016 §10, 0019 §4, 0019 §6, 0020 §5, 0020 §6, 0020 §7 |
-| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md), [0010](./docs/adr/0010-leeches.md), [0011](./docs/adr/0011-new-card-rate-and-daily-limits.md), [0012](./docs/adr/0012-the-note-authoring-experience.md), [0014](./docs/adr/0014-when-parameter-optimisation-runs.md), [0015](./docs/adr/0015-the-sync-experience.md), [0018](./docs/adr/0018-the-card-pane-ordering.md), [0019](./docs/adr/0019-naming-the-account-at-enrolment.md) | 0002 §4, 0016 §6, 0016 §11, 0016 §12, 0017 §5, 0017 §6, 0020 §7 |
+| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md), [0010](./docs/adr/0010-leeches.md), [0011](./docs/adr/0011-new-card-rate-and-daily-limits.md), [0012](./docs/adr/0012-the-note-authoring-experience.md), [0014](./docs/adr/0014-when-parameter-optimisation-runs.md), [0015](./docs/adr/0015-the-sync-experience.md), [0018](./docs/adr/0018-the-card-pane-ordering.md), [0019](./docs/adr/0019-naming-the-account-at-enrolment.md), [0021](./docs/adr/0021-note-ordering-saving-and-the-note-list.md) | 0002 §4, 0016 §6, 0016 §11, 0016 §12, 0017 §5, 0017 §6, 0020 §7 |
 | *the workspace itself* | [0009](./docs/adr/0009-crate-and-workspace-layout.md) | 0013 §11, 0013 §12, 0015 §15, 0016 §5 |
 
 **`replay` having no ADR of its own is why it is a context.** Its rules were each written for another

--- a/crates/app/src/CONTEXT.md
+++ b/crates/app/src/CONTEXT.md
@@ -15,9 +15,47 @@ and §5** — read those amendments before touching the authoring pane; also by
 [ADR-0015](../../../docs/adr/0015-the-sync-experience.md) and
 [ADR-0019](../../../docs/adr/0019-naming-the-account-at-enrolment.md) (everything the user sees about
 sync — the `sync` crate holds the mechanism and none of the surface; the second **amends ADR-0015 §7
-and §12**, adding the connected account to enrolment and to sync settings).
+and §12**, adding the connected account to enrolment and to sync settings); and
+[ADR-0021](../../../docs/adr/0021-note-ordering-saving-and-the-note-list.md), which adds the **note
+list** and the app's navigation shell and **amends ADR-0012 §2, §7 and §9 and ADR-0006 §3 and §5** —
+read those before touching the editor or the review screen's actions.
 
 ## Language
+
+**Top-level destination**:
+One of the three places the app can be: **Review**, **Notes**, **Settings** (ADR-0021 §1). The floor
+that makes every specified screen reachable — the leech screen hangs off review's end-of-session
+pointer, enrolment sits inside settings. How the three are rendered is the visual design pass's.
+_Avoid_: Tab, page, route — none of which is fixed here.
+
+**Note list**:
+The browse surface, and the app's authoring home (ADR-0021 §2). Lists **notes, not cards** — the
+card-level list is the leech screen, and two would be two speakers for one fact. Narrowed by three
+composable filters, **deck, tag and text**, reusing ADR-0005 §6's queue-filter vocabulary; text search
+is load-bearing, not a convenience, because without it "find note 200 of 500" is browsing. Offers
+**create, edit, delete** — never **suspend**, which belongs to the leech screen's permanent home for
+suspended cards (ADR-0010 §8). Carries **no schedule information at all**: a note generates several
+cards in several boxes, so any per-note figure is boxes *counted*, which ADR-0001 §3 forbids. Deleted
+notes are not listed — ADR-0004 §7's delete discards the content, so there is nothing to list.
+_Avoid_: Browser, card browser, deck view.
+
+**List order**:
+The note list has **exactly one order — `position` — and no sort control** (ADR-0021 §4). Filters
+narrow; nothing re-sorts. This is load-bearing rather than tidy: a drag inside an alphabetical view
+has no definable result, so a sort silently makes reordering meaningless while it is active. **The key
+is never shown** — the list's own sequence *is* the rendering of order — and reordering inside a
+filtered list is well-defined, hidden notes staying between the neighbours they were between. A new
+note goes to the end of the **collection's** order, not of the filtered view.
+_Avoid_: Sort, sort order, position number.
+
+**Autosave**:
+How the editor saves: **per field, on blur or a short idle**, with a new note committed on its first
+non-empty field (ADR-0021 §7). **There is no Save button and no discard.** ADR-0012 §5 already moved
+the only decision a save could carry onto the ambient warning, and a draft the store has not seen is
+the one thing in this design an Android freeze can lose. One write is one row on ADR-0004 §7's
+surface with one stamp — the granularity §7 already chose. It also makes ADR-0012 §5's Undo copy
+literally true: undo is an ordinary edit writing the old value back.
+_Avoid_: Save, commit, draft, dirty state.
 
 **Session**:
 One sitting of review: a chosen card count, with a 10-minute timer running from the same moment.
@@ -154,6 +192,15 @@ grant, and ADR-0004 §8's clock-skew warning. A network failure never speaks —
   is not a lock on review — the app never blocks reviewing (ADR-0015 §1) — it is what stops a merge
   recomputing every `(S, D)` mid-session, which ADR-0014 called locally unfixable. It works only
   because there is no background sync, so treat that absence as load-bearing (ADR-0015 §6).
+  **This does not mean "nothing may change the queue mid-session".** A note edited from the review
+  screen changes it immediately and correctly (ADR-0021 §6) — the rule bans an *unannounced* recompute
+  caused by another device, not the visible result of the user's own act on the card in front of them.
+  Reading it the broad way deletes mid-review editing as a violation, which is the predictable mistake.
+- **Enter is inert in every single-line field, the last one included** (ADR-0012 §7, widened by
+  ADR-0021 §8). Never bind a key to "the last field": which field is last is a property of the **kind
+  definition**, which is data — and ADR-0008 §7 lets a note carry an *acquired* kind, so a stranger's
+  file would be deciding what a key does. Nothing fails when it changes. The *New note* rhythm is an
+  action with a modifier chord, never bare Enter, which `cloze`'s multiline field would need anyway.
 - **Only two things may speak about sync**, and every future feature will have a reason to want a
   third. A badge, a toast on success, a "syncing…" indicator in the chrome — each is a defect
   against ADR-0015 §4, not a UX improvement.

--- a/crates/core/src/content/CONTEXT.md
+++ b/crates/core/src/content/CONTEXT.md
@@ -54,11 +54,20 @@ Another card generated from the same note. **At most one card per note is introd
 skills they exist to schedule separately.
 
 **Position**:
-The integer fixing a note's place in authored order. From a local high-water counter on creation,
-from the `notes.jsonl` line index on import, ties broken by note id. **Not dense and not unique** —
-it only has to sort. Two things read it: new cards are introduced in `(position, ordinal)` order, and
-`export` emits notes in it (ADR-0011 §7).
-_Avoid_: Index, sequence number (which means `log`'s per-writer counter), sort key.
+The **order key** fixing a note's place in authored order — not an integer, and not a counter. Its
+defining property is **infill**: there is always a value between any two neighbours, so reordering a
+note writes **exactly one value** (ADR-0021 §3). A key after the current last on creation, keys in
+line order on import, ties broken by note id. **Not dense and not unique** — it only has to sort, and
+under ADR-0021 that is finally true rather than decorative. Two things read it: new cards are
+introduced in `(position, ordinal)` order, and `export` emits notes in it (ADR-0011 §7) — the file
+carries **line order**, never the key, so the representation reaches no byte of `.ldeck`.
+_Avoid_: Index, sequence number (which means `log`'s per-writer counter), sort key, position *number*
+— it is not one and is never shown as one.
+
+**Never renumber positions.** A move is one write. Any bulk rewrite — a "tidy up", a compaction, a
+migration that redistributes keys — is N independent writes on ADR-0004 §7's surface, and **order is a
+gestalt, so one lost value scrambles the whole list**: two devices reordering concurrently then agree
+on neither order, and nothing anywhere reports it. This is the entire reason the type is what it is.
 
 ### Kinds and fields
 

--- a/docs/adr/0002-the-card-model.md
+++ b/docs/adr/0002-the-card-model.md
@@ -278,6 +278,16 @@ Notes, by contrast, *are* created by a user action, so a minted identifier is co
 > it stays a random UUIDv4 and is not made time-ordered, so this section's clock-skew argument
 > stands. An empty `position` on a note predating the field is the defined state §4 already
 > provides for.
+>
+> > **Revised by [ADR-0021 §3](0021-note-ordering-saving-and-the-note-list.md): `position` is an
+> > **order key with infill**, not a plain integer.** *"Need not be dense or unique, only to sort"*
+> > above was a permission ADR-0011's own assignment rule never let anyone exercise — a high-water
+> > counter and a line index both produce consecutive integers — so a user could not be offered
+> > *"put this note between those two"* without renumbering a run of notes, which scrambles order
+> > across devices under ADR-0004 §7's per-value settling. The assignment rules survive with only
+> > the type changed, and **the id is untouched a second time**: still a random UUIDv4.
+
+
 
 #### Canonical encoding
 

--- a/docs/adr/0006-the-review-session-experience.md
+++ b/docs/adr/0006-the-review-session-experience.md
@@ -95,6 +95,20 @@ The card itself is the tap target for revealing the answer — not a separate "S
 Verified by real touch on the Pixel 8 Pro and by mouse click on desktop; no divergence between the
 two was needed or found.
 
+> **Amended by [ADR-0021 §6](0021-note-ordering-saving-and-the-note-list.md): reveal has a second
+> cause.** The review screen gains an *edit this note* action opening
+> [ADR-0012](0012-the-note-authoring-experience.md)'s editor, and **entering the editor counts as a
+> reveal** — because the editor shows the back, so without this §4's *"self-grading can't happen
+> before the answer is seen"* is quietly false. Tap-the-card is unchanged as the ordinary cause.
+>
+> The tidier alternatives both fail on this ADR's own terms: *skip the card ungraded* needs an
+> in-session set of deferred cards, which §2 spent a handset force-stop proving does not exist; *flag
+> it and edit at the end* is the stored *"since you last looked"* state
+> [ADR-0010 §9](0010-leeches.md) already refused. And an edit that makes the current card dormant
+> needs no mechanism at all — §2 recomputes the queue on read, so it is simply gone, and
+> [ADR-0011 §9](0011-new-card-rate-and-daily-limits.md)'s counting of *gradings* means the counter
+> does not advance.
+
 ### 4. Grading: four buttons, full-width, stacked vertically, shown only after reveal
 
 No swipes, no dedicated keyboard-only path (the prototype's variant switcher used arrow keys, but
@@ -111,6 +125,13 @@ The same layout, the same button sizes, worked identically for real touch on the
 mouse clicks on desktop. No platform-specific interaction path — larger touch targets, different
 gestures — was needed. (Keyboard-only grading was not requested or explored; if it's wanted later,
 it's additive, not a redesign.)
+
+> **Amended by [ADR-0021 §8](0021-note-ordering-saving-and-the-note-list.md): the app acquires
+> exactly one keyboard shortcut, and it is not here.** A modifier chord for *New note* in the editor,
+> admitted because bulk authoring is the case ADR-0021 §3's ordering work exists to serve and
+> `AGENTS.md` client-stack rule 8 already makes serious authoring desktop-only. **Review remains
+> keyboard-free**, and the first shortcut is recorded deliberately so that a second is a decision
+> rather than a drift.
 
 ### 6. Constraint 4's box display: a quiet badge, only after reveal
 

--- a/docs/adr/0008-the-deck-export-format.md
+++ b/docs/adr/0008-the-deck-export-format.md
@@ -380,6 +380,15 @@ identical content twice would yield different bytes — leaking build time, maki
 control diff as changed when nothing did, and weakening §9's "same revision, same file" from a property
 to an approximation.
 
+> **Touched but unchanged by [ADR-0021 §3](0021-note-ordering-saving-and-the-note-list.md), recorded
+> so nobody re-derives it.** That ADR makes `position` an **order key with infill** rather than a plain
+> integer, so that a user reordering notes writes one value instead of renumbering a run of them. **No
+> byte of this format moves.** Emission stays `(position, note id)` and stays byte-for-byte
+> deterministic, because the file carries **line order** rather than the value — ADR-0011 §7 already
+> specified import as reading the `notes.jsonl` line index, so the representation was never in the
+> container to begin with. A reader who notices `position`'s type changing and comes looking for a
+> format version bump should stop here: there isn't one, and there does not need to be.
+
 **Verification of constraint 2's content/progress split, which the ticket asked for.** Every channel is
 clean: writer ids are absent because the deck profile carries no log; device labels are never exported;
 scheduler configuration lives in the log, not in content; personal per-deck preferences are excluded by

--- a/docs/adr/0011-new-card-rate-and-daily-limits.md
+++ b/docs/adr/0011-new-card-rate-and-daily-limits.md
@@ -267,6 +267,28 @@ in `(position, ordinal)` order.
 This closes ADR-0008 §12's gap rather than adding an obligation: the export already needed a fixed
 emission order for determinism to be honest, and `position` is now it. One concept serves both.
 
+> **Amended by [ADR-0021 §3](0021-note-ordering-saving-and-the-note-list.md): `position` is an
+> **order key with infill**, not a plain integer — and the user *can* reorder notes, which is the
+> question this section handed onward and is now discharged.**
+>
+> **The bullet above granted a freedom this section then specified away.** *"Need not be dense"* is a
+> permission that the assignment rule never lets anyone exercise: a local high-water counter and a
+> `notes.jsonl` line index both produce **consecutive** integers, so *"put this note between those
+> two"* has no value to write. Every way of writing it by renumbering costs N writes on ADR-0004 §7's
+> surface, each settling independently — and **order is a gestalt, so one lost value scrambles the
+> whole list**: two devices reordering concurrently produce neither device's order, and nothing
+> reports it.
+>
+> So `position` becomes a key that always admits a value between any two neighbours (a fractional
+> index). **A move writes exactly one value, forever.** The three rules above survive with only the
+> type changed — a key after the current last on creation, keys in line order on import, ties broken
+> by note id — and *"need not be dense or globally unique"* becomes true and load-bearing rather than
+> decorative. **Nothing reaches the export**: the file carries line order, not the value, exactly as
+> the import rule above already said, so ADR-0008 §12's emission clause is textually unchanged and
+> still byte-for-byte deterministic. *One concept serves both* survives the field becoming editable,
+> which only this option allows — the two readers want different things, introduction order needing
+> only "what comes next" where emission order needs the whole authored sequence.
+
 ### 8. The cap counts cards, and at most one card per note is introduced per day
 
 **Counting cards rather than notes is forced by the cap's purpose.** An eight-blank `cloze` note is
@@ -364,6 +386,18 @@ ADR-0010 (its requirement on this ticket is honoured in §8 unchanged).
 2. **Introduction order is visible to the author**, so a deck built for sequence needs the authoring
    surface to show what that sequence is.
 
+> **Both discharged by [ADR-0021](0021-note-ordering-saving-and-the-note-list.md), not by #28** —
+> which closed without reaching either, which is why the map re-owned them.
+>
+> Requirement 1: **yes, and it is one mutable-surface edit exactly as anticipated** — but only because
+> §7's type changed. Under the plain integer it would have been N edits, which is the hazard ADR-0021
+> §3 closes.
+>
+> Requirement 2 is met **somewhere this ADR did not expect**. Sequence is visible on the **note
+> list**, not in the editor: ADR-0021 §4 shows order as the list's own sequence and never as a number,
+> because order is a property of the collection rather than of a note in isolation. *"How `position`
+> is surfaced while authoring"* therefore has the answer **not in the editor at all**.
+
 ### [#37 — backup and restore](https://github.com/amin-bf/leitner/issues/37)
 
 1. **The new-card rate is personal, not content**: it belongs to the progress profile, must survive
@@ -415,5 +449,5 @@ in [`ui`](../../crates/app/src/CONTEXT.md), which owns the session.
 |---|---|
 | **Workload prediction as advice** — showing *"at this rate, expect roughly N reviews a day once it settles"* using `expected_workload`. Useful, and explicitly never allowed to *control* the rate (§3). | **Out of scope** — [the map](https://github.com/amin-bf/leitner/issues/1), 2026-07-31. §3 already fixed the hard part, and the interim answer — this ADR's own estimate table — ships; what remains is a read-only figure beside the rate setting |
 | **Per-deck new-card on/off** — shape known (§6), not built. | **Out of scope** — [the map](https://github.com/amin-bf/leitner/issues/1), 2026-07-31, on **scope not sharpness**: the decision was taken (defer) and the mechanism is written down, so what remains is a build. It carries one live sub-question a fresh effort inherits — [ADR-0005](0005-the-deck-model.md)'s row on whether such a preference syncs or stays device-local |
-| **Whether notes are user-reorderable**, and how `position` is surfaced while authoring. | [Decide: note ordering, saving, and where authoring is entered from](https://github.com/amin-bf/leitner/issues/66) — **re-owned on 2026-08-01**: [#28](https://github.com/amin-bf/leitner/issues/28) was named here and closed without touching it, which the *Open items* sweep caught |
+| ~~**Whether notes are user-reorderable**, and how `position` is surfaced while authoring~~ — **answered by [ADR-0021 §3 and §4](0021-note-ordering-saving-and-the-note-list.md)**: they are, `position` becomes an **order key with infill** so a move is one write rather than a renumber, and it is surfaced as the note list's own sequence — never as a number, and not in the editor at all | — *(was [#66](https://github.com/amin-bf/leitner/issues/66), **re-owned on 2026-08-01**: [#28](https://github.com/amin-bf/leitner/issues/28) was named here and closed without touching it, which the* Open items *sweep caught)* |
 | **Revisiting 10/20/40 and five a day against real usage** — §4 records the relationship between them; neither number is measured. | Post-implementation |

--- a/docs/adr/0012-the-note-authoring-experience.md
+++ b/docs/adr/0012-the-note-authoring-experience.md
@@ -65,6 +65,14 @@ while chips spend a permanent row on it.
 **Changing kind later is permitted, and is not a special mechanism** — see §6 for the hazard it
 carries, which is the sharpest finding in this ADR.
 
+> **Extended by [ADR-0021 §9](0021-note-ordering-saving-and-the-note-list.md): there is a second
+> dropdown beside it, for the note's *deck*, with *create a new deck* available from it.** This ADR
+> specified the kind dropdown and was silent on deck, and no other ADR said where a note's `deck`
+> reference is set — so between them nothing did. Creation belongs on the dropdown because the moment
+> you need a deck that does not exist is while filing the note that wants it, and
+> [ADR-0005 §8](0005-the-deck-model.md) forbids ever auto-creating one. Declining costs nothing:
+> ADR-0005 §7 makes an absent reference legal, and such a note is unfiled and still reviewable.
+
 > **Amended by [ADR-0017 §6](0017-card-slots.md): the dropdown lists the shipped kinds, plus the
 > note's own current kind when that kind was *acquired*** ([ADR-0008 §7](0008-the-deck-export-format.md)).
 > A note of an imported kind therefore shows its own kind, can be switched away from it, and can be
@@ -209,6 +217,18 @@ implementation.
 - **Enter in a single-line field does nothing**, and the field keeps focus. egui treats Enter in a
   `TextEdit::singleline` as a submit and surrenders focus, which leaves the caret nowhere.
   Advancing to the next field was tried and rejected: a note editor is not a wizard.
+
+> **Widened by [ADR-0021 §8](0021-note-ordering-saving-and-the-note-list.md) to the *last* field,
+> which §9 below left unowned — the rule holds without exception.** Under ADR-0021 §7's autosave there
+> is nothing for Enter to commit, so the only meaning left would be *"and now give me a fresh note"* —
+> a navigation act, and it must not be bound to Enter for two reasons. **"The last field" is a
+> property of the kind definition, which is *data***, so a kind gaining a field would silently change
+> what a key does, with no code change and nothing failing — and
+> [ADR-0008 §7](0008-the-deck-export-format.md) lets a note carry an **acquired** kind, putting that
+> in a stranger's hands. And the rule could not be uniform anyway: `cloze`'s field is multiline, where
+> Enter must insert a newline, so the carve-out would be invisible to a user pressing Enter in the
+> last field of two different notes. The rhythm instead gets a **New note** action carrying kind and
+> deck forward, with one modifier-chord accelerator that can never collide with a field's own Enter.
 - **Single-line fields must be `singleline`**, or Enter inserts a newline into a `Term` and long
   values wrap inside a one-row box.
 - **Each line aligns by its own first strong character** — the `dir="auto"` rule. A Persian term
@@ -249,6 +269,25 @@ one-frame deferral to a second reason.
 - **Saving semantics** — autosave versus explicit save, and what Enter means on the last field.
 - **Editing a note mid-review**, and where authoring is entered from.
 
+> **The last two are closed by [ADR-0021](0021-note-ordering-saving-and-the-note-list.md).**
+>
+> **Saving is automatic, per field** (§7) — and the decisive argument is *this ADR's own §5*. Making
+> the destructive-edit warning ambient *"rather than a check at save time"* already spent the only
+> decision a save could have carried, leaving a control that commits bytes and asks nothing. Two
+> further grounds: this ADR's *Consequences* note that *"the editor holds a draft the store has not
+> seen"* describes the one piece of state in the whole design a kill can lose, against
+> [ADR-0006 §2](0006-the-review-session-experience.md)'s proof that nothing else does; and on Android
+> an app is **frozen, not slowed**, so under explicit save putting the phone down mid-note is the
+> standard way to lose work, silently. It also makes §5's Undo copy **literally** true rather than
+> approximately: undo becomes an ordinary edit writing the old value back with a fresh stamp.
+>
+> **Where authoring is entered from** (§5, §6) turned out to need a screen that did not exist —
+> **no browse surface is specified anywhere in twenty ADRs**, which is why
+> [ADR-0010 §7](0010-leeches.md) could say *"edit … already exists"* about a door nobody had built.
+> ADR-0021 specifies a **note list** and makes this one editor with four entrances. **A note is
+> editable mid-review**, and **entering the editor counts as a reveal** — without which §4 of
+> ADR-0006 is quietly false, since the editor shows the back.
+
 ## Amendments to accepted ADRs
 
 - **ADR-0002 §7** — its claim that the replay mechanism "absorbs a note changing kind" is amended
@@ -263,6 +302,10 @@ one-frame deferral to a second reason.
 *(§1 and §5 are in turn amended by [ADR-0018](0018-the-card-pane-ordering.md) — a dormant entry is a
 line rather than a card, and the form-pane warning is primary on both platforms. Both amendments are
 recorded inline above.)*
+
+*(§2, §7 and §9 are amended by [ADR-0021](0021-note-ordering-saving-and-the-note-list.md) — the
+editor gains a deck dropdown, the Enter rule widens to the last field, and two of §9's four unsettled
+items close. All three are recorded inline above.)*
 
 ## Consequences
 
@@ -284,16 +327,22 @@ recorded inline above.)*
   [ADR-0017](0017-card-slots.md)**: no discriminator, and the ordinal becomes an assigned slot instead.
 - **A soft-keyboard pass on the handset** (§9) — the one question desktop cannot answer. Now owned by
   [Prototype: the authoring screen under a soft keyboard](https://github.com/amin-bf/leitner/issues/67).
-- **Saving semantics** (§9) — autosave versus explicit save, and what Enter means on the last field.
-  Now owned by [Decide: note ordering, saving, and where authoring is entered from](https://github.com/amin-bf/leitner/issues/66).
-- **Editing a note mid-review, and where authoring is entered from** (§9) — owned by the same ticket.
+- ~~**Saving semantics** (§9)~~ — **discharged by
+  [ADR-0021 §7 and §8](0021-note-ordering-saving-and-the-note-list.md)**: autosave, per field, on blur
+  or a short idle, with a new note committed on its first non-empty field; and Enter stays inert in
+  every single-line field, the last one included.
+- ~~**Editing a note mid-review, and where authoring is entered from** (§9)~~ — **discharged by
+  [ADR-0021 §5 and §6](0021-note-ordering-saving-and-the-note-list.md)**: one editor with four
+  entrances, one of them the review screen, where opening it counts as a reveal.
   *This row was missing from the table until 2026-08-01*, along with saving semantics: §9 named four
   things this ADR does not settle and the table carried two, so the map's fog triage — which sweeps
   these tables — never saw them. Recorded rather than quietly added, because the gap is the reason a
   session's worth of decisions sat unowned for a month.
-- **Whether notes are user-reorderable, and how `position` is surfaced while authoring** — handed
-  *here* by [ADR-0011](0011-new-card-rate-and-daily-limits.md) and never answered; also now
-  [#66](https://github.com/amin-bf/leitner/issues/66)'s.
+- ~~**Whether notes are user-reorderable, and how `position` is surfaced while authoring**~~ — handed
+  *here* by [ADR-0011](0011-new-card-rate-and-daily-limits.md) and never answered; **discharged by
+  [ADR-0021 §3 and §4](0021-note-ordering-saving-and-the-note-list.md)**, which found that ADR-0011
+  §7's *"need not be dense"* permission was one its own assignment rule never let anyone use, and made
+  `position` an order key with infill so a move is one write. Surfaced on the **note list**, not here.
 - **Visual design** — **out of scope** for the map as of 2026-07-31, as *the visual design pass* that
   [ADR-0006 §10](0006-the-review-session-experience.md) opened.
   Narrowed by [ADR-0018](0018-the-card-pane-ordering.md) for this pane: what a dormant line *says*,

--- a/docs/adr/0021-note-ordering-saving-and-the-note-list.md
+++ b/docs/adr/0021-note-ordering-saving-and-the-note-list.md
@@ -1,0 +1,389 @@
+# ADR-0021: Note ordering, saving, and the note list
+
+- **Status**: Accepted
+- **Date**: 2026-08-01
+- **Resolves**: [Decide: note ordering, saving, and where authoring is entered from](https://github.com/amin-bf/leitner/issues/66)
+- **Map**: [Map: local-first Leitner app spec](https://github.com/amin-bf/leitner/issues/1)
+- **Related**: [ADR-0012](0012-the-note-authoring-experience.md) (the editor this ADR gives
+  entrances, a save rule and a keyboard rule — this ADR **amends it**),
+  [ADR-0011](0011-new-card-rate-and-daily-limits.md) (which minted `position` and handed its
+  surfacing here — **amended**), [ADR-0006](0006-the-review-session-experience.md) (the session this
+  ADR opens a door out of — **amended**), [ADR-0005](0005-the-deck-model.md) (decks, filters, and
+  *no deck is ever auto-created*), [ADR-0010](0010-leeches.md) (which already assumed the editor was
+  reachable), [ADR-0004 §7](0004-the-review-event-log.md) (the mutable surface every write here
+  lands on)
+
+## Context
+
+Three questions arrive together because they are one screen's contract, and all three reached this
+ticket by being **dropped rather than deferred**.
+
+[ADR-0012 §9](0012-the-note-authoring-experience.md) lists four things it does not settle; its *Open
+items* table carried two. The two it omitted were **saving semantics** — autosave versus explicit
+save, and what Enter does on the last field — and **where authoring is entered from, and whether a
+note can be edited mid-review**. A third was handed *to* that ticket by
+[ADR-0011 §7](0011-new-card-rate-and-daily-limits.md), whose own prose says *"whether the user can
+reorder notes is that ticket's call"*, and the ticket closed without touching it. The map's fog
+triage sweeps *Open items* tables, so none of the three was ever swept.
+
+Answering the third of them turned out to require a screen that does not exist. **No browse surface
+is specified anywhere in twenty ADRs.** The named screens are the count-picker and empty state, the
+review screen, the leech screen, settings, enrolment, and the editor; nothing says how you move
+between them. Two ADRs already lean on the absence: [ADR-0010 §7](0010-leeches.md) makes **edit** the
+primary leech action and says *"it already exists"*, while §8 of the same ADR argues against
+suspend-and-forget on the ground that it would leave content rotting *"with no way back short of
+hunting through a browser"* — written as though no browser exists, because none does.
+
+So this ADR specifies the note list's **contract** and leaves its **appearance** to the visual
+design pass. That is the split [ADR-0018](0018-the-card-pane-ordering.md) made and the map recorded
+as vindicated: what an entry says, where it sits and when it appears were answerable without knowing
+a single colour.
+
+## Decision
+
+### 1. Three top-level destinations: Review, Notes, Settings
+
+The smallest set that makes every already-specified screen reachable. The leech screen stays exactly
+where [ADR-0010](0010-leeches.md) put it — the end-of-session pointer, plus its own screen — and
+enrolment stays inside Settings, per [ADR-0015 §7](0015-the-sync-experience.md). **Notes** is the new
+one.
+
+How the three are rendered — a tab bar, a drawer, something else — is the visual design pass's, and
+this ADR deliberately does not pin it. What is fixed is that all three are reachable from a
+persistent affordance, because a destination reachable only by completing a session is not reachable.
+
+### 2. The note list: what it lists, what narrows it, what it offers
+
+**It lists notes, not cards.** Editing is per note ([ADR-0012](0012-the-note-authoring-experience.md)),
+and a card-level list already exists as the leech screen. Two card-level lists would be two speakers
+for one fact, which this map has now refused four times.
+
+**Three composable filters: deck, tag, and text.** Deck ∩ tag reuses
+[ADR-0005 §6](0005-the-deck-model.md)'s queue-filter vocabulary verbatim rather than inventing a
+second one — *narrowing is a filter, not a mode* — and text is a plain substring match over the
+note's own field values.
+
+**Text search is load-bearing, not a convenience.** Without it, *"fix the typo in note 200 of 500"*
+is browsing, which is the failure that justified creating this surface at all. It is affordable
+without argument: field values are rows in [ADR-0007 §4](0007-the-local-store.md)'s `mutable` table,
+keyed `(entity, entity_id, attr)`, so a scan at collection scale is a few thousand rows — and if it
+ever is not, `derived.db` is the disposable place for an index, which costs nothing to lose.
+
+**Actions: create, edit, delete. Not suspend.** Suspension is per-`CardRef` and
+[ADR-0010 §8](0010-leeches.md) gives suspended cards a **permanent home** on the leech screen,
+because that surface is the only place they exist once they leave the due count. A second place to
+suspend splits that home in two and reintroduces suspend-and-forget by the back door.
+
+**No schedule information in the list. None.** No box, no due count, not even aggregated per note. A
+note generates several cards in several boxes, so *any* per-note figure is boxes **counted**, which
+[ADR-0001 §3](0001-scheduling-algorithm-and-grade-scale.md) forbids outright — and an aggregate would
+be worse than a count, since it would also have to invent a rule for combining them. This keeps the
+surface honestly an authoring surface, and it is the third time constraint 4 has decided a rendering
+rather than a mechanism.
+
+**Deleted notes are not listed, and there is no undelete here.**
+[ADR-0004 §7](0004-the-review-event-log.md)'s delete keeps a marker and *discards* the content, so a
+deleted note has nothing to list — a row would be an id and a stamp. Recovery is
+[ADR-0016](0016-backup-and-restore.md)'s restore, which is already specified as the mechanism and is
+the reason §7 was allowed to discard content in the first place.
+
+**The empty state is [ADR-0015 §7](0015-the-sync-experience.md)'s, unchanged.** *"Nothing here yet —
+create a deck, import one, or set up sync"* is the same empty collection seen from a second screen,
+and this ADR now puts a surface behind all three of its verbs.
+
+### 3. Notes are reorderable, and `position` stops being a plain integer
+
+[ADR-0011 §7](0011-new-card-rate-and-daily-limits.md) says `position` *"need not be dense or globally
+unique — only to sort"*. **That permission is decorative, because its own assignment rule never lets
+you exercise it**: a local high-water counter and a `notes.jsonl` line index both produce consecutive
+integers. So *"put this note between those two"* has no value to write. The section granted a freedom
+and then specified it away, one paragraph apart — the same shape [ADR-0017](0017-card-slots.md) found
+in [ADR-0002 §5](0002-the-card-model.md), which talked itself out of a hazard one sentence before the
+hazard arrived.
+
+Four ways out were considered.
+
+- **No reordering.** Cheapest, and it makes the tool broken for the case that *invented* `position`.
+  ADR-0011 §7 justified the field on *"a frequency-ordered vocabulary course, the most common shape
+  of shared deck there is"*. An author who realises note 40 belongs first has one repair —
+  delete and recreate — and [ADR-0002 §6](0002-the-card-model.md) forbids re-minting an id while
+  ADR-0004 §7's delete discards the content, so **the only available fix destroys the note's review
+  history**.
+- **Reorder by renumbering.** Drag, rewrite every position in between. That is N writes on ADR-0004
+  §7's surface, each settling independently by counter-stamp. **Order is a gestalt, so one lost value
+  scrambles the whole list**: two devices reordering concurrently produce neither device's order, and
+  nothing reports it. This is strictly worse than the per-field text case §7 accepts, where every
+  value that survives is independently meaningful.
+- **Extremes only** — *introduce this next*, *introduce this last*. One write each, concurrency-safe,
+  no renumber. It serves a **consumer** ("what comes next") and fails an **author** outright: you
+  cannot say "put this one third", and sorting two hundred notes by repeated *move to last* is two
+  hundred operations in the wrong direction.
+- **An order key with infill**, which is what ships.
+
+**Therefore: `position` is an order key that always admits a value between any two neighbours** — a
+fractional index, conventionally a lexicographically-ordered string over a fixed alphabet, though the
+representation is an implementation choice so long as it has that property and one total order every
+device computes identically.
+
+- **Reordering writes exactly one value, forever.** No renumber, ever.
+- **Two devices each moving a note both survive**, because each wrote one independent value. ADR-0011
+  §7's *"ties broken by note id"* survives verbatim as the tie-break when two moves land in the same
+  slot, and it is deterministic on every device.
+- **Creation assigns a key after the current last**, which is ADR-0011 §7's high-water rule with the
+  type changed. **Import assigns keys in `notes.jsonl` line order**, which is ADR-0011 §7's line-index
+  rule with the type changed.
+- **`.ldeck` is untouched.** The file carries *line order*, not the value — ADR-0011 §7 already
+  specified import as reading the line index — so no format change, no new field, and
+  [ADR-0008 §12](0008-the-deck-export-format.md)'s emission clause is textually unchanged: notes are
+  still emitted in `(position, note id)` order, still byte-for-byte deterministic.
+
+**Three reasons this is the right cost.** It **removes** the hazard rather than accepting it — and
+while renumbering's damage is admittedly only cosmetic (nothing is lost; only introduction order of
+unstudied cards and export order move), it is unlike [ADR-0004 §8](0004-the-review-event-log.md)'s
+accepted skew residual in being neither bounded, nor self-limiting, nor detectable, and for an author
+a scrambled published course *is* the product being wrong. It is **the only option that serves both
+readers of `position`**, which want different things: introduction order wants "what comes next",
+where the extremes suffice; export emission order wants the whole authored sequence, where only
+arbitrary placement will do — and ADR-0011 §7's pride was that *"one concept serves both"*, which
+only survives editing under this option. And it is **decided now because it is free now** — the third
+time on this map, after [ADR-0017](0017-card-slots.md) and
+[ADR-0019](0019-naming-the-account-at-enrolment.md). Nothing is implemented and no note has a
+position; later it is a migration across every device's mutable surface and every `.lcoll` in
+existence.
+
+Accepted cost: keys grow slowly under repeated insertion at one spot. At collection scale this is
+irrelevant, and it is the standard price of the property that buys the single write.
+
+### 4. Order is never a number on screen, and the operation is specified rather than the gesture
+
+**The value is never shown, anywhere.** Under §3 it is not a number at all. Showing it would invite
+the reading that it is dense, unique and comparable — precisely what it is not. **The list's own
+sequence is the rendering of order**, and it is the only honest one.
+
+**The note list has exactly one order — `position` — and no sort control.** Filters narrow; nothing
+re-sorts. This is ADR-0005 §6's *narrowing is a filter, not a mode* applied to the browse surface,
+and it is load-bearing rather than tidy: a drag inside an alphabetically sorted view has no definable
+result, so a sort control silently makes reordering meaningless while it is active. A sort is in any
+case the answer to a question §2's text search already answers better.
+
+**Reordering inside a filtered list is well-defined, and that is a dividend of §3.** Placing a note
+between two visible neighbours puts it between them; hidden notes that sat between them stay between
+them. Under renumbering, the same gesture has to invent positions for notes the user cannot see.
+
+**The decision is the operation — *place this note before/after that one*, one write — never the
+gesture.** Whether that is a drag handle or a *move to…* action belongs to the visual design pass,
+and the distinction matters: long-press-drag in a scrolling list is genuinely poor on a phone, so
+pinning the spec to a drag would decide a handset interaction from a desktop assumption. Same split
+as ADR-0018, for the same reason.
+
+**The editor neither shows nor edits order.** This dissolves ADR-0011's handoff as phrased — *"how
+`position` is surfaced while authoring"* has the answer **not in the editor**. Order is a property of
+the collection, not of a note in isolation, and the note list is where the collection is visible.
+
+**A new note is created at the end of the collection's order**, not at the end of whatever the active
+filter shows. Worth stating because "the end of the deck I am looking at" is the intuitive misreading
+and is not expressible: ADR-0005 §6 gives one collection-wide queue and therefore one collection-wide
+order. It costs an author nothing, since exporting one deck emits that deck's notes in their relative
+order regardless of what is interleaved between them.
+
+### 5. Authoring is one editor with four entrances
+
+The same editor, reached from: **create** (the note list, or ADR-0015 §7's empty state), **the note
+list's edit**, **the leech screen's edit** (ADR-0010 §7, already specified and until now assuming a
+door that was never built), and **the review screen** (§6).
+
+### 6. A note is editable mid-review, and entering the editor counts as a reveal
+
+**The review screen offers *edit this note*, at any point in the card's life.**
+
+**Why at all**: ADR-0010 §7 already fixes that *"the honest diagnosis of most leeches is a defective
+card"* and makes edit the primary response — but routes you there only from the end-of-session
+pointer, by which time the user must have carried "the note about X was wrong" across twenty more
+cards. The moment a defective card can be diagnosed is the moment it is in front of you.
+
+**Why this is not what ADR-0010 §9 rejected.** That section refused *inline prompting* because it
+demands a considered judgement when the user is most frustrated, which routes to delete. That is the
+**app interrupting to ask a question**; this is the **user choosing to fix a typo**. Only the first
+has that failure mode, and reading §9 as "nothing may be done to a card mid-session" would delete
+this section.
+
+**Why "counts as a reveal" rather than anything cleverer.** The editor shows the back, so
+[ADR-0006 §4](0006-the-review-session-experience.md)'s guarantee — grade buttons appear only after
+reveal, *"so self-grading can't happen before the answer is seen"* — is otherwise quietly broken. Both
+tidier-sounding alternatives fail on this design's own terms. *Skip the card ungraded* needs an
+in-session set of deferred cards, or [ADR-0006 §2](0006-the-review-session-experience.md)'s
+recomputed queue hands it straight back — and §2's whole proof, made on the handset with a real
+force-stop, is that no session position is stored. *Flag it and edit at the end* is a to-do list,
+which is the stored *"since you last looked"* state ADR-0010 §9 already refused for want of anywhere
+to keep it.
+
+**An edit that kills the card you are looking at needs no mechanism.** Delete the blank you are
+staring at and the card is dormant; ADR-0006 §2 recomputes the queue on read, so it is simply not
+there and the session moves on. No grade is recorded, and because
+[ADR-0011 §9](0011-new-card-rate-and-daily-limits.md) counts **gradings**, the counter does not
+advance. This falls out of two existing rules rather than adding a third.
+
+**This does not breach [ADR-0015 §6](0015-the-sync-experience.md)'s *never start a sync while the
+review screen is up*.** That rule bans an **unannounced** recompute caused by another device — the
+thing ADR-0014 called locally unfixable. Here the recompute is the immediate and visible result of
+the user's own act, on the card in front of them. Written down explicitly because, left unstated,
+someone will read the sync rule as *"nothing may change the queue mid-session"* and remove this
+section as a violation of it.
+
+### 7. Saving is automatic, per field
+
+**Autosave — per field, on blur or a short idle — with a new note committed on its first non-empty
+field.** There is no Save button and no discard.
+
+Four grounds:
+
+1. **[ADR-0012 §5](0012-the-note-authoring-experience.md) already spent the Save button's job.** It
+   made the destructive-edit warning ambient and recomputed every frame *"rather than a check at save
+   time"*, and rejected the modal-at-save because *"by the time you press Save the edit is already
+   made, and a dialog asks for a decision about work you have stopped thinking about."* The one
+   decision a save could have carried has been moved off it. What remains is a control that commits
+   bytes and asks nothing.
+2. **An unsaved draft is the only thing in this design that a kill can lose.** ADR-0006 §2 proved on
+   the handset that nothing about *"where was I"* survives a kill and nothing needs to, because the
+   store answers everything. A draft in memory is a second source of truth alongside it — exactly
+   what §2 says the session UI had to avoid inventing. ADR-0012's own *Consequences* flags it already:
+   *"the editor holds a draft the store has not seen."*
+3. **On Android the failure is silent and is the normal case.** `AGENTS.md` client-stack rule 10 and
+   [ADR-0014 §3](0014-when-parameter-optimisation-runs.md): a backgrounded app is **frozen, not
+   slowed**, and may be killed outright. Under explicit save, putting the phone down mid-note is the
+   standard way to lose work — no error, nothing to recover, and no opportunity for the app to warn,
+   because it is frozen before it could.
+4. **The write granularity already exists and is the right one.** ADR-0004 §7 settles note fields
+   **per field**, precisely so that *"editing the front on one device and the back on another loses
+   neither"*, and ADR-0007 §4's `mutable` table is keyed `(entity, entity_id, attr)`. An autosave
+   write is one row and one stamp. No new machinery.
+
+**One thing falls out rather than being paid for: autosave makes ADR-0012 §5's Undo copy literally
+true.** Under autosave, Undo is an ordinary edit writing the previous value back with a fresh stamp,
+so *"nothing is deleted, the reviews stay in the log, and they reattach by themselves if the content
+returns"* describes exactly what happens. Under explicit save, Undo-before-save is discarding a
+draft — a second and different mechanism wearing the same word.
+
+**Two costs, stated rather than glossed.** **There is no discard**: an explicit-save editor lets you
+experiment and back out, and this one does not; the way back is §5's Undo or retyping. This is
+consistent with a design that has no undo stack anywhere, but it is a real loss. And **intermediate
+states are syncable** — a field mid-edit can publish. Blur-or-idle rather than per-keystroke keeps it
+rare, ADR-0015 §6's foreground-only triggers keep it rarer, and the counter rule means a device is
+always ahead of what it published.
+
+### 8. Enter is inert everywhere, including the last field
+
+[ADR-0012 §7](0012-the-note-authoring-experience.md) fixed that Enter in a single-line field does
+nothing and keeps focus, and rejected field-to-field advancement because *"a note editor is not a
+wizard"*. **That rule is widened to the last field rather than carved out.** Under §7 above there is
+nothing to commit, so Enter-as-save has no referent; the only remaining meaning would be *"and now
+give me a fresh note"*, which is a navigation act rather than a text act.
+
+Two reasons it must not be bound to Enter:
+
+- **"The last field" is a property of the kind definition, which is *data*.** Binding a key's meaning
+  to which field comes last means **a kind gaining a field silently changes what Enter does** — a
+  behaviour change with no code change and nothing failing. Worse,
+  [ADR-0008 §7](0008-the-deck-export-format.md) lets a note carry an **acquired** kind from a
+  stranger's file, so "the last field" could be decided by someone else's deck.
+- **The rule could not be uniform anyway.** `cloze`'s text field is multiline, where Enter must
+  insert a newline. So *"Enter on the last field commits"* is already carved out for one of four
+  kinds, and the carve-out is invisible: the user presses Enter in the last field of two notes and
+  gets two behaviours.
+
+**The rhythm is real and gets its own answer.** An author entering two hundred vocabulary notes wants
+type-type-next without reaching for the mouse. So the editor carries a **New note** action that
+**carries the current kind and deck forward** — under autosave, that is all "save and add another"
+ever meant — with **one desktop keyboard accelerator** bound to a modifier chord, never bare Enter,
+so it can never collide with a field's own Enter, multiline included.
+
+The accelerator is admitted deliberately, against
+[ADR-0006 §5](0006-the-review-session-experience.md)'s note that a keyboard vocabulary was *"not
+requested; additive if wanted"*. Bulk authoring is the case §3's ordering work exists to serve, and it
+would be incoherent to specify an authored sequence while making it painful to enter one. That it is
+the app's first shortcut is recorded so that a later table of them is a decision someone takes
+knowingly.
+
+### 9. Decks are created where they are filtered, and assigned where the note is written
+
+Neither source ADR owns this. [ADR-0005 §8](0005-the-deck-model.md) is explicit that **no deck is ever
+auto-created** — a built-in default would mint a different UUID per device and produce a guaranteed
+unmergeable duplicate the first time two never-synced devices meet — and ADR-0015 §7's empty state
+says *"create a deck"*, but no ADR says where. ADR-0012 specifies a **kind** dropdown and is silent on
+**deck**, so nothing said where a note's `deck` reference is set either.
+
+- **Deck creation and rename live on the note list, beside the deck filter** — where decks are already
+  visible as filter values, needing no new surface. Deletion stays what ADR-0005 §7 made it, a flag
+  deriving through to the notes, reachable from the same place.
+- **A note's deck is a dropdown in the editor, beside the kind dropdown, with *create a new deck*
+  available from it.** The moment you need a deck that does not exist is while filing the note that
+  wants it, and sending the user to another screen to make one is the friction that produces a
+  collection of unfiled notes. Nothing breaks if they decline: ADR-0005 §7 already makes a dangling or
+  absent reference legal, and such a note is unfiled and still reviewable.
+- **No bulk move.** Moving fifty notes to another deck is a build, not a decision, and no part of the
+  spec waits on it.
+
+### 10. What this ADR does *not* settle
+
+- **Appearance.** How the three destinations are rendered, how a list row looks, whether reordering is
+  a drag or a *move to…* action, and where the *New note* action sits. All of it is the visual design
+  pass, out of scope for the map since 2026-07-31.
+- **The soft-keyboard layout** — owned by
+  [Prototype: the authoring screen under a soft keyboard](https://github.com/amin-bf/leitner/issues/67).
+- **Import preview and export reporting** — owned by
+  [Decide: what an import preview states, and what export reports back](https://github.com/amin-bf/leitner/issues/68).
+  This ADR puts a surface behind ADR-0015 §7's *"import one"* verb; what that import *says* is not
+  its call.
+
+## Amendments to accepted ADRs
+
+| ADR | What changes | Why |
+|---|---|---|
+| [ADR-0011 §7](0011-new-card-rate-and-daily-limits.md) | **`position` is an order key with infill, not "a plain integer".** Creation assigns a key after the current last; import assigns keys in `notes.jsonl` line order; ties still break by note id. *"Need not be dense or globally unique"* becomes true and load-bearing rather than decorative. | §3: the high-water counter and the line index both produce dense values, so "insert between" was never expressible, and every renumbering alternative scrambles order across devices with nothing reporting it. |
+| [ADR-0011 §7](0011-new-card-rate-and-daily-limits.md) | *"Whether the user can reorder notes is that ticket's call"* is **discharged**: they can. | §3 and §4. |
+| [ADR-0002 §6](0002-the-card-model.md) | Transitively — the `position` ADR-0011 §7 added to the note changes type. Nothing else in §6 moves; note ids stay random UUIDv4. | Same as above. |
+| [ADR-0012 §7](0012-the-note-authoring-experience.md) | The Enter rule is **widened** to the last field: Enter is inert in every single-line field without exception, and the *New note* rhythm is an action with a modifier-chord accelerator. | §8: binding Enter to "the last field" makes a kind definition's field count change a key's behaviour silently, and an acquired kind puts that in a stranger's hands. |
+| [ADR-0012 §9](0012-the-note-authoring-experience.md) | Two of the four unsettled items are **closed** — saving semantics (§7), and editing mid-review plus where authoring is entered from (§5, §6). | This ADR. |
+| [ADR-0012 §2](0012-the-note-authoring-experience.md) | The editor gains a **deck** dropdown beside the kind dropdown, with deck creation available from it. | §9: no ADR said where a note's `deck` reference is set. |
+| [ADR-0006 §3 and §4](0006-the-review-session-experience.md) | **Reveal has a second cause**: entering the editor from the review screen counts as a reveal. Tap-the-card is unchanged as the ordinary one. | §6: the editor shows the back, so without this §4's *"self-grading can't happen before the answer is seen"* is quietly false. |
+| [ADR-0006 §5](0006-the-review-session-experience.md) | *"Keyboard-only grading: not requested; additive if wanted"* is amended by the app acquiring **one** shortcut, in the editor and not in review. | §8. |
+| [ADR-0008 §12](0008-the-deck-export-format.md) | **Touched but unchanged, recorded so nobody re-derives it.** Emission stays `(position, note id)` and stays byte-for-byte deterministic; the file carries line order rather than the value, so §3's type change reaches no byte of the format. | §3. |
+
+**Confirmed rather than amended**, because each already assumed what this ADR now supplies:
+[ADR-0010 §7](0010-leeches.md)'s *"edit … already exists"* — it does now; ADR-0015 §7's empty-state
+copy — all three verbs have surfaces; [ADR-0005 §8](0005-the-deck-model.md)'s *no deck is ever
+auto-created* — §9 gives creation a home without giving it a default.
+
+## Glossary
+
+New terms are of record in the `CONTEXT.md` files, per
+[ADR-0009 §6](0009-crate-and-workspace-layout.md): **note list**, **top-level destination** and
+**autosave** in [`ui`](../../crates/app/src/CONTEXT.md), which owns the screens; **position** is
+revised in [`content`](../../crates/core/src/content/CONTEXT.md), which owns the value.
+
+## Consequences
+
+- **The application now has a navigation shell, which it did not before.** Three destinations is the
+  floor, not a design; every screen already specified hangs off one of them.
+- **Reordering costs exactly one write, and that is the property to protect.** Any future change that
+  reintroduces a renumber — a "tidy up positions" action, a compaction pass, a migration that
+  redistributes keys — reopens the concurrency hazard §3 exists to close, and does so silently.
+- **The store gains a text scan, and it is allowed to be naive.** ADR-0007 §4's attribute table makes
+  substring search a scan of one column; `derived.db` is where an index goes if a collection ever
+  outgrows that, and losing it costs nothing by construction.
+- **The editor no longer holds unsaved state**, which removes the one place in the design where an
+  Android freeze could lose user work.
+- **There is no discard and no undo stack.** ADR-0012 §5's Undo remains scoped to the dormancy
+  warning. A user who wants to experiment on a note has no sandbox, and this is accepted.
+- **A note's order and its deck are both editable from surfaces this ADR creates**, so both ride
+  ADR-0004 §7's mutable surface and both settle by counter-stamp like every other authored value.
+  Neither enters the log.
+
+## Open items handed onward
+
+| Item | Owner |
+|---|---|
+| Appearance of all three destinations, of a list row, of the reorder affordance, and of the *New note* action | **Out of scope** — *the visual design pass*, which [ADR-0006 §10](0006-the-review-session-experience.md) opened and ADR-0010, ADR-0012, ADR-0015, ADR-0017, ADR-0018 and ADR-0019 have joined |
+| The concrete order-key encoding (alphabet, growth bound) | Implementation, not a spec question — §3 fixes the property, and any encoding with it is conformant |
+| Whether one keyboard accelerator becomes a table of them | Post-implementation; §8 records the first one deliberately so the second is a decision rather than a drift |
+| Bulk operations on the note list (multi-select, bulk deck move) | **Out of scope** — a build, and nothing in the spec waits on it (§9) |


### PR DESCRIPTION
Resolves [#66](https://github.com/amin-bf/leitner/issues/66) on [the map](https://github.com/amin-bf/leitner/issues/1). Adds **ADR-0021**, amends five accepted ADRs, and gives `AGENTS.md` an *Authoring and the note list* section.

Three questions that reached the ticket by being **dropped rather than deferred** — two omitted from ADR-0012's *Open items* table despite its own §9 naming them, and one handed to that ticket by ADR-0011 §7 and never touched.

### What it decides

**Answering *where is authoring entered from* required a screen that does not exist.** No browse surface is specified anywhere in twenty ADRs — yet ADR-0010 §7 makes **edit** the primary leech action and says *"it already exists"*, while §8 argues against suspend-and-forget because it would leave content *"with no way back short of hunting through a browser"*, written as though none exists, because none did. So a **note list** is specified — its contract, not its appearance, the split ADR-0018 made and the map recorded as vindicated.

**`position` stops being a plain integer.** ADR-0011 §7's *"need not be dense or globally unique — only to sort"* is a permission **its own assignment rule never lets anyone exercise**: a high-water counter and a `notes.jsonl` line index both produce consecutive integers, so *"put this note between those two"* had no value to write. Every renumbering alternative is N writes on ADR-0004 §7's surface, and **order is a gestalt, so one lost value scrambles the whole list** — two devices reordering concurrently agree on neither order, and nothing reports it. `position` becomes an **order key with infill**, so a move writes exactly one value, forever. **Decided now because it is free now**, third time on this map.

**`.ldeck` is untouched** — the file carries line order rather than the value, so ADR-0008 §12 is *touched but unchanged* and says so, to stop anyone hunting for a format version bump.

**Saving is automatic, per field**, on ADR-0012 §5's own argument: making the destructive-edit warning ambient *"rather than a check at save time"* already spent the only decision a save could carry. A draft is also the one piece of state a kill can lose, and Android **freezes rather than slows**.

**A note is editable mid-review, and entering the editor counts as a reveal** — without which ADR-0006 §4's *"self-grading can't happen before the answer is seen"* is quietly false.

**Enter stays inert on the last field.** *"The last field"* is a property of the kind definition — which is **data**, and via ADR-0008 §7 possibly a **stranger's** data.

### Amendments

ADR-0011 §7, ADR-0012 (§2, §7, §9), ADR-0006 (§3, §5), ADR-0002 §6, and ADR-0008 §12 (touched but unchanged). Three more are **confirmed rather than amended**, each having already assumed what this supplies.

### Verification

`cargo test --workspace` passes; all relative links in the new and edited documents resolve; ADR number re-checked against `origin/main` immediately before committing (0020 was still the highest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)