### PR TITLE
Agent Standards / Name Branches by Domain, Not by Ticket Number

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,22 @@ This applies to every agent working in this repo, on every artifact that persist
 Tickets here are worked in **parallel worktree sessions**, each branching from `origin/main` and
 never seeing what merged afterwards. Two things break silently because of it.
 
+### Branch names
+
+**`Domain/PascalCaseDescription`** — one slash, no spaces, no kebab-case, and **no ticket number**.
+It is the pull-request title with the spaces taken out: the PR convention is
+`Domain / Title Case Description`, so `Client Stack / Read the IME Insets and Stop the Per-Tap
+Keyboard Re-Pop` branches as `ClientStack/ReadImeInsetsAndStopKeyboardRePop`.
+
+Derive it from the title you intend to give the PR, never from the issue you are resolving. A
+ticket-numbered branch — `sandcastle/issue-84`, `worktree-wayfinder-75-…` — names **the tracker
+rather than the work**, and the tracker is the one thing a PR already links. Nothing fails when a
+branch is misnamed, which is why it needs saying: the cost is paid later and by someone else, when
+the branch list has stopped being a map of the system and become a list of who happened to open what.
+
+`ClientStack/…`, `NoteAuthoring/…`, `DeckExport/…`, `Sync/…`, `AgentStandards/…` — the same domains
+the PR titles already use. Branch and PR then agree on which part of the system the work belongs to.
+
 ### Rules that are easy to break silently
 
 1. **If commit signing fails, stop and ask. Never fall back to `--no-gpg-sign`.** Every commit on


### PR DESCRIPTION
## What

`AGENTS.md`'s **Landing work** section said how work reaches `main` — signing, ADR renumbering — and nothing about what to call the branch it lands from. So sessions have been emitting `sandcastle/issue-NN`, and older ones `worktree-wayfinder-75-…`.

Those name **the tracker rather than the work**, and the tracker is the one thing a pull request already links. Meanwhile the branch list stops being a map of the system and becomes a list of who happened to open what.

The convention is now written down: **`Domain/PascalCaseDescription`** — the PR title with the spaces taken out. `Client Stack / Read the IME Insets and Stop the Per-Tap Keyboard Re-Pop` branches as `ClientStack/ReadImeInsetsAndStopKeyboardRePop`. Branch and PR then agree on which part of the system the work belongs to.

It is the same rule as `/home/amin/projects/ptt/api`, whose branches are the source: `Account/ApiKey`, `Leasing/ContractModelAdjustments`, `Settings/PreferencesCausing422`, `Database/PolymorphicAndMongoIndexes`.

## Also

Written as its own subsection rather than a third numbered rule, because the two under *Rules that are easy to break silently* are about a commit that **does not exist** (signing) and an ADR number that **collides** (renumbering) — both of which produce a wrong artefact. This one produces a correct artefact with a bad name. The section's opening line still says *"two things break silently"*, and it still means those two.

The rule says the cost out loud anyway, since a rule nothing enforces is the kind that erodes: nothing fails when a branch is misnamed, and the cost is paid later and by someone else.

## Not in this PR

- **Renaming the open branch.** #100 is on `sandcastle/issue-84` and stays there — renaming a branch under a live PR buys nothing, and the convention starts cleanly with this one, which follows it.
- **The global `~/.claude/CLAUDE.md`**, where the `Domain / Title Case Description` PR rule already lives and where this arguably belongs as a cross-project default. That file is Amin's, and touching it is his call, not this repo's.

## Verification

Documentation only — no code changed, so no build or test surface is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)