### PR TITLE
Client Stack / Verify Persian, Arabic and IPA on the Handset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,15 @@ because they are validated findings, not because a web build ships.
    logical order, so a plain `ui.label("…")` renders Persian and Arabic with the words backwards, and
    Arabic-Indic digits reversed. Build a `LayoutJob` with sections in visual order instead. A
    `ui.label` on card content is a bug, not a style choice.
+   **That job's sections are pushed by hand, and `LayoutJob::append` may never come back.** It merges
+   into the previous section whenever the format matches — sensible for sections carrying only a
+   colour, fatal where **the section boundaries are the reordering**. Merged, the paragraph becomes
+   one shaping run, harfrust infers RTL for it, and it reverses the order the helper just put the
+   words in. What hid that is rule 7's other half: runs are re-split by **face** below the merge, so
+   wherever the spaces come from a different face than the words the order survives by accident. It
+   did in `Proportional` and `Monospace`, and did not in `bold`, where one face owns both — Persian
+   rendered backwards there and only there. Every test asserting on the job's *text* passes either
+   way; only laying it out through real faces tells them apart.
 2. **`TextEdit` needs the same treatment, via `.layouter()`** — it lays out its own text and
    otherwise bypasses the helper. Note that caret and selection are then in visual order while the
    buffer is logical, so RTL editing is imprecise; design around it rather than fighting it.
@@ -215,7 +224,15 @@ because they are validated findings, not because a web build ships.
    alongside `android-native-activity`.
 7. **Fonts are ours to ship — and must be installed on the first frame, not in `CreationContext`.**
    egui bundles only Hack, Ubuntu-Light and Noto Emoji. Register any added face in **every** family
-   you use, including `Monospace`, or text silently renders as boxes. Registering during creation
+   you use, or text silently renders as boxes. **That is three families, not the two this rule used
+   to name** — `Proportional`, `Monospace` and ADR-0012 §8's `bold`, enumerated once in
+   `fonts::families()`, which install, the coverage test and the specimen all read so a fourth cannot
+   be added to only one of them. Bold is the one to watch: it is built from scratch rather than
+   appended to, so nothing of egui's sits behind it. **And within a family, order decides which face
+   is reached** — first match wins, and more than one shipped face carries the Arabic script, so
+   DejaVu listed ahead of Noto meant Noto was never reached and Persian was drawn by DejaVu's
+   afterthought Arabic. A glyph existing is not the same as the right face drawing it, and the
+   difference is invisible to anyone who does not read the script. Registering during creation
    breaks the web build: wgpu panics with "Tried to update a texture that has not been allocated
    yet", glow renders everything near-black. Defer it one frame.
 8. **Android text input is ASCII-only, and cannot be fixed here.** winit's Android backend handles

--- a/crates/app/src/CONTEXT.md
+++ b/crates/app/src/CONTEXT.md
@@ -196,6 +196,25 @@ third of *carrying the patch*. All three live where every screen with a text fie
 _Avoid_: Keyboard fix, IME workaround; and never key any of them on a per-frame "something is focused
 and the pointer went down", which is what issued 72 show requests from one scroll gesture.
 
+**Family** / **Face**:
+Two words this crate had been using as one, which is how two silent defects hid at once. A **family**
+is what a caller *asks for* — `Proportional`, `Monospace`, `bold` — and there are exactly three,
+enumerated in `fonts::families()`. A **face** is the font file that actually *draws* a given
+character, resolved per character by **first match** down the family's list. So "register a face in
+every family" and "which face is reached" are different claims, and only the first was ever written
+down: DejaVu Sans Bold carries a partial Arabic block, so listing it ahead of Noto Sans Arabic Bold
+meant Noto was never reached and every bold Persian word was drawn by a face that carries the script
+as an afterthought. It rendered, so nothing complained. **A glyph existing is not the same as the
+right face drawing it.**
+_Avoid_: Font for either one — it is the word that lets the two collapse.
+
+**Shaping run**:
+The unit epaint hands to the shaper, and the unit whose *internal* order the shaper is free to
+reverse. It is **not** the section: sections with a matching format are merged, and the merged text
+is then re-split by **face**. This is why the bidi helper pushes its sections by hand — see the rules
+below. The distinction is only visible in a rendering, never in the job's text.
+_Avoid_: Section and run as synonyms; "epaint lays out sections in order" as a complete statement.
+
 **Last caught up**:
 The only resting statement the app makes about sync — *when* it last completed one, a fact.
 **Never "in sync"**: after a sync the app knows every writer's highest *published* sequence, and
@@ -271,6 +290,14 @@ _Avoid_: Train, recalculate, sync parameters — and never a threshold, a badge 
 - **All user-visible text goes through `bidi`.** egui places text runs left-to-right in logical
   order, so a plain `ui.label("…")` renders Persian with the words backwards and Arabic-Indic digits
   reversed. This is the single most likely way to break the app without any test failing.
+- **`bidi` pushes its sections by hand, and `LayoutJob::append` must never return.** `append` merges
+  into the previous section when the format matches, and in this module **the section boundaries are
+  the reordering** — merged, the paragraph is one shaping run, the shaper infers RTL and reverses the
+  order the module just produced. It survived because runs are re-split by *face*, so the order held
+  wherever the spaces came from a different face than the words: right in `Proportional` and
+  `Monospace`, backwards in `bold`. The seventeen tests asserting on `job.text` pass either way;
+  `every_family_draws_the_sections_in_the_order_they_were_given` lays it out through real faces in
+  every family and is the only one that can tell.
 - **`TextEdit` needs the same treatment, via `.layouter()`** — it lays out its own text and
   otherwise bypasses the helper. Caret and selection are then in visual order while the buffer is
   logical, so RTL editing is imprecise; design around it rather than fighting it.
@@ -282,10 +309,12 @@ _Avoid_: Train, recalculate, sync parameters — and never a threshold, a badge 
   partial state to repair. Never schedule it, and never tell the user a started job is still
   progressing (ADR-0014 §3).
 - **Fonts are installed on the first frame, never in `CreationContext`**, and every added face must
-  be registered in **every** family including `Monospace`, or text silently renders as boxes. The
-  shipped set lives in `fonts` — Noto Sans Arabic (Persian) and DejaVu Sans (the IPA extensions the
-  bundled Latin faces lack) as fallbacks, plus a bold cut of each in its own family. The install
-  frame draws nothing: a newly-named family is not referenceable until the next pass (ADR-0012 §8).
+  be registered in **every** family, of which there are **three** — `fonts::families()` is the
+  enumeration, read by install, by the coverage test and by the specimen alike. The shipped set lives
+  in `fonts` — Noto Sans Arabic (Persian) and DejaVu Sans (the IPA extensions the bundled Latin faces
+  lack) as fallbacks, plus a bold cut of each in its own family, **Arabic first in both lists**,
+  because both faces carry the Arabic script and first match wins. The install frame draws nothing: a
+  newly-named family is not referenceable until the next pass (ADR-0012 §8).
 - **Bold is a face, never a colour — this is the note the editor meets.** There is no synthetic
   emboldening: epaint has none, and `RichText::strong` only *brightens*, which is invisible against
   this near-white body (measured as "I can't see bold"). To draw the `**bold**` Markdown subset

--- a/crates/app/src/bidi.rs
+++ b/crates/app/src/bidi.rs
@@ -16,10 +16,25 @@
 //! order the runs: it places them left-to-right in logical order, which is why a Persian sentence
 //! comes out with its words backwards while each word looks right.
 //!
-//! epaint's own docs say "each section is an independent shaping run", and sections are laid out in
-//! the order given. So we run the Unicode bidi algorithm ourselves and hand egui a `LayoutJob`
-//! whose **sections are already in visual order**, each still holding its text in logical order so
-//! shaping is untouched.
+//! A section is an independent shaping run, and sections are laid out in the order given. So we run
+//! the Unicode bidi algorithm ourselves and hand egui a `LayoutJob` whose **sections are already in
+//! visual order**, each still holding its text in logical order so shaping is untouched.
+//!
+//! # Sections are built by hand, because `LayoutJob::append` would merge them away
+//!
+//! `append` merges into the previous section whenever the format matches and the leading space is
+//! zero — a sensible optimisation for text whose sections carry only colour, and fatal here, where
+//! **the section boundaries are the reordering**. Merged, the whole paragraph becomes one shaping
+//! run, harfrust infers RTL for it, and it reverses the very order this module put the words in:
+//! the sentence comes out backwards, which is precisely the defect being fixed.
+//!
+//! What made that survive for so long is that the merge is only *visible* when one face covers the
+//! whole run. Runs are re-split by **font face** below the merge, so in `Proportional` and
+//! `Monospace` the spaces between the words come from egui's Latin face while the words come from
+//! Noto Sans Arabic — the split falls at every space and the word order happens to hold. The bold
+//! family is one face throughout, so nothing split it and Persian rendered backwards there and only
+//! there (measured on the handset, issue #97). **Do not restore `append`**: it would leave this
+//! module's correctness resting on which face happens to own U+0020.
 //!
 //! **Every user-visible string goes through here.** A plain `ui.label("…")` on card content is a
 //! bug, not a style choice — see `AGENTS.md` rule 1. `TextEdit` needs the same treatment via
@@ -29,8 +44,24 @@
 //! If epaint ever implements bidi upstream, **delete this module** rather than keeping it
 //! alongside — two bidi passes would double-reverse (ADR-0003 Consequences).
 
-use egui::text::{LayoutJob, TextFormat};
+use egui::text::{ByteIndex, LayoutJob, LayoutSection, TextFormat};
 use egui::{Color32, FontId};
+
+/// Append `text` to `job` as a section of its **own**, never merged into the one before it.
+///
+/// This is `LayoutJob::append` with the merge left out — see the module header for why that merge
+/// destroys the ordering below. Everything else is identical: the text is concatenated, the section
+/// spans what was just added, and the leading space stays zero (a non-zero one would also defeat
+/// the merge, at the cost of a visible gap).
+fn push(job: &mut LayoutJob, text: &str, fmt: &TextFormat) {
+    let start = ByteIndex(job.text.len());
+    job.text.push_str(text);
+    job.sections.push(LayoutSection {
+        leading_space: 0.0,
+        byte_range: start..ByteIndex(job.text.len()),
+        format: fmt.clone(),
+    });
+}
 
 /// Arabic-Indic digits carry the Arabic script property, so `guess_segment_properties()` infers
 /// RTL for them and epaint emits them right-to-left — `۱۲۳۴۵` comes out as `۵۴۳۲۱`. Numbers are
@@ -97,7 +128,7 @@ pub fn job(text: &str, font_id: FontId, color: Color32) -> LayoutJob {
 
     let info = BidiInfo::new(text, None);
     if info.paragraphs.is_empty() {
-        job.append(text, 0.0, fmt);
+        push(&mut job, text, &fmt);
         return job;
     }
 
@@ -134,7 +165,7 @@ pub fn job(text: &str, font_id: FontId, color: Color32) -> LayoutJob {
                     let words: Vec<&str> = slice.split(' ').collect();
                     for (i, w) in words.iter().rev().enumerate() {
                         if i > 0 {
-                            job.append(" ", 0.0, fmt.clone());
+                            push(&mut job, " ", &fmt);
                         }
                         append_rtl_word(&mut job, w, &fmt);
                     }
@@ -144,20 +175,16 @@ pub fn job(text: &str, font_id: FontId, color: Color32) -> LayoutJob {
                     // lands here.
                     for (i, w) in slice.split(' ').enumerate() {
                         if i > 0 {
-                            job.append(" ", 0.0, fmt.clone());
+                            push(&mut job, " ", &fmt);
                         }
-                        job.append(&fix_digits(w), 0.0, fmt.clone());
+                        push(&mut job, &fix_digits(w), &fmt);
                     }
                 }
             }
         }
 
         if sep > 0 {
-            job.append(
-                &text[para.range.end - sep..para.range.end],
-                0.0,
-                fmt.clone(),
-            );
+            push(&mut job, &text[para.range.end - sep..para.range.end], &fmt);
         }
     }
     job
@@ -210,7 +237,7 @@ fn append_rtl_word(job: &mut LayoutJob, word: &str, fmt: &TextFormat) {
     let flip = |s: &str| -> String { s.chars().rev().map(mirror).collect() };
     let Some(start) = word.find(is_core) else {
         // All punctuation: still mirrored, but there is no core for it to sit beside.
-        job.append(&flip(word), 0.0, fmt.clone());
+        push(job, &flip(word), fmt);
         return;
     };
     let end = word
@@ -221,11 +248,11 @@ fn append_rtl_word(job: &mut LayoutJob, word: &str, fmt: &TextFormat) {
     // Visual order inside an RTL run: what trailed the word now leads it, and vice versa.
     let (leading, core, trailing) = (&word[..start], &word[start..end], &word[end..]);
     if !trailing.is_empty() {
-        job.append(&flip(trailing), 0.0, fmt.clone());
+        push(job, &flip(trailing), fmt);
     }
-    job.append(&fix_digits(core), 0.0, fmt.clone());
+    push(job, &fix_digits(core), fmt);
     if !leading.is_empty() {
-        job.append(&flip(leading), 0.0, fmt.clone());
+        push(job, &flip(leading), fmt);
     }
 }
 
@@ -425,6 +452,67 @@ mod tests {
             assert_eq!(drawn.rect.min.x, 0.0);
             assert!(drawn.rect.max.x > 0.0);
         });
+    }
+
+    /// The ordering above is a claim about **sections**; this is the claim about **pixels**, and
+    /// nothing else in the suite connects the two.
+    ///
+    /// Every test up to here asserts on `job.text` — the string the sections spell out — which is
+    /// right and was not enough: a merged `LayoutJob` spells out exactly the same string and then
+    /// draws it backwards, because harfrust reverses a run it infers as RTL. So this lays the
+    /// sentence out through real faces, in **every family**, and reads the order back off the
+    /// glyphs' x coordinates. It caught the bold family drawing Persian right-to-left while the
+    /// other two were correct — the same string, the same sections, three renderings, one wrong
+    /// (issue #97).
+    ///
+    /// Two assertions, because either alone passes the broken build. The families must **agree**,
+    /// which is what a face-dependent mechanism breaks; and the full stop must sit at the **visual
+    /// left**, which is the absolute anchor a unanimous regression would otherwise sail past.
+    ///
+    /// It installs the shipped faces rather than using the stock ones, since the whole question is
+    /// which face owns which character.
+    #[test]
+    fn every_family_draws_the_sections_in_the_order_they_were_given() {
+        let ctx = egui::Context::default();
+        crate::fonts::install(&ctx);
+        // `set_fonts` applies at the start of the *next* pass (ADR-0012 §8).
+        let _ = ctx.run_ui(Default::default(), |_| {});
+
+        let mut rendered: Vec<(egui::FontFamily, String)> = Vec::new();
+        for family in crate::fonts::families() {
+            let mut job = job(
+                "سگ در خانه است.",
+                FontId::new(20.0, family.clone()),
+                Color32::WHITE,
+            );
+            job.wrap.max_width = 1000.0;
+            let galley = ctx.fonts_mut(|f| f.layout_job(job));
+
+            // Zero-advance glyphs are the continuation entries epaint emits for the rest of a
+            // cluster; they all sit at the cluster's own x and say nothing about order.
+            let mut glyphs: Vec<_> = galley.rows[0]
+                .glyphs
+                .iter()
+                .filter(|g| 0.0 < g.advance_width)
+                .collect();
+            glyphs.sort_by(|a, b| a.pos.x.total_cmp(&b.pos.x));
+            let order: String = glyphs.iter().map(|g| g.chr).collect();
+
+            assert!(
+                order.starts_with('.'),
+                "{family:?} drew {order:?} — the full stop must be at the visual left"
+            );
+            rendered.push((family, order));
+        }
+
+        let (first_family, first_order) = &rendered[0];
+        for (family, order) in &rendered[1..] {
+            assert_eq!(
+                order, first_order,
+                "{family:?} drew {order:?} but {first_family:?} drew {first_order:?} — a family \
+                 must not change the order of the words"
+            );
+        }
     }
 
     #[test]

--- a/crates/app/src/fonts.rs
+++ b/crates/app/src/fonts.rs
@@ -16,8 +16,9 @@
 //! Both are registered into **every family in use**, because a face missing from one renders as
 //! boxes there silently (ADR-0003 §4, client-stack rule 7). That is now **three** families, not the
 //! two rule 7 was written against — [`families`] is the enumeration, and [`bold_family`] is the
-//! third — and the one most easily missed, because it is built from scratch rather than appended
-//! to, so nothing of egui's own sits behind it.
+//! third. Two things follow that the two-family version never had to say: the bold family is built
+//! from scratch, so nothing of egui's own sits behind it, and **within a family, order decides which
+//! face is reached** — first match wins, and more than one of these faces carries the Arabic script.
 //!
 //! Installation is deferred to the first frame ([`crate::LeitnerApp`] guards it), never done in
 //! `CreationContext`: registering a face during creation was measured to break rendering on some
@@ -110,7 +111,8 @@ pub fn install(ctx: &egui::Context) {
     let mut fonts = FontDefinitions::default();
 
     // Regular faces, appended to the existing families so egui's own faces still win where they
-    // have the glyph — a face absent from a family renders as boxes there silently.
+    // have the glyph — and `ar` before `dejavu`, because both carry the Arabic script and the first
+    // match is the one reached (see the bold list below, where that ordering was wrong).
     let regular = [
         (
             "ar",
@@ -119,16 +121,22 @@ pub fn install(ctx: &egui::Context) {
         ("dejavu", &include_bytes!("../assets/DejaVuSans.ttf")[..]),
     ];
     // The bold cut of each writing system, gathered into its own family (see `bold_family`).
-    // DejaVu-bold is first so the Latin/IPA body it usually wraps stays in the same face;
-    // Arabic-bold follows so Persian rendered bold is *bold*, not a fall back to tofu.
+    //
+    // **Arabic-bold goes first, for the same reason `ar` precedes `dejavu` above.** Face resolution
+    // is first match wins, and DejaVu Sans Bold carries a partial Arabic block — 165 code points to
+    // Noto's 256, including `گ چ پ ژ` — so listing it first meant Noto Sans Arabic Bold was never
+    // reached for *any* Arabic-script character and every bold Persian word was drawn by DejaVu's
+    // afterthought Arabic. It rendered, which is why nothing complained. Noto takes the Arabic
+    // script; Latin and the IPA extensions fall through to DejaVu-bold, which Noto does not carry
+    // (16 of 95 printable ASCII, none of them a letter), so nothing else moves.
     let bold = [
-        (
-            "dejavu-bold",
-            &include_bytes!("../assets/DejaVuSans-Bold.ttf")[..],
-        ),
         (
             "ar-bold",
             &include_bytes!("../assets/NotoSansArabic-Bold.ttf")[..],
+        ),
+        (
+            "dejavu-bold",
+            &include_bytes!("../assets/DejaVuSans-Bold.ttf")[..],
         ),
     ];
 
@@ -158,7 +166,7 @@ pub fn install(ctx: &egui::Context) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use egui::FontId;
+    use egui::{Color32, FontId};
 
     /// Run one full pass so `set_fonts` takes effect, then hand back the context. `set_fonts`
     /// applies at the *start* of the next pass, so a caller that queries coverage in the same frame
@@ -172,38 +180,103 @@ mod tests {
 
     /// Every added face must cover its script in **every family the app draws with** — a face
     /// registered only in `Proportional` renders as boxes in `Monospace` with no test failing
-    /// anywhere (ADR-0003 §4, client-stack rule 7). So the scripts the shipped faces exist to
-    /// provide — Persian (the four letters Arabic lacks, plus Persian ی/ک), Arabic, the IPA
-    /// extension symbols of `deːɐ̯ hʊnt`, and Arabic-Indic digits — are each checked against both
-    /// families.
+    /// anywhere (ADR-0003 §4, client-stack rule 7). The families come from [`families`], so a fourth
+    /// is checked the day it is added rather than the day someone notices boxes.
     ///
-    /// The strings hold **no ASCII Latin**, and deliberately: egui's own Hack sits first in
-    /// `Monospace` and carries the replacement glyph, so `has_glyph` reports a false negative for
-    /// every character Hack itself covers (its own documented `TODO`). ASCII is egui's to draw and
-    /// is not what this ticket ships; the `deːɐ̯ hʊnt` example renders because its Latin base is
-    /// Hack/Ubuntu-Light and the symbols below are ours.
+    /// The characters come from [`SPECIMENS`], which is also what the handset specimen draws: this
+    /// test then answers *is the glyph there*, and the screen answers *is it in the right place* —
+    /// the half no headless check can reach (issue #97). Two lists would let each half cover a script
+    /// the other does not.
+    ///
+    /// Whitespace and format controls are skipped: a space has no glyph and the zero-width
+    /// non-joiner has none *by definition*, which makes neither less load-bearing — `می‌روم` needs
+    /// the ZWNJ — so the join it produces is checked by eye on the specimen, where its absence is
+    /// what would show.
     #[test]
     fn every_added_face_covers_its_script_in_every_family() {
         let ctx = installed();
-        let scripts = [
-            ("Persian", "گچپژکی"),
-            ("Arabic", "مرحبا"),
-            ("IPA extensions", "ːɐ̯ʊ"),
-            ("Arabic-Indic digits", "۱۲۳٤٥"),
-        ];
-        for family in [FontFamily::Proportional, FontFamily::Monospace] {
+        for family in families() {
             let font_id = FontId::new(14.0, family.clone());
-            for (label, s) in scripts {
-                for c in s.chars() {
+            for (caption, specimen) in SPECIMENS {
+                for c in specimen
+                    .chars()
+                    .filter(|c| c.is_alphanumeric() || is_symbol(*c))
+                {
                     assert!(
-                        ctx.fonts_mut(|f| f.has_glyph(&font_id, c)),
-                        "family {family:?} is missing {label} glyph {c:?} \
-                         (U+{:04X}) — it would render as a box",
+                        draws(&ctx, &font_id, c),
+                        "family {family:?} draws {c:?} (U+{:04X}) as a box — from the specimen \
+                         {caption:?}",
                         u32::from(c)
                     );
                 }
             }
         }
+    }
+
+    /// **A glyph existing is not the same as the right face drawing it**, and the difference is
+    /// invisible in a screenshot to anyone who does not read the script.
+    ///
+    /// Face resolution is *first match wins* over the family's list, and DejaVu Sans carries a
+    /// partial Arabic block — 165 code points against Noto Sans Arabic's 256, the Persian-specific
+    /// `گ چ پ ژ` among them. So a family that lists DejaVu ahead of Noto never reaches Noto for
+    /// **any** Arabic-script character: the text draws, the coverage test above passes, and Persian
+    /// is rendered by a face that carries it as an afterthought. That is what the bold family did.
+    ///
+    /// The check is that the face drawing Persian is **not** the face drawing Latin, which is what
+    /// distinguishes *the Arabic face was reached* from *the Latin face happened to have it*. Faces
+    /// are told apart by their own ascent and line height, which epaint records per glyph.
+    #[test]
+    fn the_arabic_face_draws_the_arabic_script_in_every_family() {
+        let ctx = installed();
+        for family in families() {
+            let font_id = FontId::new(14.0, family.clone());
+            let face = |c: char| {
+                let g = ctx.fonts_mut(|f| {
+                    f.layout_no_wrap(c.to_string(), font_id.clone(), Color32::WHITE)
+                });
+                let g = g.rows[0].glyphs[0];
+                (g.font_face_ascent.to_bits(), g.font_face_height.to_bits())
+            };
+            for c in "گچپژکیسلام".chars() {
+                assert_ne!(
+                    face(c),
+                    face('a'),
+                    "family {family:?} draws {c:?} with the same face as Latin — the Arabic face is \
+                     behind a face that also carries {c:?}, so it is never reached"
+                );
+            }
+        }
+    }
+
+    fn is_symbol(c: char) -> bool {
+        // The IPA length mark and the stress marks are modifier letters and punctuation, not
+        // alphanumerics, and they are exactly what `deːɐ̯ hʊnt` is shipped to draw.
+        matches!(c, 'ː' | 'ˈ' | 'ˌ' | '\u{032F}')
+    }
+
+    /// True when `c` really draws in `font_id`'s family — that is, when the glyph it lays out to is
+    /// **not the replacement box**.
+    ///
+    /// # Why not `Fonts::has_glyph`
+    ///
+    /// `has_glyph` is `resolve_face(c) != replacement_face_key`: it asks whether the face that owns
+    /// `c` is the same face that owns `U+FFFD`. That is a false negative for **every character
+    /// covered by whichever face owns the replacement glyph**, which is not a corner case here —
+    /// it is most of two families. In `Monospace` egui's own Hack owns `U+FFFD`, so `has_glyph`
+    /// answers *no* for `θ ð ŋ æ œ ø`, all of which Hack draws perfectly well. In
+    /// [`bold_family`] DejaVu-Bold owns it and DejaVu-Bold covers nearly everything, so `has_glyph`
+    /// answers *no* for the entire specimen — a test built on it would have reported the bold family
+    /// as totally broken while it renders fine.
+    ///
+    /// Laying the character out and comparing its texture rectangle against `U+FFFD`'s answers the
+    /// question actually being asked — *does a box appear* — for every family the same way.
+    fn draws(ctx: &egui::Context, font_id: &FontId, c: char) -> bool {
+        let uv = |c: char| {
+            let galley =
+                ctx.fonts_mut(|f| f.layout_no_wrap(c.to_string(), font_id.clone(), Color32::WHITE));
+            galley.rows.first()?.glyphs.first().map(|g| g.uv_rect)
+        };
+        uv(c).is_some() && uv(c) != uv('\u{FFFD}')
     }
 
     /// Bold is a heavier **face**, not a brighter colour: measuring the laid-out width proves a

--- a/crates/app/src/fonts.rs
+++ b/crates/app/src/fonts.rs
@@ -13,8 +13,11 @@
 //!   Cyrillic still come from egui's own Hack / Ubuntu-Light wherever they have the glyph, because
 //!   the added faces are appended as **fallbacks**.
 //!
-//! Both are registered into **every family in use** — `Proportional` *and* `Monospace` — because a
-//! face missing from one family renders as boxes there silently (ADR-0003 §4, client-stack rule 7).
+//! Both are registered into **every family in use**, because a face missing from one renders as
+//! boxes there silently (ADR-0003 §4, client-stack rule 7). That is now **three** families, not the
+//! two rule 7 was written against — [`families`] is the enumeration, and [`bold_family`] is the
+//! third — and the one most easily missed, because it is built from scratch rather than appended
+//! to, so nothing of egui's own sits behind it.
 //!
 //! Installation is deferred to the first frame ([`crate::LeitnerApp`] guards it), never done in
 //! `CreationContext`: registering a face during creation was measured to break rendering on some
@@ -46,14 +49,68 @@ pub fn bold_family() -> FontFamily {
     FontFamily::Name("bold".into())
 }
 
+/// Every family this crate draws with, and therefore every family a face must be registered into.
+///
+/// **The count is not two.** Client-stack rule 7 says "every family you use, including `Monospace`",
+/// which was written when there were two; ADR-0012 §8's [`bold_family`] is a third, and it is the one
+/// most likely to be missed, because it is *built from scratch* rather than appended to — nothing of
+/// egui's own sits behind it, so a script absent from the two bold cuts has no fallback at all. Both
+/// readers of this list — the coverage test below and the on-screen specimen (issue #97) — take it
+/// from here, so a fourth family cannot be added without both of them following.
+pub(crate) fn families() -> [FontFamily; 3] {
+    [
+        FontFamily::Proportional,
+        FontFamily::Monospace,
+        bold_family(),
+    ]
+}
+
+/// The rendering specimen: each script the shipped faces exist for, paired with **what it must read**.
+///
+/// One list, two readers: [`every_added_face_covers_its_script_in_every_family`] checks coverage
+/// headlessly, and the temporary settings block draws exactly these strings on the handset so a reader
+/// of the script can confirm the ordering the test cannot see (issue #97). Two lists would let the
+/// screen show a script the test never checks — and a missing glyph is silent in both directions.
+///
+/// The captions carry no Persian or Arabic themselves. A caption is the statement being checked
+/// *against*, so it has to be readable even on the run where the rendering is what is broken.
+pub(crate) const SPECIMENS: [(&str, &str); 7] = [
+    (
+        "Persian — the dog is in the house; the full stop belongs at the far left",
+        "سگ در خانه است.",
+    ),
+    ("Arabic — the book is on the table", "الكتاب على الطاولة"),
+    (
+        "Persian-only letters (the four Arabic lacks), then mi-ravam with its zero-width non-joiner",
+        "گچپژ می\u{200C}روم",
+    ),
+    (
+        "Mixed scripts and digits — the Persian digits read one-two-three, and the brackets enclose \
+         the Latin rather than sitting beside it",
+        "تمرین ۱۲۳ (page 45)",
+    ),
+    (
+        "Arabic-Indic digits, then Persian digits — each reads left to right, one to five and six \
+         to zero",
+        "١٢٣٤٥ ۶۷۸۹۰",
+    ),
+    (
+        "IPA — ADR-0002 §9's own pronunciation example, and the reason DejaVu is shipped",
+        "deːɐ̯ hʊnt",
+    ),
+    (
+        "IPA, wider — every symbol a glyph, none of them a box",
+        "ɸθðʃʒŋɲʎɫæœøɜɾʔ ˈˌː",
+    ),
+];
+
 /// Install the shipped faces into `ctx`. Call **once, on the first frame** — see the module header
 /// and [`crate::LeitnerApp`].
 pub fn install(ctx: &egui::Context) {
     let mut fonts = FontDefinitions::default();
 
     // Regular faces, appended to the existing families so egui's own faces still win where they
-    // have the glyph, and into *both* families in use — a face absent from `Monospace` renders as
-    // boxes there silently.
+    // have the glyph — a face absent from a family renders as boxes there silently.
     let regular = [
         (
             "ar",
@@ -80,14 +137,20 @@ pub fn install(ctx: &egui::Context) {
             .font_data
             .insert(name.into(), Arc::new(FontData::from_static(bytes)));
     }
-    for family in [FontFamily::Proportional, FontFamily::Monospace] {
-        let list = fonts.families.entry(family).or_default();
-        list.extend(regular.iter().map(|&(name, _)| name.into()));
+    // Driven by `families()` so the enumeration the test and the specimen read is the same one that
+    // installs — a family added there is registered here without a second edit.
+    for family in families() {
+        if family == bold_family() {
+            // Bold is built *from scratch*, not appended to: it must hold the bold cuts and nothing
+            // else, or the regular faces sit in front of them and bold silently stops being bold.
+            fonts
+                .families
+                .insert(family, bold.iter().map(|&(name, _)| name.into()).collect());
+        } else {
+            let list = fonts.families.entry(family).or_default();
+            list.extend(regular.iter().map(|&(name, _)| name.into()));
+        }
     }
-    fonts.families.insert(
-        bold_family(),
-        bold.iter().map(|&(name, _)| name.into()).collect(),
-    );
 
     ctx.set_fonts(fonts);
 }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1468,7 +1468,71 @@ fn settings_screen(
     ui.add_space(12.0);
     ui.separator();
     ui.add_space(8.0);
-    reset_control(ui)
+    let reset = reset_control(ui);
+
+    ui.add_space(12.0);
+    ui.separator();
+    ui.add_space(8.0);
+    rendering_specimen(ui);
+
+    reset
+}
+
+/// **Temporary, and not a specified feature.** The rendering specimen: every script the shipped faces
+/// exist for, drawn in every family they are registered into, so issue #97's criteria can be read off
+/// one screen by someone who reads the script.
+///
+/// **It is here because the handset cannot be asked any other way.** Client-stack rule 8 makes Android
+/// text input ASCII-only — there is no IME path, so a Persian sentence can never be *typed* on the
+/// device — and a screenshot compared against a reference image only tells a non-reader that something
+/// shaped like Persian appeared. So the strings ship in the binary, each above what it must read, and
+/// the judgement handed over is the one only a reader can make.
+///
+/// **Three families, drawn one under the other on purpose.** A face is resolved per family and per
+/// character, so the same string can be right in `Proportional` and wrong in `Monospace` or in
+/// [`fonts::bold_family`] with nothing failing anywhere (client-stack rule 7). Stacking them puts the
+/// three renderings of one string side by side, which is the only way a wrong *face* — as opposed to a
+/// missing glyph — shows up at all: it draws, it just draws in the wrong hand.
+///
+/// It goes through [`bidi::job`] like every other string in the app, because half of what is being
+/// checked is the ordering that helper produces (client-stack rule 1) rather than the glyphs alone.
+fn rendering_specimen(ui: &mut egui::Ui) {
+    body(
+        ui,
+        "Development control — every script the shipped faces exist for, in every family. Each line \
+         below is the same text drawn by a different family; check it against the caption above it.",
+    );
+    ui.add_space(8.0);
+
+    for (caption, specimen) in fonts::SPECIMENS {
+        field_label(ui, caption);
+        for family in fonts::families() {
+            ui.horizontal(|ui| {
+                // The family's own name, in the family itself: a tag drawn in some *other* face
+                // would be naming a rendering it is not part of.
+                ui.label(bidi::job(
+                    &family_tag(&family),
+                    egui::FontId::new(11.0, family.clone()),
+                    ui.visuals().weak_text_color(),
+                ));
+                ui.label(bidi::job(
+                    specimen,
+                    egui::FontId::new(20.0, family.clone()),
+                    ui.visuals().text_color(),
+                ));
+            });
+        }
+        ui.add_space(10.0);
+    }
+}
+
+/// The short name of a family, for the specimen's row tag.
+fn family_tag(family: &egui::FontFamily) -> String {
+    match family {
+        egui::FontFamily::Proportional => "prop".to_owned(),
+        egui::FontFamily::Monospace => "mono".to_owned(),
+        egui::FontFamily::Name(name) => name.to_string(),
+    }
 }
 
 /// **Temporary, and not a specified feature.** A development control that returns this device to a


### PR DESCRIPTION
Picks up [#97](https://github.com/amin-bf/leitner/issues/97) — the on-device half of the shipped font set, which #80 left open because a container has no JDK, NDK or handset. Verified on the Pixel 8 Pro (arm64-v8a, debug APK, `source scripts/android-env.sh`), and confirmed by a reader of the script.

## The instrument first, because the ticket cannot be discharged without one

Two of the five criteria are unreachable on the device as it stands. Client-stack rule 8 makes Android text input ASCII-only, so a Persian sentence can never be **typed** on the handset; and a screenshot compared against a reference image tells a non-reader only that something Persian-shaped appeared. So the strings ship in the binary, at the bottom of settings, each under a caption stating **what it must read** — the statement being checked against, written in Latin so it stays readable on the run where the rendering is what is broken.

Every specimen is drawn **once per family**, stacked. A face is resolved per family and per character, so the same string can be right in `Proportional` and wrong in `Monospace` or `bold` with nothing failing anywhere. Stacking the three renderings of one string is the only way a wrong *face* shows up at all: it draws, it just draws in the wrong hand. Both defects below were found that way, in the first two minutes of looking at it.

`families()` and `SPECIMENS` are each one list with several readers — install, the coverage test and the specimen — so the screen cannot show a script the test never checks, and a fourth family cannot reach one without reaching the others.

## The five criteria

- **Persian and Arabic sentences render with the words in the right order, through the bidi helper.** Confirmed by the repo owner — after the second fix below. Before it, the bold family drew them backwards.
- **Mixed text and digits render correctly, with Arabic-Indic digits not reversed.** Confirmed: `تمرین ۱۲۳ (page 45)` with the digits reading one-two-three and the brackets enclosing the Latin, plus `١٢٣٤٥ ۶۷۸۹۰` covering both digit ranges.
- **IPA renders as glyphs rather than boxes.** Confirmed: ADR-0002 §9's own `deːɐ̯ hʊnt`, and a wider sweep — `ɸθðʃʒŋɲʎɫæœøɜɾʔ ˈˌː` — with no boxes in any family.
- **Text renders in every family in use, including `Monospace`.** Confirmed, and the criterion turned out to be **three** families rather than two: ADR-0012 §8's `bold` arrived after rule 7 was written, and it is the family both defects were in.
- **Confirmed by a reader of the script, not only by eye against a reference image.** Yes — and it was the reader who caught the word order, from a rendering I had looked at and passed.

## Two defects, both in the family nobody was checking

**Persian and Arabic rendered backwards in `bold`, and only there.** `LayoutJob::append` merges into the previous section whenever the format matches — sensible for sections carrying only a colour, fatal in the bidi helper, where **the section boundaries are the reordering**. Merged, the paragraph is one shaping run, harfrust infers RTL from the script, and it reverses the order the helper had just produced. What hid it is that runs are re-split by **face** below the merge: in `Proportional` and `Monospace` the spaces come from egui's Latin face and the words from Noto Sans Arabic, so the split fell at every space and the order held *by accident*. The bold family is one face throughout. The helper's correctness was resting on which face happens to own U+0020; it now pushes its sections by hand.

**Bold Persian was drawn by DejaVu, not by Noto.** Face resolution is first match wins, and DejaVu Sans Bold carries a partial Arabic block — 165 code points to Noto's 256, `گ چ پ ژ` among them — so listing it first meant Noto Sans Arabic Bold was never reached for *any* Arabic-script character. It rendered, which is why nothing complained. Latin and the IPA extensions still fall through to DejaVu-bold, which Noto does not carry (16 of 95 printable ASCII, none a letter), so nothing else moves.

Neither predates the other: both were already there when the bold family was created, and both are silent by construction.

## What could not be checked, and now can

`Fonts::has_glyph` is `resolve_face(c) != replacement_face_key` — a false negative for **every character covered by whichever face owns U+FFFD**. That is Hack in `Monospace`, so it reports `θ ð ŋ æ œ ø` missing; and DejaVu-Bold in `bold`, so it reports the entire specimen missing. A coverage test built on it would have called the bold family totally broken while it rendered fine, which is why the old one checked two families and a hand-written string list. It now lays the character out and compares its texture rectangle against U+FFFD's, which answers the question actually being asked — *does a box appear* — the same way for every family.

The ordering test is the one that matters most. All seventeen existing bidi tests assert on `job.text`, which is **byte-identical in the broken build**, so none of them could ever have caught this. The new one lays the sentence out through the real shipped faces in every family and reads the order back off the glyphs' x coordinates, asserting both that the families agree and that the full stop sits at the visual left — either alone passes a broken build.

## Recorded where the next reader meets them

**Family** and **face** are now two words in `crates/app/src/CONTEXT.md`, along with **shaping run**, which is not a section. Client-stack rules 1 and 7 in `AGENTS.md` carry the two prohibitions: `append` may not come back, and order within a family decides which face is reached.

No new ADR — nothing here is hard to reverse and none of it was a live trade-off, which fails two of the three tests.

## Feedback loops

`cargo fmt --check` clean. **Every commit independently** passes `cargo clippy --all-targets --all-features -D warnings` and `cargo test --workspace`, verified with `git rebase --exec`. Both fixes were confirmed to fail their new test before the fix and pass after. `cargo apk build` and install on the handset for each round.

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)
