### PR TITLE
Agent Standards / Align the Platform-Seam Rule with ADR-0003 and ADR-0009

### DIFF
--- a/.sandcastle/CODING_STANDARDS.md
+++ b/.sandcastle/CODING_STANDARDS.md
@@ -6,7 +6,9 @@ time without costing tokens during implementation.
 
 Architectural decisions live in `docs/adr/` and the per-context `CONTEXT.md`
 files, not here. Where an ADR and this file disagree, the ADR wins — say so
-rather than silently following one.
+rather than silently following one. `CONTEXT-MAP.md` at the repository root
+indexes which ADR sections bind which context; `docs/adr/` is past 2,600 lines,
+and that index is what stops "read the ADRs" from meaning all of them.
 
 ## Style
 
@@ -60,12 +62,26 @@ rather than silently following one.
 
 ## Architecture
 
-- The domain core — scheduling, the event log, replay — stays free of I/O, of
-  the clock, and of any UI or platform dependency. It should be testable with
-  nothing but `cargo test`.
-- Platform-specific code (storage backends, Android specifics, wasm) sits behind
-  a trait at the edge, with the core depending on the trait rather than the
-  implementation.
+- The domain core — content, the event log, scheduling, replay — stays free of
+  I/O, of the clock, and of any UI or platform dependency. `leitner-core` is a
+  crate boundary rather than a convention: `cargo test -p leitner-core` needs no
+  database, no window and no handset (ADR-0009 §2).
+- **The platform seam is a compile-time `#[cfg]`, never a trait and never a
+  runtime check** (ADR-0003 §5, ADR-0009 §4). Three arms, the third a
+  `compile_error!`, so an unrecognised target fails the build instead of
+  silently taking the desktop path. The rule is **per crate**: `leitner-store`
+  stays at exactly two functions and a third appearing there means the seam is
+  eroding; a crate needing the platform for an unrelated reason gets its own
+  module under the same discipline (ADR-0016 §5).
+- **A trait-based store seam was considered and rejected** (ADR-0009 §2). There
+  is one adapter and `rusqlite` opens `:memory:`, so the abstraction would exist
+  only to serve tests that do not need it — which is why there is **no fake
+  store**: store tests open a real database in a temp directory, because the
+  design *is* WAL, `BEGIN IMMEDIATE`, `ATTACH` and `INSERT OR IGNORE`.
+- **Time and identity are values, never injected traits** (ADR-0009 §8). Replay
+  needs no clock at all — day numbers are frozen on the row at write time and
+  fuzz is seeded from card identity — so a `Clock` trait would be a hypothetical
+  seam. The two call sites that need "now" take it as a parameter.
 - Keep modules focused on one responsibility, and prefer composition and traits
   over deep generic gymnastics. If a signature needs three lines of `where`
   clauses, reconsider the design.


### PR DESCRIPTION
## What

`.sandcastle/CODING_STANDARDS.md` told the reviewer agent that platform-specific code *"sits behind a trait at the edge, with the core depending on the trait rather than the implementation"*. Three accepted ADRs say the opposite:

- **ADR-0003 §5 / ADR-0009 §4** — the platform seam is a **compile-time `#[cfg]`**, three arms with a `compile_error!` third, and *"never introduce a runtime platform check — the whole stack choice rests on wrong platform code failing the build."*
- **ADR-0009 §2** — a trait-based store seam was **considered and rejected**: one adapter, and `rusqlite` opens `:memory:`, so it would exist only to serve tests that do not need it. Hence also *"there is no fake store."*
- **ADR-0009 §8** — time and identity are **values, never injected traits**; replay needs no clock at all.

The file already says the ADR wins where the two disagree. That is not enough on its own: the reviewer loads this file at review time and its brief is to *improve* code, so the contradiction is a standing licence to refactor a correct `#[cfg]` seam into a trait and file it as a standards fix — the exact erosion `AGENTS.md` client-stack rule 3 exists to catch, arriving through the one agent nobody reviews.

It also named **wasm**, which went out of scope in ADR-0007 §1.

## Also

The intro told the reviewer the ADR wins but gave it no route to the ADRs. It now points at `CONTEXT-MAP.md`, whose whole job is saying which sections bind which context — `docs/adr/` is past 2,600 lines.

## Not in this PR

Two other things I found in `.sandcastle/` and deliberately left alone, since they are behaviour rather than documentation:

- Commits made inside the sandbox are **unsigned** — the container writes its own `~/.gitconfig` with no key, so they succeed rather than fail, and the merge phase lands them on `main`. `AGENTS.md` landing rule 1 covers exactly this case.
- The implement prompt requires a `RALPH:` commit prefix, which is not this repo's `type(Scope): <gitmoji> subject` convention.

## Verification

Documentation only — no code changed, so no build or test surface is touched.