### PR TITLE
Note Authoring / Settle the Authoring Screen Under a Soft Keyboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,22 @@ because they are validated findings, not because a web build ships.
     or killed run holds no partial state and the recovery action is to press the button again. Never
     schedule it, never take a wakelock, and never promise the user that a started job is still
     progressing. [ADR-0014 §3](./docs/adr/0014-when-parameter-optimisation-runs.md).
+11. **The soft keyboard is invisible to the app unless it asks, and the failure is unreachability,
+    not occlusion.** Rule 8's gap has a second half: winit's Android backend reports no **insets**
+    either, and the window is enforced edge-to-edge, so `adjustResize` is inert — nothing resizes and
+    nothing is reported. egui then sizes its `ScrollArea` to a viewport taller than the visible one,
+    the content fits, and there is **no scroll range**, so the covered band cannot be reached at all.
+    Measured on the handset: **923dp of usable height down to 565dp, 39% of the screen, silently**.
+    So the `ui` crate carries a one-function `platform` seam returning the IME and system-bar insets
+    (zero off Android) and reserves the band — a **third** per-crate seam under
+    [ADR-0016 §5](./docs/adr/0016-backup-and-restore.md), not a widening of `leitner-store`'s two.
+    **Two guards come with it and an implementation missing either visibly oscillates**: keep the
+    focused field inside the shrunken viewport **in the same frame it shrinks** — a `TextEdit`
+    publishes `output.ime` only while its rect is visible, `egui-winit` turns that absence into
+    `hide_soft_input`, which collapses the inset, which restores the viewport, which shows the field
+    again — and **surrender focus when a focused field is scrolled *completely* out of view**, which
+    is the same loop entered from the other end.
+    [ADR-0025 §1 §2 §3](./docs/adr/0025-the-authoring-screen-under-a-soft-keyboard.md).
 
 ## The local store
 

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -101,7 +101,7 @@ Read the ADR sections in your row. Read the whole ADR only if you are changing t
 | `store` | [0007](./docs/adr/0007-the-local-store.md) | 0004 §11, 0003 §5, 0013 §9, 0016 §3, 0016 §7, 0019 §6, 0020 §3, 0020 §4 |
 | `export` | [0008](./docs/adr/0008-the-deck-export-format.md), [0016](./docs/adr/0016-backup-and-restore.md), [0022](./docs/adr/0022-the-import-preview-and-export-report.md), [0023](./docs/adr/0023-sending-a-written-file.md), [0024](./docs/adr/0024-identifying-a-written-file.md) | 0005, 0002 §9, 0004 §11, 0011 §7, 0020 §4, 0021 §3 |
 | `sync` | [0013](./docs/adr/0013-the-sync-transport.md) | 0004 §2, 0004 §7, 0004 §10, 0007, 0014 §7, 0015 §2, 0015 §4, 0016 §10, 0019 §4, 0019 §6, 0020 §5, 0020 §6, 0020 §7 |
-| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md), [0010](./docs/adr/0010-leeches.md), [0011](./docs/adr/0011-new-card-rate-and-daily-limits.md), [0012](./docs/adr/0012-the-note-authoring-experience.md), [0014](./docs/adr/0014-when-parameter-optimisation-runs.md), [0015](./docs/adr/0015-the-sync-experience.md), [0018](./docs/adr/0018-the-card-pane-ordering.md), [0019](./docs/adr/0019-naming-the-account-at-enrolment.md), [0021](./docs/adr/0021-note-ordering-saving-and-the-note-list.md), [0022](./docs/adr/0022-the-import-preview-and-export-report.md) | 0002 §4, 0016 §6, 0016 §11, 0016 §12, 0017 §5, 0017 §6, 0020 §7, 0023 §5, 0023 §6, 0024 §3 |
+| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md), [0010](./docs/adr/0010-leeches.md), [0011](./docs/adr/0011-new-card-rate-and-daily-limits.md), [0012](./docs/adr/0012-the-note-authoring-experience.md), [0014](./docs/adr/0014-when-parameter-optimisation-runs.md), [0015](./docs/adr/0015-the-sync-experience.md), [0018](./docs/adr/0018-the-card-pane-ordering.md), [0019](./docs/adr/0019-naming-the-account-at-enrolment.md), [0021](./docs/adr/0021-note-ordering-saving-and-the-note-list.md), [0022](./docs/adr/0022-the-import-preview-and-export-report.md), [0025](./docs/adr/0025-the-authoring-screen-under-a-soft-keyboard.md) | 0002 §4, 0016 §5, 0016 §6, 0016 §11, 0016 §12, 0017 §5, 0017 §6, 0020 §7, 0023 §5, 0023 §6, 0024 §3 |
 | *the workspace itself* | [0009](./docs/adr/0009-crate-and-workspace-layout.md) | 0013 §11, 0013 §12, 0015 §15, 0016 §5 |
 
 **`replay` having no ADR of its own is why it is a context.** Its rules were each written for another
@@ -119,6 +119,15 @@ mechanism — the **gate/describe** two-stage read, and the rule that an import 
 every read, never cached*. Its `ui` half is what four surfaces say: the import preview, the export
 screen, the export report and the file list. Change either half without the other and the surfaces
 state numbers the mechanism cannot produce.
+
+**[0025](./docs/adr/0025-the-authoring-screen-under-a-soft-keyboard.md) is the only ADR about a
+surface the app cannot see.** On Android nothing below the app reports the soft keyboard — the window
+is enforced edge-to-edge, so the old resize mode is inert, and winit reports no insets — so the UI
+layer is handed a viewport taller than the visible one. Read it before touching any screen with a text
+field: the cost is not occlusion but **unreachability**, since the scroll area sizes itself to the
+viewport it was given and the covered band has no scroll range. It also carries the two guards without
+which the keyboard oscillates, and it is why [0012 §5](./docs/adr/0012-the-note-authoring-experience.md)'s
+destructive-edit warning sits *above* the fields rather than after the last one.
 
 **[0024](./docs/adr/0024-identifying-a-written-file.md) is an Android-only correction, and it amends
 four accepted ADRs rather than deciding much of its own.** Read it before touching anything that

--- a/crates/app/src/CONTEXT.md
+++ b/crates/app/src/CONTEXT.md
@@ -8,9 +8,11 @@ through, and both platform entry points.
 [ADR-0010](../../../docs/adr/0010-leeches.md) and
 [ADR-0011](../../../docs/adr/0011-new-card-rate-and-daily-limits.md), the last of which **amends
 ADR-0006 §1 and §2** — read those amendments before touching the session;
-[ADR-0012](../../../docs/adr/0012-the-note-authoring-experience.md) and
-[ADR-0018](../../../docs/adr/0018-the-card-pane-ordering.md), the second of which **amends ADR-0012 §1
-and §5** — read those amendments before touching the authoring pane; also by
+[ADR-0012](../../../docs/adr/0012-the-note-authoring-experience.md),
+[ADR-0018](../../../docs/adr/0018-the-card-pane-ordering.md) and
+[ADR-0025](../../../docs/adr/0025-the-authoring-screen-under-a-soft-keyboard.md), the second of which
+**amends ADR-0012 §1 and §5** and the third of which **moves §5's warning above the fields and adds
+the inset seam** — read those amendments before touching the authoring pane; also by
 [ADR-0002 §4](../../../docs/adr/0002-the-card-model.md) (layout is data, stored once per kind) and
 [ADR-0015](../../../docs/adr/0015-the-sync-experience.md) and
 [ADR-0019](../../../docs/adr/0019-naming-the-account-at-enrolment.md) (everything the user sees about
@@ -109,12 +111,17 @@ when neither resolves — shown, never hidden**, since an omission is the header
 round 1 (ADR-0018 §3). The history reads *kept*, never *lost*.
 _Avoid_: Dormant card *for the on-screen row* — the card is the domain object, the entry is its line.
 
-**The card pane demonstrates; the form pane warns**:
+**The card pane demonstrates; the form pane warns — and the warning sits *above* the fields**:
 Ordinal position **cannot** guarantee a dormant entry is on screen — blank 18 of 20 lands below the
 fold on desktop too — so ADR-0012 §5's form-pane warning is **primary on both platforms**, not
 redundancy for the phone (ADR-0018 §4). Never add a third speaker: a pinned header indicator is the
 counter that failed, and auto-scrolling to a newly-dormant entry needs a before-state that dormancy's
 per-frame recomputation does not have.
+**Its position is above the fields, not after the last one** (ADR-0025 §4): under a soft keyboard only
+the form pane's *first screen* is on show, and a warning after the last field leaves just the
+`· 1 dormant` marker visible at the moment of the edit — which is the counter ADR-0018 §4 established
+does not warn. Moving it adds no speaker; it is the same warning, placed where it can be read.
+Reserving the IME band makes it *reachable*, which is not the same as *visible*.
 
 **Last caught up**:
 The only resting statement the app makes about sync — *when* it last completed one, a fact.
@@ -204,6 +211,16 @@ grant, and ADR-0004 §8's clock-skew warning. A network failure never speaks —
 - **Only two things may speak about sync**, and every future feature will have a reason to want a
   third. A badge, a toast on success, a "syncing…" indicator in the chrome — each is a defect
   against ADR-0015 §4, not a UX improvement.
+- **The soft keyboard is invisible unless this crate asks**, and the failure is *unreachability*, not
+  occlusion. Nothing below us reports the IME inset — rule 8's gap has a second half — and the window
+  is edge-to-edge, so `adjustResize` does nothing. egui then sizes its `ScrollArea` to a viewport
+  taller than the visible one, the content fits, and there is **no scroll range** over the covered
+  39%. This crate's one-function `platform` seam returns the insets and the band is reserved. **Two
+  guards are load-bearing**: keep the focused field inside the shrunken viewport *in the same frame it
+  shrinks* (a `TextEdit` publishes `output.ime` only while visible; `egui-winit` turns its absence
+  into `hide_soft_input`, which collapses the inset, which restores the viewport — a closed loop that
+  presents as a flickering keyboard), and **surrender focus when a focused field is scrolled fully out
+  of view** (the same loop from the other end). ADR-0025 §1–§3.
 - **Verify on the real handset.** The emulator is x86_64; the Pixel 8 Pro is arm64-v8a only.
 
 ## Why this crate has no `main.rs`

--- a/docs/adr/0003-client-stack.md
+++ b/docs/adr/0003-client-stack.md
@@ -172,6 +172,15 @@ repeats the experiment.
 discarding whatever it composes. GameActivity implements IME correctly underneath; winit never reads
 it. Verified on the handset: Persian still could not be typed.
 
+> **Second half recorded by [ADR-0025 §1](0025-the-authoring-screen-under-a-soft-keyboard.md).** The
+> gap above costs **composed text**, which is what this section measured. It also costs the
+> **insets**: the backend reports the keyboard's height to nobody, so the app is never told the
+> keyboard is there. On a window enforced edge-to-edge the old resize soft-input mode is inert too, so
+> nothing resizes and nothing is reported. The cost is not occlusion but **unreachability** — the UI
+> layer sizes its scroll area to a viewport taller than the visible one, so the covered band has no
+> scroll range at all: **39% of the screen, silently**. The client therefore reads the insets from the
+> platform itself, through a second per-crate seam in the UI crate.
+
 | | NativeActivity | GameActivity (tested) |
 |---|---|---|
 | Non-Latin text input | ❌ | ❌ **still broken** |

--- a/docs/adr/0012-the-note-authoring-experience.md
+++ b/docs/adr/0012-the-note-authoring-experience.md
@@ -157,6 +157,15 @@ Three rules:
 > This also re-reads round 1. Its finding was recorded as *position is the mechanism*; what it showed
 > is that **a count is not a warning** — variant B carried two defects at once, a counter in the header
 > *and* the card below the fold, and the repair was credited to position alone.
+>
+> **Position corrected by [ADR-0025 §4](0025-the-authoring-screen-under-a-soft-keyboard.md): the
+> warning sits *above* the fields.** After the last field it does not survive a soft keyboard — with
+> the keyboard up, the only thing on screen at the moment of a destructive edit is the `· 1 dormant`
+> marker on the pane toggle, which is the counter ADR-0018 §4 established does not warn. That section's
+> ground, *the form pane is the one always on screen*, is narrowed rather than overturned: on a handset
+> only the form pane's **first screen** is, so its own argument against position applies to the form
+> pane too, one level up. Reading the platform's IME insets makes the warning reachable by scrolling
+> and **not** visible at the moment of the edit, so insets are necessary and not sufficient.
 - **It offers Undo**, and the copy says what is true: nothing is deleted, the reviews stay in the
   log, and they reattach by themselves if the content returns.
 
@@ -300,7 +309,9 @@ one-frame deferral to a second reason.
   `Pronunciation` field, which requires a face with IPA coverage.
 
 *(§1 and §5 are in turn amended by [ADR-0018](0018-the-card-pane-ordering.md) — a dormant entry is a
-line rather than a card, and the form-pane warning is primary on both platforms. Both amendments are
+line rather than a card, and the form-pane warning is primary on both platforms — and §5 again by
+[ADR-0025 §4](0025-the-authoring-screen-under-a-soft-keyboard.md), which moves that warning **above the
+fields** because after the last one it is off-screen under a soft keyboard. All three amendments are
 recorded inline above.)*
 
 *(§2, §7 and §9 are amended by [ADR-0021](0021-note-ordering-saving-and-the-note-list.md) — the
@@ -325,8 +336,12 @@ items close. All three are recorded inline above.)*
 
 - ~~**`CardRef` and the kind discriminator** (§6)~~ — **discharged by
   [ADR-0017](0017-card-slots.md)**: no discriminator, and the ordinal becomes an assigned slot instead.
-- **A soft-keyboard pass on the handset** (§9) — the one question desktop cannot answer. Now owned by
-  [Prototype: the authoring screen under a soft keyboard](https://github.com/amin-bf/leitner/issues/67).
+- ~~**A soft-keyboard pass on the handset** (§9)~~ — **discharged by
+  [ADR-0025](0025-the-authoring-screen-under-a-soft-keyboard.md)**: the split view survives (width was
+  never the risk — both panes fit on the handset), the client reads the platform's IME insets itself
+  because nothing below it reports them, and **§5's warning moves above the fields**. The pass also
+  found that the app is not merely occluded by the keyboard but loses **39% of its height with no
+  scroll range over the covered band**.
 - ~~**Saving semantics** (§9)~~ — **discharged by
   [ADR-0021 §7 and §8](0021-note-ordering-saving-and-the-note-list.md)**: autosave, per field, on blur
   or a short idle, with a new note committed on its first non-empty field; and Enter stays inert in

--- a/docs/adr/0018-the-card-pane-ordering.md
+++ b/docs/adr/0018-the-card-pane-ordering.md
@@ -173,6 +173,20 @@ the card below the fold — and the ADR credited the repair to position alone.
 The card-pane entry keeps the job §1 gives it, which is **demonstration**: it shows *which* card and
 *how much* history, in the place the pane already puts that card.
 
+> **Narrowed by [ADR-0025 §4](0025-the-authoring-screen-under-a-soft-keyboard.md); the conclusion is
+> unchanged.** *"The only warning that is always visible"* is true of the form pane on a desktop and of
+> **the form pane's first screen** on a handset: a soft keyboard takes 39% of the display, and the
+> warning specified after the last field is not in that first screen. What is left on screen at the
+> moment of a destructive edit is the `· 1 dormant` marker on the pane toggle — **the counter this
+> section established does not warn**, arriving from the opposite direction, because the keyboard
+> leaves only the counter standing rather than because a counter was chosen.
+>
+> So this section's own argument applies to the form pane one level up, and ADR-0025 moves the warning
+> **above the fields**. Nothing here is overturned: the form pane still warns, the card pane still
+> demonstrates, and there are still exactly two speakers. Note also that reading the platform's IME
+> insets makes the warning *reachable* and not *visible* — the two are different, and only the second
+> is what this section requires.
+
 Rejected: **a pinned indicator in the card pane's header.** It is the counter that failed, and it would
 be a third thing speaking about one edit.
 

--- a/docs/adr/0021-note-ordering-saving-and-the-note-list.md
+++ b/docs/adr/0021-note-ordering-saving-and-the-note-list.md
@@ -328,8 +328,12 @@ says *"create a deck"*, but no ADR says where. ADR-0012 specifies a **kind** dro
 - **Appearance.** How the three destinations are rendered, how a list row looks, whether reordering is
   a drag or a *move to…* action, and where the *New note* action sits. All of it is the visual design
   pass, out of scope for the map since 2026-07-31.
-- **The soft-keyboard layout** — owned by
-  [Prototype: the authoring screen under a soft keyboard](https://github.com/amin-bf/leitner/issues/67).
+- ~~**The soft-keyboard layout**~~ — **settled by
+  [ADR-0025](0025-the-authoring-screen-under-a-soft-keyboard.md)**: the split view survives, the client
+  reads the platform's IME insets itself, and ADR-0012 §5's warning moves above the fields. §7's
+  autosave and §8's *New note* are what make that layout judgeable — there is no Save button competing
+  for the bottom of the screen, and *New note* is the only control there that a phone cannot reach by
+  accelerator.
 - **Import preview and export reporting** — owned by
   [Decide: what an import preview states, and what export reports back](https://github.com/amin-bf/leitner/issues/68).
   This ADR puts a surface behind ADR-0015 §7's *"import one"* verb; what that import *says* is not

--- a/docs/adr/0025-the-authoring-screen-under-a-soft-keyboard.md
+++ b/docs/adr/0025-the-authoring-screen-under-a-soft-keyboard.md
@@ -1,0 +1,181 @@
+# ADR-0025: The authoring screen under a soft keyboard
+
+- **Status**: Accepted
+- **Date**: 2026-08-01
+- **Resolves**: [Prototype: the authoring screen under a soft keyboard](https://github.com/amin-bf/leitner/issues/67)
+- **Map**: [Map: local-first Leitner app spec](https://github.com/amin-bf/leitner/issues/1)
+- **Related**: [ADR-0003 §6](0003-client-stack.md) (the client stack, and what winit's Android
+  backend does not do), [ADR-0012 §1 §5 §9](0012-the-note-authoring-experience.md) (the two panes, the
+  ambient destructive-edit warning, the handoff this ADR discharges),
+  [ADR-0018 §2 §4](0018-the-card-pane-ordering.md) (a dormant entry is a line; the form-pane warning is
+  primary on both platforms), [ADR-0021 §7 §8 §9](0021-note-ordering-saving-and-the-note-list.md)
+  (autosave, *New note*, the deck dropdown — all of which land on this surface),
+  [ADR-0016 §5](0016-backup-and-restore.md) (the per-crate platform-seam rule this ADR adds a third seam under)
+
+## Context
+
+[ADR-0012 §9](0012-the-note-authoring-experience.md) recorded that its prototype *"fakes the width but
+not a keyboard taking half the screen, which is what decides whether a live preview survives while
+typing"*, and handed the question on. [ADR-0021 §10](0021-note-ordering-saving-and-the-note-list.md)
+handed it on again untouched. Everything about the authoring screen had therefore been judged on a
+desktop.
+
+Two things specified in the meantime were at stake and are re-judged here rather than assumed:
+§5's ambient destructive-edit warning, which [ADR-0018 §4](0018-the-card-pane-ordering.md) made
+**primary on both platforms** rather than a concession to the phone; and §3's numbered blank list,
+which is read while typing into the field above it.
+
+Answered on the Pixel 8 Pro, per [`AGENTS.md`](../../AGENTS.md) client-stack rule 9. Evidence:
+tag `prototypes/issue-67`.
+
+## Decision
+
+### 1. The client reads the platform's IME insets, because nothing below it does
+
+**The app is never told the soft keyboard exists.** Measured with the keyboard up: the window frame
+stays at the full display, and the platform reports the keyboard's height only to something that asks.
+The window carries the resize soft-input mode, which is inert — the same window is enforced
+edge-to-edge, and an edge-to-edge window is expected to read the inset and lay itself out rather than
+be resized under it.
+
+[ADR-0003 §6](0003-client-stack.md) and client-stack rule 8 already record that winit's Android
+backend handles only motion and key events and has no IME path, and draw the consequence for **composed
+text**. This is the same gap's other half, and it had not been written down: the backend reports no
+**insets** either. Raising the keyboard works — the "allow IME" call reaches the platform's
+show-soft-input — and nothing comes back.
+
+**So the client asks the platform directly**, reading the IME and system-bar insets from the activity's
+window each frame.
+
+**The consequence of not asking is worse than occlusion, which is why this is a decision and not a
+polish item.** The UI layer is handed a viewport taller than the one the user can see; the content fits
+inside it; so the scroll area has **no scroll range at all** and the covered region is **unreachable
+rather than scrolled off**. Measured at this device's density, typing costs **923dp of usable height
+down to 565dp — 39% of the screen — with no notification, no reflow, and nothing to scroll.**
+
+Reading the insets also fixes, for free, a defect this pass found on the way: the app currently draws
+its first line of text under the status bar and its last under the gesture bar, keyboard or no
+keyboard.
+
+### 2. Where the seam lives, and why it is not the store's
+
+[ADR-0016 §5](0016-backup-and-restore.md) settled that the platform-seam rule is **per crate** rather
+than per workspace, keeping `leitner-store::platform` at exactly two functions and giving
+`leitner-export` its own. This is a **third** such module, in the **UI crate**, and it
+belongs there: an inset is a fact about the window the UI is drawing into, and routing it through the
+store would make the store answer a question about layout.
+
+It is bound by the same discipline: **one function, returning the insets, with a non-Android
+implementation that returns zero** — not a family of window queries that grows a helper per platform
+question. The compile-time storage seam of client-stack rule 3 is unaffected.
+
+### 3. Two guards, without which the keyboard oscillates
+
+Both were found by driving the prototype, both are behavioural rather than incidental, and an
+implementation missing either is visibly broken. They are specified here because "read the insets and
+shrink the viewport" is *not* a sufficient instruction.
+
+- **The focused field must be kept inside the shrunken viewport, in the same frame the viewport
+  shrinks.** The text widget publishes its IME output only while its rect is visible, and the layer
+  below turns the *absence* of that output into hide-the-keyboard. So reserving the band clips the
+  focused field, which hides the keyboard, which collapses the inset, which restores the viewport,
+  which shows the field, which raises the keyboard — a closed loop, and on the handset a continuously
+  flickering keyboard. Requesting a scroll is not enough: it lands a frame later, and one frame without
+  the output is one hide.
+- **A focused field the user scrolls *completely* out of view surrenders focus.** The same loop runs
+  from the other end when the field leaves the viewport by scrolling. Dragging it back is wrong,
+  because scrolling away is deliberate; surrendering focus makes the state consistent — no focus, no
+  IME output, no keyboard, nothing to oscillate between. **Completely**, not merely clipped: a field
+  half off the edge is still being typed into.
+
+### 4. The destructive-edit warning moves above the fields
+
+[ADR-0012 §5](0012-the-note-authoring-experience.md) puts the ambient warning in the form pane and
+[ADR-0018 §4](0018-the-card-pane-ordering.md) makes it **primary on both platforms**. Its position —
+after the last field — does not survive a soft keyboard, and the failure is exactly the one ADR-0018 §4
+diagnosed.
+
+**With the keyboard up, the only thing on screen at the moment of a destructive edit is a counter.**
+Staged on the handset: a `basic + reverse` note switched to `basic`, one card dormant, front field
+focused. Visible: the `· 1 dormant` marker on the pane toggle. Not visible: the warning, its copy, and
+Undo.
+
+ADR-0018 §4 re-read round 1 of the authoring prototype and concluded that **a count is not a warning**
+— that the earlier variant carried two defects at once and the repair had been wrongly credited to
+position alone. The handset reproduces that failure from the opposite direction: not because a counter
+was chosen over a warning, but because the keyboard leaves only the counter standing.
+
+**Reading the insets does not fix this**, and the distinction matters. Reserving the band makes the
+warning *reachable* by scrolling; it does not make it *visible at the moment of the edit*. Insets are
+necessary and not sufficient.
+
+**And ADR-0018 §4's own argument already predicted it.** It rejected position as the mechanism because
+*"ordinal position cannot guarantee the card-pane entry is on screen — blank 18 of 20 lands below the
+fold on desktop too"*, and moved the warning to the form pane on the ground that the form pane is **the
+one always on screen**. With a keyboard up, the form pane is not always on screen either; only its
+first ~565dp is. The argument survives intact and the *position* it chose does not.
+
+**So the warning sits above the fields**, where the form pane's first screen is the part that is
+always visible. §4's reasoning is unchanged and its conclusion — the form pane warns, the card pane
+demonstrates — is unchanged; only where in the form pane is corrected.
+
+**This is not the pinned header indicator ADR-0018 §4 forbids**, and the difference is stated rather
+than assumed. What that section rules out is a **counter** in a fixed header, on the ground that a
+count does not warn. This is the warning itself — the sentence naming the card, its history and Undo —
+placed where it can be read. A third speaker is still forbidden, and moving the warning adds none:
+there are still exactly two, the form pane's warning and the card pane's entry.
+
+### 5. The split view survives, and width was never the risk
+
+At this handset's width both panes fit and read without prompting, so
+[ADR-0012 §1](0012-the-note-authoring-experience.md)'s `Write | Cards` toggle stands on its own merits
+rather than on necessity, and [ADR-0002 §8](0002-the-card-model.md)'s *"preview beside the input"* is
+serialised rather than dropped exactly as §1 claimed. **The failure is vertical, and no width rule
+addresses it** — which is why the toggle was never the thing to re-judge and the form pane's ordering
+was.
+
+### 6. What this ADR does *not* settle
+
+- **The per-tap keyboard re-pop.** As shipped, text entry on this platform dismisses and reopens the
+  soft keyboard on **every tap** into a text field, including a tap on the field that already has
+  focus, because the UI layer interrupts IME composition on every pointer interaction and the layer
+  below implements that interruption as hide-then-show. It is independent of everything above — it
+  reproduces with inset handling switched off, and it is not a layout question. Owned by
+  [Decide: whether we carry a patched `egui-winit`](https://github.com/amin-bf/leitner/issues/75).
+- **Visual design**, unchanged from [ADR-0012 §9](0012-the-note-authoring-experience.md) and out of
+  scope for the map. Where the warning sits is behaviour; what it looks like is not.
+- **Non-Latin authoring on the handset**, which client-stack rule 8 forecloses and this ADR does not
+  reopen. The pass was judged with Latin content, as that rule requires.
+
+## Amendments to accepted ADRs
+
+| ADR | What changes | Why |
+|---|---|---|
+| [0012 §5](0012-the-note-authoring-experience.md) | The form-pane warning sits **above the fields**, not after the last one. | §4 above: after the last field it is off-screen under a keyboard, and what remains is a counter. |
+| [0018 §4](0018-the-card-pane-ordering.md) | Its ground — *the form pane is the one always on screen* — is **narrowed**: on a handset with the keyboard up, only the form pane's first screen is. Its conclusion is unchanged. | §4 above. The section's own argument against position applies to the form pane too, one level up. |
+| [0003 §6](0003-client-stack.md) | The record of what winit's Android backend does not do gains its second half: **no IME insets**, not only no composed text. | §1 above. The first half was recorded; the second cost 39% of the screen silently. |
+| [0016 §5](0016-backup-and-restore.md) | The per-crate platform-seam rule gains a **third** module under it, in the UI crate, held to one function. | §2 above. Recorded so the rule is seen to be applied rather than bypassed, and so [ADR-0009 §4](0009-crate-and-workspace-layout.md)'s erosion signal keeps meaning what it says. |
+
+## Consequences
+
+- **The editor is the first surface that must know about insets, and it will not be the last.** Every
+  screen with a text field inherits §3's two guards. They are written as rules rather than as editor
+  details for that reason.
+- **A viewport that matches what the user can see is now load-bearing for reachability, not comfort.**
+  Without it there is no scroll range over the covered band, so "it is below the fold" and "it does not
+  exist" are the same thing.
+- **The form pane's first screen is now a specified resource.** Two things claim it — the warning, and
+  the field being typed into — and anything added to the top of that pane later is competing with a
+  warning that was moved there because nowhere else works.
+- **The handset can now be used to judge a layout, which it could not before.** The prototype's inset
+  read and guards are what make the surface stable enough to react to; the two keyboard defects had to
+  be diagnosed before the layout question could be answered at all.
+
+## Open items handed onward
+
+- **The per-tap keyboard re-pop** (§6) — owned by
+  [Decide: whether we carry a patched `egui-winit`](https://github.com/amin-bf/leitner/issues/75).
+  Until it is settled, an implementation of this ADR is correct and still visibly flickers on each tap.
+- **What the moved warning looks like** — the visual design pass's, on the same terms
+  [ADR-0018](0018-the-card-pane-ordering.md) left for a dormant line: what it says and where it sits are
+  settled here, only how it looks is not.


### PR DESCRIPTION
Resolves [#67](https://github.com/amin-bf/leitner/issues/67), the last question
[ADR-0012 §9](https://github.com/amin-bf/leitner/blob/main/docs/adr/0012-the-note-authoring-experience.md)
handed on and [ADR-0021 §10](https://github.com/amin-bf/leitner/blob/main/docs/adr/0021-note-ordering-saving-and-the-note-list.md)
handed on again. Everything about the authoring screen had been judged on a desktop.

Judged live on the Pixel 8 Pro. Evidence: tag `prototypes/issue-67`.

## The app is never told the keyboard exists

The window is `EDGE_TO_EDGE_ENFORCED`, so the resize soft-input mode is inert, and winit reports no
insets — the other half of the gap ADR-0003 §6 recorded for *composed text*. Measured: `mInputShown=true`
while the frame stays `[0,0][1344,2992]`, `mImeHeight=1145`.

**The consequence is unreachability, not occlusion.** egui sizes its `ScrollArea` to a viewport
1145px taller than the visible one, the content fits, so there is **no scroll range** over the covered
band — verified by swiping, which produced a byte-identical frame. Typing costs **923dp → 565dp, 39% of
the screen, silently**.

## What was decided

1. **The client reads the platform's IME insets itself** and reserves the band. Third per-crate
   `platform` module under ADR-0016 §5, in the `ui` crate — not a widening of `leitner-store`'s two
   functions. Also stops the app drawing under the status and gesture bars, which it does today.
2. **Two guards are part of the decision**, because "read the insets and shrink the viewport" is not a
   sufficient instruction — without either, the keyboard oscillates on the handset.
3. **ADR-0012 §5's destructive-edit warning moves above the fields.** With the keyboard up the only
   thing on screen at the moment of a destructive edit is `· 1 dormant` — a **counter**, which is
   exactly what ADR-0018 §4 concluded does not warn. Insets make the warning *reachable*, not
   *visible*. ADR-0018 §4's ground — *the form pane is the one always on screen* — is **narrowed**, not
   overturned: on a handset only its first screen is, so its own argument against position applies one
   level up. Still exactly two speakers.
4. **The split view survives, and width was never the risk.** Both panes fit at handset width; the
   failure is vertical and no width rule addresses it.

## Not in this PR

The per-tap keyboard re-pop — as shipped, text entry on Android dismisses and reopens the keyboard on
**every tap**, including on the already-focused field. Independent of insets and of layout, measured at
6 hides / 17 shows per three taps against 0 / 0 with the offending block disabled. Filed as
[#75](https://github.com/amin-bf/leitner/issues/75) with the prototype's evidence, including two wrong
fixes and why each failed.

## Contents

- `docs/adr/0025-…` — the ADR.
- Amendments to ADR-0003 §6, ADR-0012 §5, ADR-0018 §4, ADR-0021 §10.
- `AGENTS.md` client-stack **rule 11** (new rather than a sub-point of rule 8 — renumbering would
  invalidate the existing "rule 9"/"rule 10" references), `CONTEXT-MAP.md` index, `crates/app/src/CONTEXT.md`.

No code changes: the prototype is throwaway and stays on its branch and tag, per the prototype
convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
