### PR TITLE
Review Session / Verify on the Handset and Fix Two Statements the Screen Was Making

### DIFF
--- a/crates/app/src/CONTEXT.md
+++ b/crates/app/src/CONTEXT.md
@@ -89,7 +89,13 @@ not diverge here.
 **Box badge**:
 The small, non-interactive indicator shown **only after reveal**. Reports durability. Never sorted,
 never counted, never presented as a queue — see `scheduling`'s rules, which bind everything in this
-file.
+file. It reads **`new` for a card with no review history**, never a box number (ADR-0006 §6): the box
+is a total function of memory state and so answers *1* for a card it has never seen — the same answer
+it gives a card reviewed thirty times and never retained — so printing the number claims a durability
+nothing has measured, and on a first introduction it reads as *the bottom box*, a position in a queue
+of boxes. That is the one reading ADR-0001 §3 exists to keep the badge from acquiring, and it arrives
+by omission rather than by anyone deciding it.
+_Avoid_: Box 1 for an unseen card; "level", "stage".
 
 **Interval preview**:
 The illustrative next-interval shown on each grade button. Confirmed wanted rather than noise once
@@ -98,6 +104,24 @@ seen rather than described.
 **Backlog**:
 More cards due than the user will get through. Always *framed* ("pick a comfortable size, the rest
 will keep"), never reported as a bare number.
+
+**Fresh deck**:
+The picker's state for a collection **nothing has ever been reviewed in** — zero history anywhere, not
+merely nothing due today (ADR-0006 §8, whose parenthesis is *zero review history*). It is one of
+**three states that all have an empty due list**, and the other two are not it: *caught up* has nothing
+to introduce either, and **nothing due** below has history behind it.
+_Avoid_: New deck for anything but a first look.
+
+**Nothing due**:
+Nothing due in a collection that **has** been reviewed: the day's repeats are finished and the new-card
+rate still has room. **Indistinguishable from a fresh deck by looking at the queue** — same empty due
+list, same new cards — so the only thing separating them is whether any review exists at all, which is
+why the distinction is stated here rather than left to be noticed. Collapsing the two tells a reviewer
+of four years that their deck is fresh. It is the **ordinary** shape of an afternoon rather than an edge
+case, because ADR-0011 §2's rate caps introductions every day; ADR-0006 §8 named only two worded states
+because it predates that rate. Its sentence states the fact and invites — never that the user is behind,
+which they are not, and never a bare count.
+_Avoid_: Fresh deck, empty, done for the day.
 
 **Leech screen**:
 The card-level list that hangs off Review — the one place cards are listed, not notes (the note list

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -513,7 +513,11 @@ fn review(
             return None;
         }
 
-        if let Some(count) = picker(ui, &queue, total) {
+        // Whether the collection has *any* history — the one fact the queue cannot carry, and what
+        // separates a first look from a finished day (`ReviewState::of`). A card appears in
+        // `replayed.cards` exactly when it has been reviewed.
+        let reviewed_ever = !replayed.cards.is_empty();
+        if let Some(count) = picker(ui, &queue, total, reviewed_ever) {
             // Snapshot the cards that are already leeches, so the pointer at this sitting's end covers
             // only what crosses during it (ADR-0010 §6).
             let before = ranked.iter().map(|l| l.card).collect();
@@ -791,9 +795,14 @@ fn card_preview(coll: &Collection, card: CardRef) -> String {
 
 /// The count picker and the explicit worded states (issue #94). Returns the chosen sitting size when
 /// the user starts one.
-fn picker(ui: &mut egui::Ui, queue: &session::Queue, total: usize) -> Option<usize> {
+fn picker(
+    ui: &mut egui::Ui,
+    queue: &session::Queue,
+    total: usize,
+    reviewed_ever: bool,
+) -> Option<usize> {
     let available = queue.available();
-    match ReviewState::of(queue, total) {
+    match ReviewState::of(queue, total, reviewed_ever) {
         ReviewState::Empty => {
             body(ui, "No cards yet. Add a note to start reviewing.");
             None
@@ -807,6 +816,13 @@ fn picker(ui: &mut egui::Ui, queue: &session::Queue, total: usize) -> Option<usi
                 ui,
                 "A fresh deck. These cards are new — start whenever you like.",
             );
+            count_buttons(ui, new)
+        }
+        // Nothing due in a collection that *has* been reviewed: the day's repeats are done and the
+        // new-card rate still has room. Never "a fresh deck", which is a false statement about a
+        // collection with history behind it (ADR-0006 §8, whose two states predate ADR-0011's rate).
+        ReviewState::NewOnly { new } => {
+            body(ui, &new_only_wording(new));
             count_buttons(ui, new)
         }
         ReviewState::Due { due, new, backlog } => {
@@ -1599,6 +1615,19 @@ fn body(ui: &mut egui::Ui, s: &str) {
 
 /// The box badge: a small, non-interactive indicator, weaker than body text so it never reads as a
 /// call to action.
+/// The picker's statement when nothing is due but cards have never been seen: the fact, then the
+/// invitation, and **no claim that the deck is fresh** — the collection has history behind it.
+///
+/// It states nothing about being behind, because the reviewer is not: reaching this state means the
+/// day's repeats are finished and only ADR-0011 §2's rate stands between them and the rest.
+fn new_only_wording(new: usize) -> String {
+    if new == 1 {
+        "Nothing due right now. One new card, whenever you like.".to_string()
+    } else {
+        format!("Nothing due right now. {new} new cards, whenever you like.")
+    }
+}
+
 /// What the **box badge** reads: the durability box, or `new` for a card with **no review history**
 /// (ADR-0006 §6).
 ///
@@ -1753,6 +1782,20 @@ mod tests {
         assert_eq!(leech_entry_wording(2, 0), "Leeches (2)");
         assert_eq!(leech_entry_wording(0, 3), "Suspended (3)");
         assert_eq!(leech_entry_wording(2, 3), "Leeches (2) · suspended (3)");
+    }
+
+    #[test]
+    fn nothing_due_with_new_cards_left_never_calls_the_deck_fresh() {
+        // The sentence a reviewer with history gets when the day's repeats are done. It states the
+        // fact and invites, and it must not claim freshness (ADR-0006 §8) or imply falling behind.
+        assert_eq!(
+            new_only_wording(1),
+            "Nothing due right now. One new card, whenever you like."
+        );
+        assert_eq!(
+            new_only_wording(4),
+            "Nothing due right now. 4 new cards, whenever you like."
+        );
     }
 
     #[test]

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -604,9 +604,11 @@ fn review(
                 card_face(ui, &rendered.answer);
 
                 // The box badge appears only after reveal, is non-interactive, and reports
-                // durability — never a queue (scheduling `CONTEXT.md`).
+                // durability — never a queue (scheduling `CONTEXT.md`). A card with no review history
+                // reads `new`, never `Box 1`, which would state a durability nothing has measured
+                // (ADR-0006 §6).
                 ui.add_space(4.0);
-                badge(ui, &format!("Box {}", offered.box_));
+                badge(ui, &box_badge_wording(!offered.is_new, offered.box_));
 
                 ui.add_space(12.0);
                 if let Some(grade) = grade_buttons(ui, &offered, today) {
@@ -1305,7 +1307,7 @@ fn editor_cards_body(ui: &mut egui::Ui, pane: Option<&cards::CardPane>) {
                 if !card.answer.is_empty() {
                     card_face(ui, &card.answer);
                 }
-                badge(ui, &format!("Box {}", card.box_));
+                badge(ui, &box_badge_wording(card.reviews > 0, card.box_));
                 ui.add_space(8.0);
             }
             // A dormant entry is a single line — its name, *dormant*, its kept history (ADR-0018 §2).
@@ -1597,6 +1599,30 @@ fn body(ui: &mut egui::Ui, s: &str) {
 
 /// The box badge: a small, non-interactive indicator, weaker than body text so it never reads as a
 /// call to action.
+/// What the **box badge** reads: the durability box, or `new` for a card with **no review history**
+/// (ADR-0006 §6).
+///
+/// The `new` case is not a nicety, and it is the one every call site is liable to drop, because
+/// [`box_of`](leitner_core::scheduling::box_of) is total and answers `1` for a card it has never seen.
+/// `1` is *also* the honest answer for a card reviewed thirty times and never retained — so rendering
+/// the number regardless makes the badge state a durability nothing has measured, on the one card where
+/// the user can tell it is wrong. A first introduction then reads as *bottom box*, a position in a queue
+/// of boxes, which is precisely the reading [ADR-0001 §3] forbids the badge from acquiring; `new` states
+/// the absence of history instead, which is what is true.
+///
+/// It is one function because the badge means one thing wherever it is drawn — the review screen and the
+/// card pane both come through here, and a second `format!("Box {}")` anywhere is this defect returning.
+///
+/// [ADR-0001 §3]: ../../../docs/adr/0001-scheduling-algorithm-and-grade-scale.md
+fn box_badge_wording(reviewed: bool, box_: u8) -> String {
+    if reviewed {
+        format!("Box {box_}")
+    } else {
+        "new".to_string()
+    }
+}
+
+/// A small, non-interactive, weak-coloured footnote carrying bidi-laid text.
 fn badge(ui: &mut egui::Ui, s: &str) {
     ui.label(bidi::job(
         s,
@@ -1727,5 +1753,15 @@ mod tests {
         assert_eq!(leech_entry_wording(2, 0), "Leeches (2)");
         assert_eq!(leech_entry_wording(0, 3), "Suspended (3)");
         assert_eq!(leech_entry_wording(2, 3), "Leeches (2) · suspended (3)");
+    }
+
+    #[test]
+    fn a_card_with_no_review_history_badges_new_not_box_one() {
+        // ADR-0006 §6. `box_of` is total and answers 1 for a never-reviewed card, so the badge has to
+        // ask whether there is any history at all — otherwise a first introduction claims a durability
+        // nothing measured, and reads as the bottom of a queue of boxes (ADR-0001 §3).
+        assert_eq!(box_badge_wording(false, 1), "new");
+        assert_eq!(box_badge_wording(true, 1), "Box 1");
+        assert_eq!(box_badge_wording(true, 4), "Box 4");
     }
 }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -279,14 +279,32 @@ impl LeitnerApp {
     }
 
     /// Open the collection under the platform's two directories (ADR-0007 §6) and, on a first launch,
-    /// seed one `basic` note so the walking skeleton has a card to review — issue #94's opening line.
+    /// seed a few `basic` notes so the walking skeleton has cards to review — issue #94's opening line.
+    ///
+    /// **More than one note, deliberately.** A single card cannot exercise the session at all: the count
+    /// picker collapses to one `All 1` button with none of ADR-0006 §1's choices reachable, and a sitting
+    /// ends on the first grading — so §2's *position is derived, never stored* cannot be demonstrated,
+    /// because there is no mid-session to be force-quit out of (issue #96). One note past
+    /// [`DEFAULT_NEW_CARD_RATE`] keeps the rate itself visible as the binding limit rather than the
+    /// seed's size.
     fn open_store() -> Result<Collection, String> {
+        const SEED: [(&str, &str); DEFAULT_NEW_CARD_RATE as usize + 1] = [
+            ("chien", "dog"),
+            ("chat", "cat"),
+            ("livre", "book"),
+            ("eau", "water"),
+            ("pain", "bread"),
+            ("maison", "house"),
+        ];
+
         let data = leitner_store::platform::data_dir().map_err(|e| e.to_string())?;
         let state = leitner_store::platform::state_dir().map_err(|e| e.to_string())?;
         let mut coll = Collection::open(&data, &state).map_err(|e| e.to_string())?;
         if coll.is_empty().map_err(|e| e.to_string())? {
-            coll.create_note("basic", &[("Front", "chien"), ("Back", "dog")])
-                .map_err(|e| e.to_string())?;
+            for (front, back) in SEED {
+                coll.create_note("basic", &[("Front", front), ("Back", back)])
+                    .map_err(|e| e.to_string())?;
+            }
         }
         Ok(coll)
     }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -308,6 +308,47 @@ impl LeitnerApp {
         }
         Ok(coll)
     }
+
+    /// **Temporary** — the other half of [`reset_control`]. Return this device to a first launch: the
+    /// store removes both databases and the writer marker, then reopening reseeds, because the
+    /// collection comes back empty. Every in-memory screen state goes with them, since all of it
+    /// describes rows that no longer exist.
+    ///
+    /// **This takes the fitted scheduler parameters and the new-card rate with it, and that is a
+    /// first-launch reset rather than a side effect.** Neither is a setting kept off to one side: an
+    /// optimisation run records its vector as a `config-set` **log row** (ADR-0014 §5, ADR-0004 §6), and
+    /// the rate is a value on ADR-0004 §7's mutable surface — both live inside `collection.db`, so
+    /// deleting the log is what deletes them. Afterwards the scheduler is back on the published defaults
+    /// and the settings nudge reads *"Using the standard parameters"* again, which is true. Anyone
+    /// wanting a reset that spares them is asking to keep a projection of a log that no longer exists.
+    ///
+    /// **The open connection is dropped first, and that ordering is the whole of the correctness here.**
+    /// SQLite holds the database plus its `-wal` and `-shm` siblings open; unlinking them underneath a
+    /// live connection leaves a checkpoint writing into inodes nothing can reach, and the reopened
+    /// collection then races the old one's flush. Assigning `store` is what closes it.
+    ///
+    /// The marker goes too, so the device **mints a fresh writer id** — correct here and the opposite of
+    /// what a *restore* may do (store rule 5, [ADR-0016 §2](../../../docs/adr/0016-backup-and-restore.md):
+    /// a writer id is never adopted). A reset device is a new writer, not a returning one.
+    fn reset_collection(&mut self) {
+        self.store = Err("Resetting…".to_owned());
+
+        let dirs = leitner_store::platform::data_dir()
+            .and_then(|data| leitner_store::platform::state_dir().map(|state| (data, state)));
+        if let Ok((data, state)) = dirs {
+            leitner_store::remove_files(&data, &state);
+        }
+
+        self.store = Self::open_store();
+        self.sitting = None;
+        self.editing = None;
+        self.showing_leeches = false;
+        self.session_pointer = None;
+        self.new_card_rate = None;
+        self.deck_filter = None;
+        self.search.clear();
+        self.dest = Destination::Review;
+    }
 }
 
 impl eframe::App for LeitnerApp {
@@ -376,6 +417,7 @@ impl eframe::App for LeitnerApp {
         // The area is taken *before* the closure so it carries guard 1's forced offset without
         // holding a borrow of `band` across the frame the destinations are drawn in.
         let area = self.band.scroll_area();
+        let mut reset_requested = false;
         let out = area.show(ui, |ui| {
             // The persistent affordance that makes all three destinations reachable (ADR-0021 §1):
             // a destination reachable only by completing a session is not reachable, so the nav row
@@ -413,18 +455,27 @@ impl eframe::App for LeitnerApp {
                         &mut self.new_deck,
                     );
                 }
-                Destination::Settings => settings_screen(
-                    ui,
-                    coll,
-                    &mut self.setting_up_sync,
-                    &mut self.new_card_rate,
-                    &mut self.optimise_job,
-                    &mut self.optimise_done,
-                    now_ms,
-                ),
+                Destination::Settings => {
+                    // The wipe cannot happen here: `coll` is borrowed for the whole frame, and the
+                    // reset closes that connection. So the control only *asks*, and the app acts once
+                    // the borrow has ended, below.
+                    reset_requested = settings_screen(
+                        ui,
+                        coll,
+                        &mut self.setting_up_sync,
+                        &mut self.new_card_rate,
+                        &mut self.optimise_job,
+                        &mut self.optimise_done,
+                        now_ms,
+                    );
+                }
             }
         });
         self.band.record(&out);
+
+        if reset_requested {
+            self.reset_collection();
+        }
     }
 }
 
@@ -1380,13 +1431,13 @@ fn settings_screen(
     optimise_job: &mut Option<optimise::OptimiseJob>,
     optimise_done: &mut bool,
     now_ms: i64,
-) {
+) -> bool {
     heading(ui, "Settings");
     ui.add_space(8.0);
 
     if *setting_up {
         enrolment_screen(ui, setting_up);
-        return;
+        return false;
     }
 
     new_card_rate_control(ui, coll, rate_buffer);
@@ -1413,6 +1464,33 @@ fn settings_screen(
     // The removal route and the app name, kept permanently because the folder is hidden and cannot be
     // navigated to (ADR-0015 §10, ADR-0020 §4). Disconnect is the only control this app owns.
     body(ui, &sync::revocation_and_removal());
+
+    ui.add_space(12.0);
+    ui.separator();
+    ui.add_space(8.0);
+    reset_control(ui)
+}
+
+/// **Temporary, and not a specified feature.** A development control that returns this device to a
+/// **first launch** — the collection deleted and reseeded exactly as [`LeitnerApp::open_store`] does it
+/// on a fresh install — so an on-handset verification run does not need a cable and `run-as` to get back
+/// to a known state. Returns whether it was pressed.
+///
+/// **It is a reset, not a delete, and it is not a step towards a user-facing one.** Nothing in this design
+/// removes data: [ADR-0016 §1](../../../docs/adr/0016-backup-and-restore.md) establishes that restore is
+/// a merge and a replace is *not implementable*, because every device holds the whole log and merge is
+/// set union — so a wipe here is undone by the next sync from any peer that still holds those rows. It
+/// is honest only as what it says it is: a local reset on a device being tested against.
+/// [ADR-0015 §10](../../../docs/adr/0015-the-sync-experience.md) separately forbids a control that
+/// deletes *published* data, which this does not touch.
+fn reset_control(ui: &mut egui::Ui) -> bool {
+    body(
+        ui,
+        "Development control — returns this device to a first launch, seed and all. Rows other \
+         devices hold come back on the next sync.",
+    );
+    ui.add_space(4.0);
+    full_width_button(ui, "Reset the collection (temporary)").clicked()
 }
 
 /// The new-card-rate control (ADR-0011 §3): a plain integer field, with the consequence explained

--- a/crates/app/src/session.rs
+++ b/crates/app/src/session.rs
@@ -184,8 +184,17 @@ pub fn crossed_this_session(before: &HashSet<CardRef>, now: &[Leech]) -> Vec<Lee
 pub enum ReviewState {
     /// No cards exist at all — an empty collection.
     Empty,
-    /// Cards exist but none has ever been reviewed: a brand-new deck. Carries how many are waiting.
+    /// Cards exist and **nothing in the collection has ever been reviewed**: a genuinely first look
+    /// (ADR-0006 §8's *"fresh deck, first look"*, whose parenthesis is *zero review history*). Carries
+    /// how many are waiting.
     NewDeck { new: usize },
+    /// Nothing is due, and what is left to offer is cards never yet seen. **Distinct from
+    /// [`NewDeck`](ReviewState::NewDeck), which it looks identical to from the queue alone** — the two
+    /// differ only in whether the collection has any history, and telling a reviewer of four years that
+    /// their deck is fresh is the failure. This state is *routine*, not exceptional: ADR-0011 §2's rate
+    /// caps introductions per day, so "the day's reviews are done and the rate still has room" is the
+    /// ordinary shape of an afternoon. ADR-0006 §8 predates the rate and named only two worded states.
+    NewOnly { new: usize },
     /// Everything reviewed is scheduled ahead; nothing is due. The reassuring resting state.
     CaughtUp,
     /// Cards are due. `backlog` is set when there are more than a comfortable sitting, so the picker
@@ -198,21 +207,29 @@ pub enum ReviewState {
 }
 
 impl ReviewState {
-    /// Classify the queue against the total card count.
-    pub fn of(queue: &Queue, total: usize) -> ReviewState {
+    /// Classify the queue against the total card count and whether the collection has **any** review
+    /// history.
+    ///
+    /// The history flag cannot be recovered from the queue, which is why it is a parameter: a queue of
+    /// new cards with nothing due looks the same whether this is the collection's first minute or its
+    /// fourth year, and only one of those is a fresh deck.
+    pub fn of(queue: &Queue, total: usize, reviewed_ever: bool) -> ReviewState {
         if total == 0 {
             return ReviewState::Empty;
         }
         if queue.due.is_empty() {
-            // Nothing due: a resting state if there is nothing to introduce either, otherwise a
-            // deck of fresh cards waiting — whether *all* the cards are new or only some makes no
-            // difference to how the picker frames them.
-            return if queue.new.is_empty() {
-                ReviewState::CaughtUp
-            } else {
-                ReviewState::NewDeck {
+            // Nothing due. Three different situations, and the copy each gets is a different sentence:
+            // nothing left to introduce either (the resting state), cards waiting in a collection with
+            // no history at all (a first look), or cards waiting in one that has plenty (the day's
+            // reviews are done and ADR-0011 §2's rate still has room).
+            return match (queue.new.is_empty(), reviewed_ever) {
+                (true, _) => ReviewState::CaughtUp,
+                (false, false) => ReviewState::NewDeck {
                     new: queue.new.len(),
-                }
+                },
+                (false, true) => ReviewState::NewOnly {
+                    new: queue.new.len(),
+                },
             };
         }
         ReviewState::Due {
@@ -278,8 +295,36 @@ mod tests {
         assert_eq!(queue.due.len(), 0);
         assert_eq!(queue.new.len(), 2);
         assert_eq!(
-            ReviewState::of(&queue, cards.len()),
+            ReviewState::of(&queue, cards.len(), false),
             ReviewState::NewDeck { new: 2 }
+        );
+    }
+
+    #[test]
+    fn a_queue_of_new_cards_is_a_fresh_deck_only_when_nothing_was_ever_reviewed() {
+        // The two states are **indistinguishable from the queue** — same empty due list, same new
+        // cards — so the history flag is the whole difference, and dropping it tells a reviewer with
+        // years of history that their deck is fresh (ADR-0006 §8's parenthesis is *zero review
+        // history*; ADR-0011 §2's rate makes the other case an everyday one).
+        let notes = [note(1), note(2)];
+        let cards = current(&notes);
+        let queue = compose(
+            &cards,
+            &positions(&notes),
+            &Replayed::default(),
+            0,
+            RATE,
+            &HashSet::new(),
+        );
+        assert_eq!(
+            ReviewState::of(&queue, cards.len(), false),
+            ReviewState::NewDeck { new: 2 },
+            "no history anywhere: a genuine first look"
+        );
+        assert_eq!(
+            ReviewState::of(&queue, cards.len(), true),
+            ReviewState::NewOnly { new: 2 },
+            "history behind it: the day's repeats are done, the rate still has room"
         );
     }
 
@@ -293,7 +338,7 @@ mod tests {
             RATE,
             &HashSet::new(),
         );
-        assert_eq!(ReviewState::of(&queue, 0), ReviewState::Empty);
+        assert_eq!(ReviewState::of(&queue, 0, false), ReviewState::Empty);
     }
 
     #[test]
@@ -421,7 +466,10 @@ mod tests {
             0,
             "a card graded today is excluded on re-derivation"
         );
-        assert_eq!(ReviewState::of(&queue, cards.len()), ReviewState::CaughtUp);
+        assert_eq!(
+            ReviewState::of(&queue, cards.len(), true),
+            ReviewState::CaughtUp
+        );
     }
 
     #[test]
@@ -524,7 +572,10 @@ mod tests {
             queue.due.is_empty(),
             "a suspended card leaves the due queue"
         );
-        assert_eq!(ReviewState::of(&queue, cards.len()), ReviewState::CaughtUp);
+        assert_eq!(
+            ReviewState::of(&queue, cards.len(), true),
+            ReviewState::CaughtUp
+        );
     }
 
     #[test]
@@ -546,7 +597,10 @@ mod tests {
             queue.new.is_empty(),
             "a suspended new card is not introduced"
         );
-        assert_eq!(ReviewState::of(&queue, cards.len()), ReviewState::CaughtUp);
+        assert_eq!(
+            ReviewState::of(&queue, cards.len(), true),
+            ReviewState::CaughtUp
+        );
     }
 
     #[test]
@@ -607,7 +661,7 @@ mod tests {
             RATE,
             &HashSet::new(),
         );
-        match ReviewState::of(&queue, cards.len()) {
+        match ReviewState::of(&queue, cards.len(), true) {
             ReviewState::Due { backlog, due, .. } => {
                 assert!(
                     backlog,

--- a/crates/store/src/collection.rs
+++ b/crates/store/src/collection.rs
@@ -41,6 +41,32 @@ const COLLECTION_DB: &str = "collection.db";
 const DERIVED_DB: &str = "derived.db";
 const WRITER_MARKER: &str = "writer.id";
 
+/// **Temporary — a development affordance, not part of the specified design.** Remove both databases
+/// and the writer marker from the two directories, so the next [`Collection::open`] behaves as a first
+/// launch. Nothing in this design deletes user data
+/// ([ADR-0016 §1](../../../docs/adr/0016-backup-and-restore.md): restore is a merge and a replace is not
+/// implementable, because every peer still holds the whole log) — this exists so a device under test can
+/// be returned to a known state without a cable.
+///
+/// **It lives here because this module names those files**, and the sibling `-wal` and `-shm` files are
+/// SQLite's business rather than a caller's. A copy of these literals in the application would keep
+/// working after a rename here while deleting nothing at all.
+///
+/// Missing files are not an error: the point is the state afterwards, and a partial collection — one
+/// database present, the other already gone — is exactly when this is most wanted. The **caller must
+/// have dropped its [`Collection`] first**; unlinking these underneath a live connection leaves a
+/// checkpoint writing into unreachable inodes.
+pub fn remove_files(data_dir: &Path, state_dir: &Path) {
+    for name in [COLLECTION_DB, DERIVED_DB] {
+        for dir in [data_dir, state_dir] {
+            for suffix in ["", "-wal", "-shm"] {
+                let _ = fs::remove_file(dir.join(format!("{name}{suffix}")));
+            }
+        }
+    }
+    let _ = fs::remove_file(state_dir.join(WRITER_MARKER));
+}
+
 /// The attribute-name prefix that makes a note's tags **settle by set union** (ADR-0002 §10,
 /// ADR-0005 §7). Each tag is its own mutable row — `tag:<name>` set to `"true"` — rather than a
 /// single multi-valued `tags` attribute, so two devices adding different tags offline each write a

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -11,4 +11,6 @@ mod collection;
 mod interchange;
 pub mod platform;
 
-pub use collection::{Collection, MergeReport, SkewWarning, StoreError, TAG_ATTR_PREFIX};
+pub use collection::{
+    Collection, MergeReport, SkewWarning, StoreError, TAG_ATTR_PREFIX, remove_files,
+};

--- a/docs/adr/0006-the-review-session-experience.md
+++ b/docs/adr/0006-the-review-session-experience.md
@@ -146,6 +146,20 @@ Round 1's open-queue variant put this exact badge in front of the repo owner spe
 whether an inert, post-reveal badge starts to read as a claim about the queue. It didn't — the
 badge survived into the final design unchanged.
 
+> **Corrected in #96: `monospace` and the lower-case `"box 3"` were never decided, and this section
+> should not have stated them.** They are the prototype's scaffolding, which **§10 of this same
+> document** disclaims outright — the typography throughout both rounds was "carried over for
+> convenience, never a considered decision". Reading them as specification puts §6 in conflict with §10
+> and hands the visual design pass a face and a letter-case it was promised were open.
+>
+> **What binds here is the badge's *content and conditions*, not its rendering**: small,
+> non-interactive, after reveal and never before, never part of the queue, and **`new` whenever the card
+> has no review history**. That last clause is the one with teeth, and it was the defect actually found
+> on the handset — the box is a total function of memory state, so it answers *1* for a card never seen,
+> and printing that number claims a durability nothing measured while reading as *the bottom box*: the
+> queue-position reading ADR-0001 §3 exists to prevent. The badge renders `Box 3` in the small text
+> style today, which is **conformant** — the case and the face are the design pass's to settle.
+
 ### 7. The header is a persistent dashboard, and backlog is framed, not just reported
 
 Progress (`done / total` against the chosen count, with a progress bar) and the timer sit together
@@ -165,6 +179,19 @@ bare number that reads as falling behind.
 
 "Nothing due right now" and "fresh deck, first look" (zero review history) are both rendered
 states with their own copy, not blank screens or a session that silently has zero cards in it.
+
+> **Amended by [ADR-0011 §2](0011-new-card-rate-and-daily-limits.md): there is a fourth worded state,
+> and this section's two cannot cover it.** A daily new-card rate means *nothing due, but cards you have
+> never seen remain* is the ordinary shape of an afternoon — and from the queue alone it is
+> **indistinguishable** from this section's fresh deck: same empty due list, same new cards on offer.
+> The only difference is whether the collection has any review history at all, which is not a property
+> of the queue, so a picker that reads only the queue must either ask for that fact or state the wrong
+> one. Left implicit, it greets a reviewer of four years with *"a fresh deck, these cards are new"* —
+> observed on the handset in #96 against a collection holding ten reviews.
+>
+> The parenthesis above — *zero review history* — was therefore load-bearing rather than clarifying, and
+> it is the whole of what separates the two. The fourth state states the fact and invites, and says
+> nothing about being behind: reaching it means the day's repeats are **done**.
 
 ### 9. Offline affordances: confirmed structurally
 


### PR DESCRIPTION
Picks up [#96](https://github.com/amin-bf/leitner/issues/96) — the on-device half of the review session, which #94 deliberately left open because a container has no JDK, NDK or handset. Verified on the Pixel 8 Pro (arm64-v8a, debug APK, `source scripts/android-env.sh`).

## The four criteria

- **Reveal by real touch behaves identically to the desktop mouse path.** Confirmed by the repo owner. No divergence needed, none found — ADR-0006 §3 and §5 hold for the shipped app as they did for the prototype.
- **The four grade buttons are reachable and hittable at handset width**, full-width and stacked. Confirmed. The log shows *Forgot* hit six times running on one card before it passed, so ADR-0011 §9's lapse re-show took repeated real taps.
- **Force-quitting mid-session lands back on the count picker with every already-graded card excluded.** Verified, and the on-disk half with it: mid-session (`2 of 3`, card unrevealed), `collection.db` held three tables — `log`, `mutable`, `local` — and **nothing in any of them named a session**. `mutable` carried only `Front`/`Back`/`kind`/`position`/`new_card_rate`; `local` only identity and counters. After `am force-stop` (process confirmed gone) and relaunch: the picker, offering `All 1`, which is arithmetically right — four notes introduced today against a rate of 5 leaves one, and four passes are scheduled ahead.
- **The box badge appears only after reveal** and reads as durability rather than as a queue claim. The post-reveal condition is visible in the mid-session capture: card face and *Edit note*, no badge. The reading was confirmed by the repo owner — against the corrected badge below.

## Two statements the screen was making that were not true

Neither is one of the four criteria. Both are on screens the criteria run through, and both failed *silently* — no error, no failing test, just a false statement on the display.

**A card with no review history badged `Box 1`.** `box_of` is total, so it answers `1` for a card it has never seen — the same answer it gives a card reviewed thirty times and never retained. Printing the number claims a durability nothing has measured, and on a first introduction it reads as *the bottom box*: the queue-position reading ADR-0001 §3 exists to prevent. ADR-0006 §6 specifies `new`; `Offered` already carried `is_new` and nothing read it. One wording function now serves both surfaces that draw the badge — the authoring card pane had the same defect via `LiveCard.reviews`.

**A collection with ten reviews was greeted with "A fresh deck. These cards are new."** `session.rs` contradicted itself: `NewDeck` is documented as *"none has ever been reviewed"*, while the classifier returned it whenever nothing was due and anything was new. Two situations were collapsed — a first look at this collection, and the day's repeats being done while ADR-0011 §2's rate still has room. The second is routine, created by the rate every day; ADR-0006 §8 named two worded states because it predates the rate. They are indistinguishable from the queue alone, so `ReviewState::of` now takes whether any review exists at all.

Both are recorded where the next reader meets them: **Box badge**, **Fresh deck** and **Nothing due** in `crates/app/src/CONTEXT.md`, and an *Amended by ADR-0011 §2* note on ADR-0006 §8. No new ADR — nothing here is hard to reverse or a live trade-off, which fails two of the three tests.

**ADR-0006 §6 is corrected rather than implemented** on one point: its `monospace` and lower-case `"box 3"` are disclaimed by §10 of the same document, which says the prototype's typography throughout was never a considered decision. Stating them as specification put the two sections in conflict and pre-empted a design pass promised those choices. What binds is the badge's content and conditions.

## Also here

- **The first-launch seed is six notes, not one.** One card could not exercise the session: the picker collapsed to a single `All 1` with none of ADR-0006 §1's choices reachable, and a sitting ended on its first grading — so there was no mid-session to force-quit out of. Six is one past the rate, so the rate stays visible as the binding limit.
- **A temporary collection reset in settings**, marked as such in both halves, so a device under test returns to a first launch without a cable and `run-as`. It is a reset, not a delete, and not a step toward a user-facing one: ADR-0016 §1 establishes that a replace is not implementable, since every peer still holds the whole log. The store owns the deletion because it names those files and their `-wal`/`-shm` siblings; the connection is dropped first, or a checkpoint writes into unreachable inodes. The fitted parameters and the new-card rate go with it — `config-set` is a log row and the rate is on the mutable surface, both inside `collection.db` — which is first-launch semantics rather than a side effect.

## Feedback loops

`cargo fmt --check` clean. **Every commit independently** passes `cargo clippy --all-targets --all-features -D warnings` and `cargo test --workspace`, verified with `git rebase --exec`. Two new tests pin the two defects. `cargo apk build` and install on the handset for each round above.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)