### PR TITLE
Client Stack / Carry a Patched Windowing Adapter So Text Entry Stops Re-Popping the Keyboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,10 @@ because they are validated findings, not because a web build ships.
 3. **The storage seam is a compile-time `#[cfg]`.** Keep it that way. Never introduce a runtime
    platform check — the whole stack choice rests on wrong platform code failing the build. It is two
    functions in `leitner-store::platform`, and a **third function appearing there means the seam is
-   eroding**. A `#[cfg(target_os)]` anywhere else in the workspace is a defect.
+   eroding**. A `#[cfg(target_os)]` anywhere else in the workspace is a defect. **The vendored
+   dependency of rule 12 is outside this rule** — it is not a workspace member and it is not our code,
+   so the `#[cfg]` you will find there is correct. Said explicitly because a correct instance of a
+   construct used as a defect signal is how the signal quietly stops meaning anything.
 4. **Immediate mode has nowhere to `await`.** Spawn the future, store a handle, read the result on a
    later frame, and call `ctx.request_repaint()` on completion or the result sits unseen until the
    next input event.
@@ -197,7 +200,9 @@ because they are validated findings, not because a web build ships.
    only motion and key events — it has no IME path, so composed text never reaches the app. This is
    not the activity backend: GameActivity was tried and reverted (see
    [`prototypes/egui-slice/android/README.md`](https://github.com/amin-bf/leitner/blob/prototypes/issue-8/prototypes/egui-slice/android/README.md)). Never design a feature that requires typing non-Latin
-   text on Android.
+   text on Android. **This rule is also rule 12's tripwire**: the patch there is justified by the
+   absence of an IME path, so the day winit grows one, that patch becomes a bug and must be re-judged
+   rather than re-applied. Whoever retires this rule owns that.
 9. **Verify Android on the real handset.** The emulator is x86_64; the Pixel 8 Pro is arm64-v8a only.
    `cargo apk build` needs a **JDK on `PATH`** — `apksigner` is a `java` wrapper, and its absence
    surfaces only at the signing step, *after* a full NDK compile, as
@@ -219,15 +224,38 @@ because they are validated findings, not because a web build ships.
     the content fits, and there is **no scroll range**, so the covered band cannot be reached at all.
     Measured on the handset: **923dp of usable height down to 565dp, 39% of the screen, silently**.
     So the `ui` crate carries a one-function `platform` seam returning the IME and system-bar insets
-    (zero off Android) and reserves the band — a **third** per-crate seam under
+    and reserves the band — a **third** per-crate seam under
     [ADR-0016 §5](./docs/adr/0016-backup-and-restore.md), not a widening of `leitner-store`'s two.
-    **Two guards come with it and an implementation missing either visibly oscillates**: keep the
-    focused field inside the shrunken viewport **in the same frame it shrinks** — a `TextEdit`
+    **That seam's return type must distinguish "this platform has no soft keyboard" from "the keyboard
+    is down"** — collapsing both to zero, as ADR-0025 §2 first wrote it, makes every gate on "the
+    keyboard is down" permanently true off Android
+    ([ADR-0026 §5](./docs/adr/0026-the-per-tap-keyboard-re-pop.md)).
+    **Three guards come with all this and an implementation missing any of them is visibly broken**:
+    keep the focused field inside the shrunken viewport **in the same frame it shrinks** — a `TextEdit`
     publishes `output.ime` only while its rect is visible, `egui-winit` turns that absence into
     `hide_soft_input`, which collapses the inset, which restores the viewport, which shows the field
-    again — and **surrender focus when a focused field is scrolled *completely* out of view**, which
-    is the same loop entered from the other end.
-    [ADR-0025 §1 §2 §3](./docs/adr/0025-the-authoring-screen-under-a-soft-keyboard.md).
+    again — **surrender focus when a focused field is scrolled *completely* out of view**, which
+    is the same loop entered from the other end — and **raise the keyboard from a discrete press on a
+    text field** (rule 12), without which it never comes back after a manual dismiss.
+    [ADR-0025 §1 §2 §3](./docs/adr/0025-the-authoring-screen-under-a-soft-keyboard.md),
+    [ADR-0026 §4 §5](./docs/adr/0026-the-per-tap-keyboard-re-pop.md).
+12. **One dependency is vendored and patched, and a bump is not just a version change.** As published,
+    `egui`'s `TextEdit` calls `request_focus` on *every* pointer interaction with no `has_focus` check,
+    `request_focus` interrupts IME composition unconditionally, and `egui-winit` implements that
+    interruption as `set_ime_allowed(false)` then `(true)` — which winit's Android backend maps onto
+    `hide_soft_input`/`show_soft_input`. So **every tap into a text field dismisses and reopens the
+    keyboard**, measured at **6 hides / 17 shows for three taps on the already-focused field**, and the
+    inset collapse it causes throws away the scroll position that rule 11 exists to make meaningful.
+    It buys nothing here: rule 8's missing IME path means there is never a composition to interrupt.
+    **There is no fix above the dependency** — the interrupt flag is private, its setter is public and
+    its clearer is not, and nothing hooks the platform output before `egui-winit` reads it. So we carry
+    a **verbatim copy of the published crate** with that one block behind `#[cfg(not(target_os =
+    "android"))]`, wired by `[patch.crates-io]`, pinned exactly, verifiable by recursive diff against a
+    pristine copy. **The patch is bound to the block's shape, not its line number: if a release
+    restructures it, re-judge rather than re-apply** — a guard applied to a block that no longer means
+    the same thing looks healthy in a diff. Routine bumps need the diff and the shape check; the handset
+    measurement only when either is unhappy.
+    [ADR-0026](./docs/adr/0026-the-per-tap-keyboard-re-pop.md).
 
 ## The local store
 

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -101,7 +101,7 @@ Read the ADR sections in your row. Read the whole ADR only if you are changing t
 | `store` | [0007](./docs/adr/0007-the-local-store.md) | 0004 §11, 0003 §5, 0013 §9, 0016 §3, 0016 §7, 0019 §6, 0020 §3, 0020 §4 |
 | `export` | [0008](./docs/adr/0008-the-deck-export-format.md), [0016](./docs/adr/0016-backup-and-restore.md), [0022](./docs/adr/0022-the-import-preview-and-export-report.md), [0023](./docs/adr/0023-sending-a-written-file.md), [0024](./docs/adr/0024-identifying-a-written-file.md) | 0005, 0002 §9, 0004 §11, 0011 §7, 0020 §4, 0021 §3 |
 | `sync` | [0013](./docs/adr/0013-the-sync-transport.md) | 0004 §2, 0004 §7, 0004 §10, 0007, 0014 §7, 0015 §2, 0015 §4, 0016 §10, 0019 §4, 0019 §6, 0020 §5, 0020 §6, 0020 §7 |
-| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md), [0010](./docs/adr/0010-leeches.md), [0011](./docs/adr/0011-new-card-rate-and-daily-limits.md), [0012](./docs/adr/0012-the-note-authoring-experience.md), [0014](./docs/adr/0014-when-parameter-optimisation-runs.md), [0015](./docs/adr/0015-the-sync-experience.md), [0018](./docs/adr/0018-the-card-pane-ordering.md), [0019](./docs/adr/0019-naming-the-account-at-enrolment.md), [0021](./docs/adr/0021-note-ordering-saving-and-the-note-list.md), [0022](./docs/adr/0022-the-import-preview-and-export-report.md), [0025](./docs/adr/0025-the-authoring-screen-under-a-soft-keyboard.md) | 0002 §4, 0016 §5, 0016 §6, 0016 §11, 0016 §12, 0017 §5, 0017 §6, 0020 §7, 0023 §5, 0023 §6, 0024 §3 |
+| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md), [0010](./docs/adr/0010-leeches.md), [0011](./docs/adr/0011-new-card-rate-and-daily-limits.md), [0012](./docs/adr/0012-the-note-authoring-experience.md), [0014](./docs/adr/0014-when-parameter-optimisation-runs.md), [0015](./docs/adr/0015-the-sync-experience.md), [0018](./docs/adr/0018-the-card-pane-ordering.md), [0019](./docs/adr/0019-naming-the-account-at-enrolment.md), [0021](./docs/adr/0021-note-ordering-saving-and-the-note-list.md), [0022](./docs/adr/0022-the-import-preview-and-export-report.md), [0025](./docs/adr/0025-the-authoring-screen-under-a-soft-keyboard.md), [0026](./docs/adr/0026-the-per-tap-keyboard-re-pop.md) | 0002 §4, 0016 §5, 0016 §6, 0016 §11, 0016 §12, 0017 §5, 0017 §6, 0020 §7, 0023 §5, 0023 §6, 0024 §3 |
 | *the workspace itself* | [0009](./docs/adr/0009-crate-and-workspace-layout.md) | 0013 §11, 0013 §12, 0015 §15, 0016 §5 |
 
 **`replay` having no ADR of its own is why it is a context.** Its rules were each written for another
@@ -125,9 +125,20 @@ surface the app cannot see.** On Android nothing below the app reports the soft 
 is enforced edge-to-edge, so the old resize mode is inert, and winit reports no insets — so the UI
 layer is handed a viewport taller than the visible one. Read it before touching any screen with a text
 field: the cost is not occlusion but **unreachability**, since the scroll area sizes itself to the
-viewport it was given and the covered band has no scroll range. It also carries the two guards without
+viewport it was given and the covered band has no scroll range. It also carries the guards without
 which the keyboard oscillates, and it is why [0012 §5](./docs/adr/0012-the-note-authoring-experience.md)'s
-destructive-edit warning sits *above* the fields rather than after the last one.
+destructive-edit warning sits *above* the fields rather than after the last one. **Read
+[0026](./docs/adr/0026-the-per-tap-keyboard-re-pop.md) with it, never instead of it** — 0026 amends its
+seam return type and turns its two guards into three.
+
+**[0026](./docs/adr/0026-the-per-tap-keyboard-re-pop.md) is the only ADR about a dependency we do not
+take as published**, and it is why a bump of the client stack is not just a version change. As shipped,
+every tap into a text field on Android dismisses and reopens the soft keyboard, because the UI toolkit
+interrupts IME composition on any pointer interaction and the layer below implements that as
+hide-then-show — on a platform whose backend has no IME path, so there was never a composition to
+interrupt. No fix exists above the dependency: the interrupt flag has a public setter and no public
+clearer. Read it before bumping `egui`, before touching the shared text-field wrapper, and before
+assuming the inset seam reports zero off Android.
 
 **[0024](./docs/adr/0024-identifying-a-written-file.md) is an Android-only correction, and it amends
 four accepted ADRs rather than deciding much of its own.** Read it before touching anything that

--- a/crates/app/src/CONTEXT.md
+++ b/crates/app/src/CONTEXT.md
@@ -12,7 +12,10 @@ ADR-0006 §1 and §2** — read those amendments before touching the session;
 [ADR-0018](../../../docs/adr/0018-the-card-pane-ordering.md) and
 [ADR-0025](../../../docs/adr/0025-the-authoring-screen-under-a-soft-keyboard.md), the second of which
 **amends ADR-0012 §1 and §5** and the third of which **moves §5's warning above the fields and adds
-the inset seam** — read those amendments before touching the authoring pane; also by
+the inset seam** — read those amendments before touching the authoring pane; and
+[ADR-0026](../../../docs/adr/0026-the-per-tap-keyboard-re-pop.md), which **amends ADR-0025 §2 and §3**
+— the seam's return type, and a third guard — and puts the keyboard raise in the shared text-field
+wrapper; also by
 [ADR-0002 §4](../../../docs/adr/0002-the-card-model.md) (layout is data, stored once per kind) and
 [ADR-0015](../../../docs/adr/0015-the-sync-experience.md) and
 [ADR-0019](../../../docs/adr/0019-naming-the-account-at-enrolment.md) (everything the user sees about
@@ -215,12 +218,24 @@ grant, and ADR-0004 §8's clock-skew warning. A network failure never speaks —
   occlusion. Nothing below us reports the IME inset — rule 8's gap has a second half — and the window
   is edge-to-edge, so `adjustResize` does nothing. egui then sizes its `ScrollArea` to a viewport
   taller than the visible one, the content fits, and there is **no scroll range** over the covered
-  39%. This crate's one-function `platform` seam returns the insets and the band is reserved. **Two
-  guards are load-bearing**: keep the focused field inside the shrunken viewport *in the same frame it
-  shrinks* (a `TextEdit` publishes `output.ime` only while visible; `egui-winit` turns its absence
-  into `hide_soft_input`, which collapses the inset, which restores the viewport — a closed loop that
-  presents as a flickering keyboard), and **surrender focus when a focused field is scrolled fully out
-  of view** (the same loop from the other end). ADR-0025 §1–§3.
+  39%. This crate's one-function `platform` seam returns the insets and the band is reserved. **Its
+  return type says whether the platform has a soft keyboard at all** — "no keyboard here" and "keyboard
+  down" both reported zero in ADR-0025 §2's original wording, which makes every "is it down" gate
+  permanently true on desktop (ADR-0026 §5). **Three guards are load-bearing**: keep the focused field
+  inside the shrunken viewport *in the same frame it shrinks* (a `TextEdit` publishes `output.ime` only
+  while visible; `egui-winit` turns its absence into `hide_soft_input`, which collapses the inset, which
+  restores the viewport — a closed loop that presents as a flickering keyboard); **surrender focus when
+  a focused field is scrolled fully out of view** (the same loop from the other end); and **raise the
+  keyboard from a discrete press on a text field**, below. ADR-0025 §1–§3, ADR-0026 §4–§5.
+- **The keyboard is raised from the shared text-field wrapper, on that field's own click.** This is the
+  recovery half of the vendored `egui-winit` patch (rule 12), and it is not optional: once the per-tap
+  interrupt is suppressed, nothing re-asserts show after the user dismisses the keyboard with the IME
+  chevron, because the layer below debounces its allow-IME flag against a state that never changed. It
+  goes through `ViewportCommand::IMEAllowed(true)`, which reaches the window without touching that flag.
+  **Keyed on a discrete click, never on a per-frame "something is focused and the pointer went down"** —
+  `request_focus` fires while *dragging* too, and the version that hung off it issued **72 show requests
+  from a single scroll gesture**. It lives in the wrapper because rule 2 already routes every field
+  through it, which is the only way every field can be promised the same behaviour. ADR-0026 §4.
 - **Verify on the real handset.** The emulator is x86_64; the Pixel 8 Pro is arm64-v8a only.
 
 ## Why this crate has no `main.rs`

--- a/docs/adr/0025-the-authoring-screen-under-a-soft-keyboard.md
+++ b/docs/adr/0025-the-authoring-screen-under-a-soft-keyboard.md
@@ -65,9 +65,15 @@ than per workspace, keeping `leitner-store::platform` at exactly two functions a
 belongs there: an inset is a fact about the window the UI is drawing into, and routing it through the
 store would make the store answer a question about layout.
 
-It is bound by the same discipline: **one function, returning the insets, with a non-Android
-implementation that returns zero** — not a family of window queries that grows a helper per platform
-question. The compile-time storage seam of client-stack rule 3 is unaffected.
+It is bound by the same discipline: **one function, returning the insets** — not a family of window
+queries that grows a helper per platform question. The compile-time storage seam of client-stack rule 3
+is unaffected.
+
+> **Amended by [ADR-0026 §5](0026-the-per-tap-keyboard-re-pop.md).** This section originally specified
+> *"a non-Android implementation that returns zero"*. Zero is also what a **down** keyboard reports, so
+> off Android the two states are indistinguishable and any gate on "the keyboard is down" is permanently
+> true. The return type therefore distinguishes **no soft keyboard on this platform** from **keyboard
+> down**. Still one function; the type gets honest, the seam does not widen.
 
 ### 3. Two guards, without which the keyboard oscillates
 
@@ -87,6 +93,14 @@ shrink the viewport" is *not* a sufficient instruction.
   because scrolling away is deliberate; surrendering focus makes the state consistent — no focus, no
   IME output, no keyboard, nothing to oscillate between. **Completely**, not merely clipped: a field
   half off the edge is still being typed into.
+
+> **Amended by [ADR-0026 §4](0026-the-per-tap-keyboard-re-pop.md): there are three guards, not two.**
+> The third is **raise the keyboard from a discrete press on a text field**, and it has a different
+> origin — these two follow from *reading insets*, that one follows from *carrying the patch*. Once the
+> per-tap interrupt is suppressed, nothing re-asserts show after the user dismisses the keyboard with
+> the IME's own chevron, because the layer below debounces its allow-IME flag against a state that never
+> changed. An implementation that takes this section as complete ships a keyboard the user cannot get
+> back.
 
 ### 4. The destructive-edit warning moves above the fields
 
@@ -140,8 +154,9 @@ was.
   soft keyboard on **every tap** into a text field, including a tap on the field that already has
   focus, because the UI layer interrupts IME composition on every pointer interaction and the layer
   below implements that interruption as hide-then-show. It is independent of everything above — it
-  reproduces with inset handling switched off, and it is not a layout question. Owned by
-  [Decide: whether we carry a patched `egui-winit`](https://github.com/amin-bf/leitner/issues/75).
+  reproduces with inset handling switched off, and it is not a layout question. **Since settled by
+  [ADR-0026](0026-the-per-tap-keyboard-re-pop.md)**: the guard is carried as a patch to the vendored
+  windowing adapter, with the recovery half in this crate's shared text-field wrapper.
 - **Visual design**, unchanged from [ADR-0012 §9](0012-the-note-authoring-experience.md) and out of
   scope for the map. Where the warning sits is behaviour; what it looks like is not.
 - **Non-Latin authoring on the handset**, which client-stack rule 8 forecloses and this ADR does not
@@ -173,9 +188,9 @@ was.
 
 ## Open items handed onward
 
-- **The per-tap keyboard re-pop** (§6) — owned by
-  [Decide: whether we carry a patched `egui-winit`](https://github.com/amin-bf/leitner/issues/75).
-  Until it is settled, an implementation of this ADR is correct and still visibly flickers on each tap.
+- ~~**The per-tap keyboard re-pop** (§6)~~ — **settled by
+  [ADR-0026](0026-the-per-tap-keyboard-re-pop.md)**, which also amends §2's seam return type and adds a
+  third guard to §3. Read it before implementing either.
 - **What the moved warning looks like** — the visual design pass's, on the same terms
   [ADR-0018](0018-the-card-pane-ordering.md) left for a dormant line: what it says and where it sits are
   settled here, only how it looks is not.

--- a/docs/adr/0026-the-per-tap-keyboard-re-pop.md
+++ b/docs/adr/0026-the-per-tap-keyboard-re-pop.md
@@ -1,0 +1,248 @@
+# ADR-0026: The per-tap keyboard re-pop, and the first dependency we patch
+
+- **Status**: Accepted
+- **Date**: 2026-08-01
+- **Resolves**: [Decide: whether we carry a patched `egui-winit` so Android text entry stops re-popping the keyboard](https://github.com/amin-bf/leitner/issues/75)
+- **Map**: [Map: local-first Leitner app spec](https://github.com/amin-bf/leitner/issues/1)
+- **Related**: [ADR-0003 §3 §5 §6](0003-client-stack.md) (the client stack; the precedent that a
+  rendering defect is patched in our own code rather than upstream; what winit's Android backend does
+  not do), [ADR-0025 §1 §2 §3 §6](0025-the-authoring-screen-under-a-soft-keyboard.md)
+  (the inset seam, the guards that come with it, and the handoff this ADR discharges),
+  [ADR-0016 §5](0016-backup-and-restore.md) (the per-crate platform-seam rule),
+  [ADR-0001 §1](0001-scheduling-algorithm-and-grade-scale.md) (the exact-pinning precedent)
+
+## Context
+
+[ADR-0025 §6](0025-the-authoring-screen-under-a-soft-keyboard.md) settled the authoring screen under a
+soft keyboard and explicitly declined one defect found on the way, because it is not a layout question
+and reproduces with inset handling switched off:
+
+**As shipped, text entry on Android dismisses and reopens the soft keyboard on every tap into a text
+field — including a tap on the field that already has focus.**
+
+The mechanism runs through three layers, and each link was read in the source rather than inferred.
+The UI toolkit's `Memory::request_focus` interrupts IME composition unconditionally, and its
+`TextEdit` calls that on **every** pointer interaction — `did_interact || response.clicked()` — with no
+check for whether the widget is already focused. The toolkit's windowing adapter implements the
+interruption as `set_ime_allowed(false)` immediately followed by `set_ime_allowed(true)`, a mechanism
+its own source marks as provisional with a `TODO` asking for a proper interrupt if the windowing layer
+ever provides one. The windowing layer's Android backend maps those two calls onto the platform's
+hide-soft-input and show-soft-input. So an ordinary tap is a visible dismiss-and-reopen.
+
+**It buys nothing on this platform.** That same backend handles only motion and key events and has no
+IME path at all — the gap [ADR-0003 §6](0003-client-stack.md) and client-stack rule 8 already record
+for composed text — so there is never a composition to interrupt.
+
+Measured on the Pixel 8 Pro with the platform's own IME request tracker, tapping the already-focused
+field three times: **6 hide and 17 show requests** as shipped, **0 and 0** with the block dropped on
+Android. Evidence and two rejected fixes are on branch
+[`prototypes/issue-67`](https://github.com/amin-bf/leitner/tree/prototypes/issue-67).
+
+**There is no fix available in our own code, and this was established before any option was weighed.**
+The interrupt flag is a private field on the toolkit's `Memory`; `interrupt_ime()` is a public
+*setter* onto it, the reader is crate-private, and the flag is cleared only in `Memory::begin_pass`.
+`Context::end_pass` stamps it onto the frame's platform output *after* all application code has run,
+and the application layer offers no hook on that output before the adapter consumes it. An application
+can raise the interrupt and can never lower it. The adapter's `State::set_allow_ime` is public, but the
+application framework owns the `State` and never hands it over. Short of writing our own text widget,
+the fix cannot live above the dependency.
+
+**That test was run first because [ADR-0003 §3](0003-client-stack.md) sets the standard.** The bidi
+defect that nearly cost us the stack was fixed in about sixty lines of our own code with **no fork**, by
+exploiting a contract the renderer already published — and that ADR names the absence of a fork as the
+reason the defect was survivable. This is the same question asked again and answered the other way, on
+a private field and a missing hook rather than on preference.
+
+## Decision
+
+### 1. Accepting the behaviour is not available, because it defeats ADR-0025 §1
+
+The obvious reading is that this is cosmetic — an editor that flickers — and cosmetics belong to the
+visual design pass, which the map ruled out of scope. That reading was tested and it fails, because
+[ADR-0025 §1](0025-the-authoring-screen-under-a-soft-keyboard.md) landed in between.
+
+§1 reads the IME inset **so the covered band becomes reachable at all**: before it, the UI layer was
+handed a viewport taller than the visible one, the content fitted inside it, and the covered region was
+unreachable rather than scrolled off. The re-pop collapses and restores that inset on every tap, which
+restores and re-shrinks the viewport, which is what the prototype observed as the scroll position
+resetting. So the user scrolls to bring a covered field into view, taps it, and the scroll just
+established is discarded — at the precise moment §1 exists to serve.
+
+That is a reachability guarantee being functionally defeated, not an editor that looks bad.
+[§4](0025-the-authoring-screen-under-a-soft-keyboard.md)'s warning-above-the-fields is in the same
+blast radius, since a scroll reset is exactly what decides which screen of the form pane is on show.
+
+### 2. The guard goes in the windowing adapter, not in the toolkit's core
+
+Three layers could hold it, and the choice is not the one it first appears to be.
+
+**The toolkit's core looks like the honest bug report.** `TextEdit` calling `request_focus` on a widget
+that already has focus, and `request_focus` interrupting composition unconditionally, is a defensible
+thing to call wrong on any platform. A `has_focus` guard there would kill the measured case and the
+drag case with it, since `did_interact` is true while dragging inside a focused field.
+
+**But it does not fix our problem.** It leaves genuine field-to-field focus changes still interrupting,
+and on Android that is still a hide-then-show with no composition to interrupt. Moving from `Front` to
+`Back` is the most ordinary act there is on the authoring screen, so the core guard reproduces §1's
+inset collapse on a slightly rarer trigger. It narrows the defect; it does not remove it.
+
+**The windowing layer** — giving its Android backend a real IME path — is the fix that would also close
+client-stack rule 8. [ADR-0003](0003-client-stack.md) looked straight at that and declined it, and
+nothing since has changed the estimate. Not reopened here.
+
+**So the guard sits in the adapter**, suppressing the interrupt on Android. Its justification is a fact
+this repository has already validated and written down — the backend has no IME path, so there is no
+composition — rather than a premise this ADR invents.
+
+### 3. We vendor the published crate, because forking the repository forks the whole family
+
+The adapter crate **as published** declares an ordinary registry dependency on the toolkit,
+`egui = { version = "0.35.0" }`. The same crate **inside its own repository** declares
+`egui = { workspace = true }`, which resolves to a path dependency on that repository's copy. So a
+fork-and-branch — attractive because re-applying a patch to a newer release is then a rebase, with
+conflicts landing exactly on the changed block — would pull a second copy of the toolkit into the
+dependency graph beside the registry copy the application framework and our own crates use, whose types
+would not unify. Making it work means patching the entire family to the fork, so we would be building
+all of the toolkit from a source revision in order to change one block. The vendored tree preserves both
+forms of the manifest side by side, which is where this is visible.
+
+**So: a verbatim copy of the published crate, wired in with `[patch.crates-io]`.** Nine files, about
+214 KB, carrying exactly one change.
+
+A build-time patch tool was rejected on a softer ground: it adds a third-party step to a stack
+[ADR-0003](0003-client-stack.md) chose partly because the build is plain cargo and the APK is a
+manifest plus a shared object. A patcher fails at build time on a fresh machine, which is the worst
+place to fail.
+
+Three disciplines come with it:
+
+- **Verbatim plus exactly one change**, verifiable by recursive diff against a freshly fetched pristine
+  copy of the same version.
+- **The version is pinned exactly**, adapter and toolkit together, following
+  [ADR-0001 §2](0001-scheduling-algorithm-and-grade-scale.md)'s precedent for the scheduler crate.
+- **The vendored tree is outside client-stack rule 3.** That rule makes a `#[cfg(target_os)]` anywhere
+  in the workspace a defect signal, and the patch is one. It is not a workspace member — a patched path
+  dependency never is — but a reader grepping the tree will find it, so the rule says so explicitly
+  rather than letting a correct instance blunt a signal the repository relies on.
+
+### 4. The recovery half is ours, and it lives in the shared text-field wrapper
+
+**Dropping the block alone breaks recovery, and this is the part most likely to be lost in
+translation.** The adapter debounces its allow-IME flag against its own previous value. After the user
+dismisses the keyboard with the IME's own chevron, the toolkit's state has not changed — only the
+platform's has — so nothing ever re-asserts it and tapping a field does nothing. The interrupt block was
+the only thing re-asserting show, so removing the defect removed recovery with it.
+
+Re-asserting *show* inside the adapter instead was tried and is worse: `request_focus` fires while
+**dragging** as well as on a tap, so a single scroll gesture issued **72 show requests**. Both wrong
+versions made the same mistake — hanging behaviour off a per-frame flag when the thing being modelled is
+a discrete event.
+
+**So the application raises the keyboard itself, from a discrete pointer press.** It goes through
+`ViewportCommand::IMEAllowed(true)`, which the adapter maps straight onto the window without touching
+its own debounced flag — public API, and no state to desync.
+
+**It lives in the crate's one shared text-field wrapper**, the one client-stack rule 2 already forces
+every field through for the bidi layouter, keyed on the field's own click. Not on a frame-level "some
+widget is focused and the pointer went down", which is the prototype's shape: that fires for a focused
+button as readily as a focused field, and it is per-frame where the event is discrete. One wrapper is
+also the only place that can promise every field behaves the same way.
+
+**This is a third guard**, alongside [ADR-0025 §3](0025-the-authoring-screen-under-a-soft-keyboard.md)'s
+two, and it differs from them in origin: those two are consequences of *reading insets*, this one is a
+consequence of *carrying the patch*. An implementation that takes the patch without it has a keyboard
+the user cannot get back after dismissing it by hand.
+
+### 5. The seam's return type learns to say "no soft keyboard here"
+
+The raise is gated on the platform reporting a keyboard that is currently **down**, because without the
+gate every click on a field sends a redundant show request and the validated zero-hides-zero-shows
+result becomes zero hides and three inert shows. Those shows are invisible — the harmful half was always
+the hide — but the measured shape is the one this repository prefers to ship.
+
+**The gate as the prototype wrote it is a live defect off Android.**
+[ADR-0025 §2](0025-the-authoring-screen-under-a-soft-keyboard.md) specifies the UI crate's seam as one
+function returning the insets, *with a non-Android implementation that returns zero*. Zero is also what
+a down keyboard reports, so on desktop "the keyboard is down" is permanently true, the gate never fires,
+and every pointer press with any widget focused re-enables IME behind the adapter's back — including
+when the adapter has deliberately disabled it because the focused widget is not a text field.
+
+**So the seam's return type distinguishes "this platform has no soft keyboard" from "the keyboard is
+down".** This is not a widening: it stays **one function** under
+[ADR-0016 §5](0016-backup-and-restore.md)'s per-crate rule, and the type it returns becomes honest.
+Collapsing the two states was the error.
+
+It is deliberately **not** expressed as a second compile-time capability constant. The existing one —
+[ADR-0015 §9](0015-the-sync-experience.md)'s non-Latin-input constant, client-stack rule 3's one
+sanctioned exception — exists *to make a limitation visible, never to vary behaviour*, and this gate
+varies behaviour. A seam that already answers questions about the window is the right owner.
+
+### 6. What re-applying the patch requires, and what invalidates it
+
+**The patch is bound to a block shape, not to a line number.** It guards
+`if !is_toggling_ime && ime.should_interrupt_composition { set_ime_allowed(false); set_ime_allowed(true) }`.
+If a future release restructures that block, the instruction is **re-judge, not re-apply** — because a
+guard mechanically applied to a block that no longer means the same thing looks perfectly healthy in a
+diff. This is the silent failure and it is the reason the shape is written out here.
+
+**Routine bumps are gated proportionately**: recursive diff against pristine, plus the block-shape
+check. The handset measurement is required only when either of those is unhappy. Demanding a handset run
+for every patch bump buys nothing when the block is byte-identical and the guard applied cleanly, and a
+discipline that heavy is one that gets skipped — which is worse than a lighter one that is followed.
+
+**The invalidating event is the windowing layer gaining an Android IME path.** Then a real composition
+exists, and suppressing its interruption becomes a bug rather than a fix. That same event invalidates
+**client-stack rule 8**, which this repository already watches — so rule 8 is the tripwire, stated here
+rather than left as an inference for whoever bumps the dependency.
+
+### 7. We report the finding upstream; we do not commit to landing it
+
+**The guard is half a fix, and that is why this is not a pull request.** Suppressing the interrupt
+without §4's recovery leaves any other application on this stack with a keyboard that never comes back
+after a manual dismiss. An honest contribution has to carry the recovery half *inside* the adapter,
+which is a design task — and the 72-request scroll gesture shows how easily it goes wrong there. Its
+latency is unbounded and the work sits past a destination that contains decisions.
+
+**The measurement is the expensive part and it is already paid for.** Publishing the mechanism and the
+request counts as an upstream *issue* costs almost nothing, lands where upstream's own `TODO` already
+concedes the mechanism is provisional, and is the only realistic route by which the vendored tree is ever
+retired. Filing it is the repository owner's, on the same terms as issues here.
+
+### 8. What this ADR does *not* settle
+
+- **Non-Latin authoring on Android**, which client-stack rule 8 forecloses. The same missing IME path
+  causes both, and fixing that path is the windowing-layer work §2 declines. Nothing here reopens it.
+- **Whether the guard is ever accepted upstream.** §7 reports; it does not predict.
+- **Any other dependency.** This is the first patched dependency the repository carries, and §3's
+  disciplines are written for this one. A second would be an erosion signal worth arguing on its own.
+
+## Amendments to accepted ADRs
+
+| ADR | What changes | Why |
+|---|---|---|
+| [0025 §2](0025-the-authoring-screen-under-a-soft-keyboard.md) | The seam's **return type** distinguishes *no soft keyboard on this platform* from *keyboard down*, replacing "a non-Android implementation that returns zero". Still one function. | §5 above. Collapsing both to zero makes the off-Android gate permanently true and re-enables IME behind the adapter's back. |
+| [0025 §3](0025-the-authoring-screen-under-a-soft-keyboard.md) | Its **two** guards become **three**. The third — raise the keyboard from a discrete press on a text field — has a different origin: it is a consequence of the patch, not of reading insets. | §4 above. §3's list reads as complete, and an implementer taking it as complete ships a keyboard that cannot be recovered after a manual dismiss. |
+| [0003 §5](0003-client-stack.md) | The toolchain constraints gain one: **the windowing adapter is vendored and patched**, so a version bump of the stack is no longer only a version change — §6's diff, block-shape check and re-judge rule run with it. | §3 and §6 above. The stack choice is unchanged; what changes is that one crate of it is no longer taken as published. |
+
+## Consequences
+
+- **The repository carries third-party source for the first time**, and the delta is invisible by
+  inspection — a reader sees a whole crate, not a one-block change. §3's recursive-diff discipline is
+  what makes the delta recoverable, and it is load-bearing rather than tidy.
+- **Client-stack rule 3's defect signal now has a stated exclusion.** A correct `#[cfg(target_os)]`
+  living in a tree the rule does not govern is exactly how a signal quietly stops meaning anything.
+- **The keyboard's correctness now spans three places that must agree** — the vendored guard, the
+  raise in the text-field wrapper, and the seam's honest return type. Any one of them alone is a
+  regression: the guard alone loses recovery, the raise alone is redundant, the seam alone changes
+  nothing.
+- **Every screen with a text field inherits this**, on the same terms as
+  [ADR-0025](0025-the-authoring-screen-under-a-soft-keyboard.md)'s two guards, because the raise lives
+  in the wrapper every field already goes through.
+- **The vendored tree has a stated exit.** §7's report is the only route to retiring it, and until
+  something lands upstream the patch is permanent by default rather than by oversight.
+
+## Open items handed onward
+
+- **Reporting the finding upstream** (§7) — the repository owner's, not this map's.
+- **Nothing else.** The defect is fully characterised, the remedy is chosen, and the residual is a
+  watched tripwire (§6) rather than an open question.


### PR DESCRIPTION
Resolves [#75](https://github.com/amin-bf/leitner/issues/75), the defect
[ADR-0025 §6](https://github.com/amin-bf/leitner/blob/main/docs/adr/0025-the-authoring-screen-under-a-soft-keyboard.md)
declined rather than folded into a layout answer. It reproduces with inset handling switched off and
it is not a layout question.

Evidence and two rejected fixes: branch [`prototypes/issue-67`](https://github.com/amin-bf/leitner/tree/prototypes/issue-67).

## The defect, and why it is not cosmetic

`Memory::request_focus` interrupts IME composition unconditionally, `TextEdit` calls it on **every**
pointer interaction with no `has_focus` check, `egui-winit` implements that interruption as
`set_ime_allowed(false)` then `(true)`, and winit's Android backend maps those onto
`hide_soft_input`/`show_soft_input`. **6 hides and 17 shows for three taps on the already-focused
field**, measured with the platform's own IME request tracker; **0 and 0** with the block dropped.

It buys nothing here — client-stack rule 8's missing IME path means there is never a composition to
interrupt.

**Accepting it would defeat ADR-0025 §1.** The obvious reading is that a flickering editor is the
visual design pass's, which the map ruled out of scope. But the re-pop collapses and restores the IME
inset, which restores and re-shrinks the viewport, which throws away the scroll the user just
established to reach a covered field — at the exact moment §1's reachability guarantee exists to
serve. §4's warning-above-the-fields is in the same blast radius.

## What was decided

1. **The guard sits in `egui-winit`, not in egui's core.** A `has_focus` guard on `TextEdit` is the
   more honest bug report and it does not fix us: it kills repeat taps and drags but leaves genuine
   field-to-field focus changes still interrupting, which is the most ordinary act on the authoring
   screen. winit growing an Android IME path is the fix ADR-0003 already declined.
2. **We vendor the published crate, and forking the repository is not the cheaper option it looks
   like.** The published manifest declares `egui = { version = "0.35.0" }`; the same crate inside its
   own repository declares `egui = { workspace = true }`, a path dependency. A fork therefore drags a
   second copy of the toolkit into the graph beside the registry copy `eframe` uses, so making it work
   means forking the whole family to change one block.
3. **The recovery half is ours, and the patch cannot ship without it.** Suppressing the interrupt
   removes the only thing that re-asserted show after the user dismisses the keyboard with the IME
   chevron, because `egui-winit` debounces its allow-IME flag against a state that never changed. It
   goes in the shared text-field wrapper rule 2 already routes every field through, keyed on that
   field's **click** — never on a per-frame flag, which is how the rejected version issued **72 show
   requests from one scroll gesture**.
4. **The inset seam's return type learns to say "no soft keyboard here".** ADR-0025 §2 specified zero
   off Android, and zero is also what a *down* keyboard reports — so the gate is permanently true on
   desktop and every pointer press re-enables IME behind `egui-winit`'s back. That is a live defect in
   the prototype. Still one function under ADR-0016 §5; the type gets honest, the seam does not widen.
5. **The patch is bound to the block's shape, not its line number.** If a release restructures it, the
   instruction is **re-judge, not re-apply** — a guard applied to a block that no longer means the same
   thing looks healthy in a diff. Routine bumps need the recursive diff and the shape check; the
   handset measurement only when either is unhappy. **Client-stack rule 8 is the tripwire**: winit
   growing an IME path invalidates the patch outright.
6. **Upstream gets an issue, not a pull request.** The guard alone removes recovery for anyone without
   our raise, so an honest contribution has to carry the recovery half inside the adapter — a design
   task with unbounded latency, sitting past a destination that contains decisions. Publishing the
   measurement is cheap and is the only route that ever retires the vendored tree. **Filing is yours.**

## Amendments

| ADR | What changes |
|---|---|
| 0025 §2 | The seam's return type distinguishes *no soft keyboard* from *keyboard down*. Still one function. |
| 0025 §3 | Two guards become **three**; the third comes from the patch, not from reading insets. |
| 0003 §5 | The toolchain constraints gain one — a bump of the stack is no longer only a version change. |

`AGENTS.md` gains **client-stack rule 12**, rule 8 gains the tripwire, rule 3 gains the exclusion for
the vendored tree (a correct `cfg(target_os)` in a tree the rule does not govern is how a defect signal
quietly stops meaning anything), and rule 11 plus the `ui` crate's `CONTEXT.md` gain the third guard
and the honest seam type.

## Not in this PR

The vendoring itself. This is a decision ticket on a planning map — the deliverable is the ADR and the
rules; the implementing fleet does the build act.

🤖 Generated with [Claude Code](https://claude.com/claude-code)