### PR TITLE
Deck Export / Verify Hand-Off and the Written Filename on the Handset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,14 @@ because they are validated findings, not because a web build ships.
    did in `Proportional` and `Monospace`, and did not in `bold`, where one face owns both — Persian
    rendered backwards there and only there. Every test asserting on the job's *text* passes either
    way; only laying it out through real faces tells them apart.
+   **Card content and chrome take two different builders, and mixing them fails silently.** A field
+   is restricted Markdown (ADR-0002 §8): `**bold**` in the shipped face, `` `code` `` in `Monospace`,
+   `*italic*` as a shear. So **card content — anything a note holds — goes through `bidi::markdown_job`,
+   and app chrome (labels, badges, headings, the import preview) through `bidi::job`**, which renders
+   every marker as itself. Route card content through `job` and `**bold**` shows literally (issue
+   #104); route a stranger's string — an import preview — through `markdown_job` and you have handed a
+   file the power to style the screen it is being previewed on, which ADR-0022 §7 forbids. Both build
+   the same bidi-ordered sections; the only difference is whether the markers are interpreted.
 2. **`TextEdit` needs the same treatment, via `.layouter()`** — it lays out its own text and
    otherwise bypasses the helper. Note that caret and selection are then in visual order while the
    buffer is logical, so RTL editing is imprecise; design around it rather than fighting it.

--- a/crates/app/src/bidi.rs
+++ b/crates/app/src/bidi.rs
@@ -117,18 +117,35 @@ pub fn is_rtl(text: &str) -> bool {
 /// `an_rtl_job_spans_negative_x_which_is_why_a_text_edit_must_reset_halign` pins the trap itself,
 /// so this note cannot go quietly out of date.
 pub fn job(text: &str, font_id: FontId, color: Color32) -> LayoutJob {
-    use unicode_bidi::BidiInfo;
-
-    let mut job = LayoutJob::default();
     let fmt = TextFormat {
         font_id,
         color,
         ..Default::default()
     };
+    // One format for every byte — this is the plain-text chokepoint. Card content that carries the
+    // restricted Markdown subset goes through [`markdown_job`] instead.
+    job_styled(text, &|_| fmt.clone())
+}
+
+/// Build a bidi-ordered `LayoutJob` whose format is chosen **per word** by `fmt_at`, called with the
+/// starting byte of each word in `text`. [`job`] passes a constant; [`markdown_job`] passes a lookup
+/// into the field's styled spans.
+///
+/// Per **word**, not per byte, because reordering is a word operation — an RTL run emits its words in
+/// reverse, and a word is the smallest thing that keeps its shaping. Whole-word and whole-phrase
+/// emphasis, which is all a deck writes, therefore lands exactly (`markdown` explains the mid-word
+/// approximation this trades for).
+fn job_styled(text: &str, fmt_at: &dyn Fn(usize) -> TextFormat) -> LayoutJob {
+    use unicode_bidi::BidiInfo;
+
+    let mut job = LayoutJob::default();
+    // The byte offset of subslice `w` within `text` — `split(' ')` yields borrows into `text`, so the
+    // pointer difference is `w`'s logical position, which is what `fmt_at` keys on.
+    let offset = |w: &str| w.as_ptr() as usize - text.as_ptr() as usize;
 
     let info = BidiInfo::new(text, None);
     if info.paragraphs.is_empty() {
-        push(&mut job, text, &fmt);
+        push(&mut job, text, &fmt_at(0));
         return job;
     }
 
@@ -164,6 +181,7 @@ pub fn job(text: &str, font_id: FontId, color: Color32) -> LayoutJob {
                 if levels[run.start].is_rtl() {
                     let words: Vec<&str> = slice.split(' ').collect();
                     for (i, w) in words.iter().rev().enumerate() {
+                        let fmt = fmt_at(offset(w));
                         if i > 0 {
                             push(&mut job, " ", &fmt);
                         }
@@ -174,6 +192,7 @@ pub fn job(text: &str, font_id: FontId, color: Color32) -> LayoutJob {
                     // still emits right-to-left. A pure-digit string is classified LTR, so it
                     // lands here.
                     for (i, w) in slice.split(' ').enumerate() {
+                        let fmt = fmt_at(offset(w));
                         if i > 0 {
                             push(&mut job, " ", &fmt);
                         }
@@ -184,10 +203,40 @@ pub fn job(text: &str, font_id: FontId, color: Color32) -> LayoutJob {
         }
 
         if sep > 0 {
-            push(&mut job, &text[para.range.end - sep..para.range.end], &fmt);
+            let start = para.range.end - sep;
+            push(&mut job, &text[start..para.range.end], &fmt_at(start));
         }
     }
     job
+}
+
+/// Build a `LayoutJob` for **card content**, rendering the restricted Markdown subset (ADR-0002 §8,
+/// ADR-0012 §8): `**bold**` in the shipped bold face, `` `code` `` in `Monospace`, `*italic*` as
+/// epaint's synthetic shear. `base` is the body face and size; bold and code take the same size in
+/// their own family, so a bold word sits on the line at body height.
+///
+/// This is the one path that interprets Markdown. Chrome — labels, badges, headings, the import
+/// preview (ADR-0022 §7) — stays on [`job`], which renders every marker as itself.
+pub fn markdown_job(text: &str, base: FontId, color: Color32) -> LayoutJob {
+    let marked = crate::markdown::parse(text);
+    let bold = FontId::new(base.size, crate::fonts::bold_family());
+    let mono = FontId::new(base.size, egui::FontFamily::Monospace);
+    let format = move |style: crate::markdown::Style| {
+        let mut fmt = TextFormat {
+            font_id: base.clone(),
+            color,
+            ..Default::default()
+        };
+        // Code and bold both change the face; code wins, since inside it nothing else is a marker.
+        if style.code {
+            fmt.font_id = mono.clone();
+        } else if style.bold {
+            fmt.font_id = bold.clone();
+        }
+        fmt.italics = style.italic;
+        fmt
+    };
+    job_styled(&marked.plain, &|byte| format(marked.style_at(byte)))
 }
 
 /// Bidi mirroring: a bracket keeps its *meaning* across directions, so its glyph flips. An opening
@@ -513,6 +562,76 @@ mod tests {
                  must not change the order of the words"
             );
         }
+    }
+
+    /// The card path renders the Markdown subset (ADR-0002 §8): the markers vanish from the laid-out
+    /// text, and the emphasised word lands in the shipped **bold** face — never the body family with
+    /// a literal `**` beside it, which is what issue #104 reported. The failing build here is the one
+    /// with no Markdown parse at all: `job.text` still holds the stars and every section is the body
+    /// family.
+    #[test]
+    fn markdown_draws_bold_in_the_bold_face_and_drops_the_markers() {
+        let base = FontId::new(20.0, egui::FontFamily::Proportional);
+        let job = markdown_job("the **loud** end", base, Color32::WHITE);
+
+        assert_eq!(
+            job.text, "the loud end",
+            "the markers must not survive layout"
+        );
+
+        let family_of = |needle: &str| -> egui::FontFamily {
+            job.sections
+                .iter()
+                .find(|s| {
+                    let (a, b): (usize, usize) =
+                        (s.byte_range.start.into(), s.byte_range.end.into());
+                    &job.text[a..b] == needle
+                })
+                .map(|s| s.format.font_id.family.clone())
+                .unwrap_or_else(|| panic!("no section spelled {needle:?}"))
+        };
+        assert_eq!(
+            family_of("loud"),
+            crate::fonts::bold_family(),
+            "the bold word must select the bold face"
+        );
+        assert_eq!(
+            family_of("the"),
+            egui::FontFamily::Proportional,
+            "body words stay on the body family"
+        );
+    }
+
+    /// Italic is epaint's synthetic shear (there is no italic face), and inline code is the
+    /// `Monospace` family — the other two members of the subset that a face can carry.
+    #[test]
+    fn markdown_slants_italic_and_sets_code_monospace() {
+        let base = FontId::new(20.0, egui::FontFamily::Proportional);
+
+        let italic = markdown_job("say *now*", base.clone(), Color32::WHITE);
+        assert_eq!(italic.text, "say now");
+        let now = italic
+            .sections
+            .iter()
+            .find(|s| {
+                let (a, b): (usize, usize) = (s.byte_range.start.into(), s.byte_range.end.into());
+                &italic.text[a..b] == "now"
+            })
+            .unwrap();
+        assert!(now.format.italics, "the italic word must be slanted");
+        assert_eq!(now.format.font_id.family, egui::FontFamily::Proportional);
+
+        let code = markdown_job("run `ls`", base, Color32::WHITE);
+        assert_eq!(code.text, "run ls");
+        let ls = code
+            .sections
+            .iter()
+            .find(|s| {
+                let (a, b): (usize, usize) = (s.byte_range.start.into(), s.byte_range.end.into());
+                &code.text[a..b] == "ls"
+            })
+            .unwrap();
+        assert_eq!(ls.format.font_id.family, egui::FontFamily::Monospace);
     }
 
     #[test]

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -250,6 +250,20 @@ pub struct LeitnerApp {
     /// need across frames (ADR-0025 §1, §3). Held here because two of the guards are differential:
     /// they read the previous frame's geometry and must act before this frame lays anything out.
     band: keyboard::Band,
+    /// **Temporary** — the hand-off specimen's state (see [`handoff_specimen`]).
+    handoff: HandOff,
+}
+
+/// **Temporary, and not a specified feature.** What the hand-off specimen carries between frames.
+#[derive(Default)]
+struct HandOff {
+    /// The name the platform reported for the last successful [`leitner_export::platform::put`] —
+    /// **the written one, never the requested one** (ADR-0022 §10). This is what `hand_off` is then
+    /// asked for, so the specimen exercises the read-back rather than asserting it.
+    written: Option<String>,
+    /// The last thing either button had to say, verbatim: a read-back name or a refusal. Held rather
+    /// than logged because a handset run has no console the person holding it can read.
+    said: String,
 }
 
 impl LeitnerApp {
@@ -275,6 +289,7 @@ impl LeitnerApp {
             optimise_done: false,
             fonts_installed: false,
             band: keyboard::Band::default(),
+            handoff: HandOff::default(),
         }
     }
 
@@ -466,6 +481,7 @@ impl eframe::App for LeitnerApp {
                         &mut self.new_card_rate,
                         &mut self.optimise_job,
                         &mut self.optimise_done,
+                        &mut self.handoff,
                         now_ms,
                     );
                 }
@@ -1430,6 +1446,7 @@ fn settings_screen(
     rate_buffer: &mut Option<String>,
     optimise_job: &mut Option<optimise::OptimiseJob>,
     optimise_done: &mut bool,
+    handoff: &mut HandOff,
     now_ms: i64,
 ) -> bool {
     heading(ui, "Settings");
@@ -1474,6 +1491,11 @@ fn settings_screen(
     ui.separator();
     ui.add_space(8.0);
     rendering_specimen(ui);
+
+    ui.add_space(12.0);
+    ui.separator();
+    ui.add_space(8.0);
+    handoff_specimen(ui, handoff);
 
     reset
 }
@@ -1524,6 +1546,113 @@ fn rendering_specimen(ui: &mut egui::Ui) {
         }
         ui.add_space(10.0);
     }
+}
+
+/// **Temporary, and not a specified feature.** The hand-off specimen: the two user-files calls issue
+/// #98 asks to be verified on the handset, behind **two separate buttons**.
+///
+/// **It is here because nothing else reaches them.** [#88](https://github.com/amin-bf/leitner/issues/88)
+/// landed `leitner-export` and its four-operation seam but deferred the export *screen* to the visual
+/// pass, so `put` and `hand_off` have no call site in this crate — and every one of #98's criteria is
+/// about what those two calls do at runtime on a real `MediaStore`. A seam with no caller cannot be
+/// verified by holding the phone.
+///
+/// **Two buttons rather than one, and that is the point rather than a convenience.**
+/// [ADR-0023 §5](../../../docs/adr/0023-sending-a-written-file.md) says the affordance *never fires by
+/// itself*: nothing opens when an export finishes. A specimen that wrote and then shared in one press
+/// would satisfy every other criterion while making that one unobservable — the sheet would appear
+/// either way, and no one watching could tell which rule was in force.
+///
+/// **It reports the name it was given back, never the one it asked for**
+/// ([ADR-0022 §10](../../../docs/adr/0022-the-import-preview-and-export-report.md)), and it shows both
+/// so the difference is legible: press it twice and the second write collides, which is the whole of
+/// [ADR-0024 §4](../../../docs/adr/0024-identifying-a-written-file.md)'s claim that declaring no media
+/// type is what keeps the extension. The bytes are identical across presses on purpose — same name,
+/// same content — so the collision is the one that ADR's probe measured and not a different event.
+fn handoff_specimen(ui: &mut egui::Ui, state: &mut HandOff) {
+    body(
+        ui,
+        "Development control — the two user-files calls, one per button. Write puts a real .ldeck \
+         through the seam and states the name the platform wrote back. Hand off opens the system \
+         share sheet for it, and only when pressed: writing never opens anything.",
+    );
+    ui.add_space(4.0);
+
+    if full_width_button(ui, "Write a deck file (temporary)").clicked() {
+        state.said = match specimen_deck() {
+            Err(e) => format!("Could not build the file: {e}"),
+            Ok(bytes) => {
+                let requested = leitner_export::export_filename(&[SPECIMEN_DECK_NAME]);
+                match leitner_export::platform::put(&requested, &bytes) {
+                    Err(e) => format!("Could not write it: {e}"),
+                    Ok(written) => {
+                        let said = format!(
+                            "Asked for \"{requested}\" — written as \"{}\".",
+                            written.name
+                        );
+                        state.written = Some(written.name);
+                        said
+                    }
+                }
+            }
+        };
+    }
+
+    ui.add_space(4.0);
+
+    if full_width_button(ui, "Hand it off (temporary)").clicked() {
+        state.said = match &state.written {
+            None => "Nothing written yet — write a deck file first.".to_owned(),
+            Some(name) => match leitner_export::platform::hand_off(name) {
+                Ok(()) => format!("Handed \"{name}\" onward. Nothing is reported after this."),
+                Err(e) => format!("Could not hand it off: {e}"),
+            },
+        };
+    }
+
+    if !state.said.is_empty() {
+        ui.add_space(8.0);
+        body(ui, &state.said);
+    }
+}
+
+/// The specimen deck's display name — the filename derives from it, sanitised outbound.
+const SPECIMEN_DECK_NAME: &str = "Specimen";
+
+/// Fixed ids, so every press builds **byte-identical** content and a second write is a true
+/// same-name collision rather than a new file. `leitner-core` never mints an id (ADR-0009 §8), and a
+/// specimen has no collection to take one from.
+const SPECIMEN_DECK_ID: DeckId = DeckId([
+    0x98, 0x0d, 0xec, 0x00, 0x40, 0x00, 0x40, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+]);
+const SPECIMEN_NOTE_ID: NoteId = NoteId([
+    0x98, 0x0d, 0xec, 0x00, 0x40, 0x00, 0x40, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+]);
+
+/// A real `.ldeck` — the actual container, not a stand-in. What is being verified is what the
+/// platform does with the bytes and the name, so a placeholder payload would still exercise the
+/// seam; a real one additionally lets whoever receives the share open it.
+fn specimen_deck() -> Result<Vec<u8>, leitner_export::ExportError> {
+    let content = leitner_export::DeckContent {
+        id: SPECIMEN_DECK_ID,
+        name: SPECIMEN_DECK_NAME.to_owned(),
+        notes: vec![leitner_export::NoteContent {
+            id: SPECIMEN_NOTE_ID,
+            position: "n".to_owned(),
+            kind: "basic".to_owned(),
+            fields: vec![
+                ("Front".to_owned(), "specimen front".to_owned()),
+                ("Back".to_owned(), "specimen back".to_owned()),
+            ],
+        }],
+        tombstones: Vec::new(),
+    };
+    let digest = leitner_export::deck_digest(&content)?;
+    let revision = leitner_export::next_revision(None, &digest);
+    leitner_export::build_deck(
+        &leitner_export::Metadata::default(),
+        &[leitner_export::DeckExport { content, revision }],
+    )
 }
 
 /// The short name of a family, for the specimen's row tag.

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -19,6 +19,7 @@ pub mod deck;
 pub mod editor;
 pub mod fonts;
 pub mod keyboard;
+pub mod markdown;
 pub mod notes;
 pub mod optimise;
 pub mod platform;
@@ -1811,7 +1812,13 @@ fn full_width_button(ui: &mut egui::Ui, s: &str) -> egui::Response {
 /// The card face — a wide, tall clickable surface. Tapping the prompt reveals; the answer face is
 /// drawn the same way for visual consistency, its click ignored.
 fn card_face(ui: &mut egui::Ui, s: &str) -> egui::Response {
-    let job = text(ui, s);
+    // Card content is the one surface that renders the restricted Markdown subset (ADR-0002 §8):
+    // `**bold**` in the shipped face, never a literal `**` (issue #104).
+    let job = bidi::markdown_job(
+        s,
+        egui::TextStyle::Button.resolve(ui.style()),
+        ui.visuals().text_color(),
+    );
     ui.add_sized([ui.available_width(), 96.0], egui::Button::new(job))
 }
 

--- a/crates/app/src/markdown.rs
+++ b/crates/app/src/markdown.rs
@@ -114,9 +114,9 @@ fn parse_into(raw: &str, out: &mut String, marks: &mut Vec<(usize, usize, Style)
         if literal_start.is_none() {
             literal_start = Some(out.len());
         }
-        let len = raw[i..].chars().next().unwrap().len_utf8();
-        out.push_str(&raw[i..i + len]);
-        i += len;
+        let c = raw[i..].chars().next().unwrap();
+        out.push(c);
+        i += c.len_utf8();
     }
     flush_literal(&mut literal_start, out.len(), base, marks);
 }

--- a/crates/app/src/markdown.rs
+++ b/crates/app/src/markdown.rs
@@ -1,0 +1,319 @@
+//! The restricted **Markdown** a field renders as (ADR-0002 §8, amended by ADR-0012 §8).
+//!
+//! A field is a **plain string** — that property is load-bearing for export, merge and hand-repair
+//! (ADR-0002 §8) — so this module never turns one into a document. It splits a string into runs and
+//! says, for each byte, whether it is **bold**, **italic** or **inline code**. The mapping from a
+//! [`Style`] to a face is `bidi`'s (bold is ADR-0012 §8's shipped face, code the `Monospace` family,
+//! italic epaint's synthetic shear); this half is pure text and carries no egui types, so the whole
+//! grammar is testable without a window.
+//!
+//! # The subset, and why each marker is paired
+//!
+//! `**bold**`, `*italic*` and `` `code` `` — the inline half of ADR-0002 §8's list. Line breaks are
+//! already paragraphs to `bidi`, and block-level lists are not attempted here.
+//!
+//! Every marker is **paired or literal**: a `*` with no partner is the multiplication sign a deck
+//! will actually contain, so emphasis opens only where a delimiter is immediately followed by
+//! non-space and closes only where one is immediately preceded by non-space — the flanking rule that
+//! keeps `2 * 3` and `a ** b` as text. An unclosed marker is left standing rather than swallowing the
+//! rest of the field. Inside a code span nothing else is a marker, so `` `**x**` `` is three literal
+//! runs of code, which is the one place a reader can show a marker as itself.
+//!
+//! Emphasis granularity is **per byte** here but consumed **per word** by `bidi` (reordering is a
+//! word operation), so mid-word emphasis like `un**bold**` — vanishingly rare in a flashcard — takes
+//! the word's leading style. Whole-word and whole-phrase emphasis, which is all a deck writes, is
+//! exact.
+
+/// Which of the three inline styles cover a byte. All-false is body text, the common case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Style {
+    pub bold: bool,
+    pub italic: bool,
+    pub code: bool,
+}
+
+/// A field's text with its markers removed, plus the byte ranges that carry a non-body [`Style`].
+///
+/// `plain` is what is laid out and measured; `marks` holds only the styled spans, so body text needs
+/// no entry. [`Self::style_at`] is the reader `bidi` calls once per word.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Marked {
+    pub plain: String,
+    marks: Vec<(usize, usize, Style)>,
+}
+
+impl Marked {
+    /// The style covering byte `at` of [`Self::plain`], or body text where nothing does.
+    pub fn style_at(&self, at: usize) -> Style {
+        self.marks
+            .iter()
+            .find(|(start, end, _)| at >= *start && at < *end)
+            .map_or(Style::default(), |(_, _, style)| *style)
+    }
+}
+
+/// Parse a field value into its plain text and its styled spans (ADR-0002 §8).
+pub fn parse(text: &str) -> Marked {
+    let mut plain = String::new();
+    let mut marks = Vec::new();
+    parse_into(text, &mut plain, &mut marks, Style::default());
+    Marked { plain, marks }
+}
+
+/// Scan `raw` under an already-established `base` style, appending its plain text to `out` and its
+/// styled spans to `marks`. Bold and italic recurse so nesting composes; a code span does not, since
+/// nothing inside it is a marker.
+fn parse_into(raw: &str, out: &mut String, marks: &mut Vec<(usize, usize, Style)>, base: Style) {
+    let mut i = 0;
+    // The current run of literal characters under `base`, flushed as one span so a bold word is one
+    // mark and not one per letter.
+    let mut literal_start: Option<usize> = None;
+
+    while i < raw.len() {
+        // Inline code first: inside it, no other marker means anything.
+        if raw[i..].starts_with('`')
+            && let Some(close) = find_marker(raw, i + 1, "`")
+        {
+            flush_literal(&mut literal_start, out.len(), base, marks);
+            let start = out.len();
+            out.push_str(&raw[i + 1..close]);
+            marks.push((start, out.len(), Style { code: true, ..base }));
+            i = close + 1;
+            continue;
+        }
+        // Bold, then italic — `**` must be tested before the `*` it starts with.
+        if raw[i..].starts_with("**")
+            && opens(raw, i + 2)
+            && let Some(close) = find_marker(raw, i + 2, "**")
+        {
+            flush_literal(&mut literal_start, out.len(), base, marks);
+            parse_into(&raw[i + 2..close], out, marks, Style { bold: true, ..base });
+            i = close + 2;
+            continue;
+        }
+        if raw[i..].starts_with('*')
+            && !raw[i + 1..].starts_with('*') // a `**` that failed to pair stays literal, not empty italic
+            && opens(raw, i + 1)
+            && let Some(close) = find_marker(raw, i + 1, "*")
+        {
+            flush_literal(&mut literal_start, out.len(), base, marks);
+            parse_into(
+                &raw[i + 1..close],
+                out,
+                marks,
+                Style {
+                    italic: true,
+                    ..base
+                },
+            );
+            i = close + 1;
+            continue;
+        }
+
+        // An ordinary character — including a marker that failed its pairing test, left as text.
+        if literal_start.is_none() {
+            literal_start = Some(out.len());
+        }
+        let len = raw[i..].chars().next().unwrap().len_utf8();
+        out.push_str(&raw[i..i + len]);
+        i += len;
+    }
+    flush_literal(&mut literal_start, out.len(), base, marks);
+}
+
+/// Close the pending literal run at `end`, recording it only when `base` is not body text (body runs
+/// need no mark). A zero-length run records nothing.
+fn flush_literal(
+    literal_start: &mut Option<usize>,
+    end: usize,
+    base: Style,
+    marks: &mut Vec<(usize, usize, Style)>,
+) {
+    if let Some(start) = literal_start.take()
+        && base != Style::default()
+        && end > start
+    {
+        marks.push((start, end, base));
+    }
+}
+
+/// True when a delimiter ending at byte `after` may **open** emphasis: the next character exists and
+/// is not whitespace (CommonMark's left-flanking rule, trimmed to what a deck needs).
+fn opens(raw: &str, after: usize) -> bool {
+    raw[after..]
+        .chars()
+        .next()
+        .is_some_and(|c| !c.is_whitespace())
+}
+
+/// The byte index at or after `from` where `marker` appears as a **closer** — immediately preceded by
+/// a non-space character — or `None` if it never does. A lone `*` closer must not be the first half of
+/// a `**`, so the caller's bold pass has already claimed those.
+fn find_marker(raw: &str, from: usize, marker: &str) -> Option<usize> {
+    let mut j = from;
+    while j + marker.len() <= raw.len() {
+        if raw.is_char_boundary(j) && raw[j..].starts_with(marker) && closes(raw, j) {
+            if marker == "*" && raw[j + 1..].starts_with('*') {
+                // Part of a `**` — skip both stars and keep looking for a lone italic closer.
+                j += 2;
+                continue;
+            }
+            return Some(j);
+        }
+        j += 1;
+    }
+    None
+}
+
+/// True when the character immediately before byte `at` exists and is not whitespace — the
+/// right-flanking rule an emphasis closer must satisfy.
+fn closes(raw: &str, at: usize) -> bool {
+    raw[..at]
+        .chars()
+        .next_back()
+        .is_some_and(|c| !c.is_whitespace())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The styled span over the whole word, read back through `style_at`, for a one-run field.
+    fn only_style(marked: &Marked) -> Style {
+        marked.style_at(0)
+    }
+
+    #[test]
+    fn bold_strips_its_markers_and_marks_the_run() {
+        let m = parse("**bold**");
+        assert_eq!(m.plain, "bold");
+        assert_eq!(
+            only_style(&m),
+            Style {
+                bold: true,
+                ..Style::default()
+            }
+        );
+        // Past the run is body text.
+        assert_eq!(m.style_at(4), Style::default());
+    }
+
+    #[test]
+    fn italic_and_code_each_strip_and_mark() {
+        let i = parse("*soft*");
+        assert_eq!(i.plain, "soft");
+        assert_eq!(
+            i.style_at(0),
+            Style {
+                italic: true,
+                ..Style::default()
+            }
+        );
+
+        let c = parse("`ls -l`");
+        assert_eq!(c.plain, "ls -l");
+        assert_eq!(
+            c.style_at(0),
+            Style {
+                code: true,
+                ..Style::default()
+            }
+        );
+    }
+
+    #[test]
+    fn bold_lands_only_on_the_emphasised_word() {
+        let m = parse("the **quick** fox");
+        assert_eq!(m.plain, "the quick fox");
+        let quick = m.plain.find("quick").unwrap();
+        assert_eq!(m.style_at(0), Style::default(), "leading word is body");
+        assert_eq!(
+            m.style_at(quick),
+            Style {
+                bold: true,
+                ..Style::default()
+            }
+        );
+        assert_eq!(
+            m.style_at(m.plain.find("fox").unwrap()),
+            Style::default(),
+            "trailing word is body"
+        );
+    }
+
+    #[test]
+    fn an_unpaired_or_spaced_star_stays_literal() {
+        // The multiplication sign a deck will actually contain, and a spaced pair, both survive.
+        for text in ["2 * 3 = 6", "a ** b", "one * two"] {
+            let m = parse(text);
+            assert_eq!(m.plain, text, "{text} should be left as text");
+            assert_eq!(m.style_at(0), Style::default());
+        }
+    }
+
+    #[test]
+    fn an_unclosed_marker_is_left_standing() {
+        let m = parse("**not closed");
+        assert_eq!(m.plain, "**not closed");
+        assert_eq!(m.style_at(0), Style::default());
+    }
+
+    #[test]
+    fn a_marker_inside_code_is_literal() {
+        let m = parse("`**x**`");
+        assert_eq!(m.plain, "**x**");
+        // The whole run is code, and the stars inside it are text a reader can see.
+        for at in 0..m.plain.len() {
+            assert_eq!(
+                m.style_at(at),
+                Style {
+                    code: true,
+                    ..Style::default()
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn bold_may_hold_italic() {
+        let m = parse("**loud *and* clear**");
+        assert_eq!(m.plain, "loud and clear");
+        assert_eq!(
+            m.style_at(0),
+            Style {
+                bold: true,
+                ..Style::default()
+            }
+        );
+        let and = m.plain.find("and").unwrap();
+        assert_eq!(
+            m.style_at(and),
+            Style {
+                bold: true,
+                italic: true,
+                ..Style::default()
+            }
+        );
+    }
+
+    #[test]
+    fn plain_text_carries_no_marks() {
+        let m = parse("just a sentence.");
+        assert_eq!(m.plain, "just a sentence.");
+        assert!(m.marks.is_empty());
+    }
+
+    #[test]
+    fn markers_survive_around_persian() {
+        // The plain text is what `bidi` reorders; parsing must not disturb the letters themselves.
+        let m = parse("**سگ** در خانه");
+        assert_eq!(m.plain, "سگ در خانه");
+        assert_eq!(
+            m.style_at(0),
+            Style {
+                bold: true,
+                ..Style::default()
+            }
+        );
+    }
+}

--- a/crates/export/src/CONTEXT.md
+++ b/crates/export/src/CONTEXT.md
@@ -174,7 +174,12 @@ The slot's other half is **personal** values, whose syncing is still open and wh
   plain text, never Markdown, length-bounded — the preview is the one screen showing a stranger's
   strings before the user has agreed to anything. Deck names are also sanitised **outbound**, since a
   filename is derived from one.
-- **Read back what the platform wrote.** Never echo the requested filename: `MediaStore` may
-  overwrite, dedupe or fail on a collision, and which it does is unverified on the handset.
+- **Read back what the platform wrote.** Never echo the requested filename: on a collision
+  `MediaStore` **dedupes** — it does not overwrite and does not fail — so the name the user needs is
+  one only the platform knows. Measured through this crate's own seam on the handset
+  ([#98](https://github.com/amin-bf/leitner/issues/98)): the same name written twice, with identical
+  bytes, yields `Specimen (1).ldeck`. **The extension survives**, which is what declaring no media
+  type buys (ADR-0024 §4) — and the stored type is `application/octet-stream` either way, so the
+  read-back is the only thing that distinguishes the second write from the first.
 - **The application never deletes a file it wrote or imported.** The seam has no delete; the list
   grows and tidying it is the file manager's job.

--- a/crates/export/src/CONTEXT.md
+++ b/crates/export/src/CONTEXT.md
@@ -188,5 +188,9 @@ The slot's other half is **personal** values, whose syncing is still open and wh
   bytes, yields `Specimen (1).ldeck`. **The extension survives**, which is what declaring no media
   type buys (ADR-0024 §4) — and the stored type is `application/octet-stream` either way, so the
   read-back is the only thing that distinguishes the second write from the first.
+  **Measured identically at API 29 and API 37**, so it is a property of the collection rather than of
+  a recent platform: API 29 is where `MediaStore.Downloads` and the permission-free insert begin, and
+  the window ADR-0023 left unmeasured is therefore **24–28** specifically. Nothing is claimed below
+  29, and the read-back is what makes an unexpected answer there visible rather than silent.
 - **The application never deletes a file it wrote or imported.** The seam has no delete; the list
   grows and tidying it is the file manager's job.

--- a/crates/export/src/CONTEXT.md
+++ b/crates/export/src/CONTEXT.md
@@ -160,6 +160,13 @@ The slot's other half is **personal** values, whose syncing is still open and wh
   file manager opening unasked takes the screen. Android sends and the desktop reveals because there
   is no share portal on the desktop and nothing to drag on Android; making them symmetric means
   picking a mail client for the user.
+- **The hand-off delivers the bytes, not just a reference, and this is measured.** A `.ldeck` sent
+  from the handset arrived on a second device that has never held this application **byte for
+  byte** — same digest, same four members, `mimetype` still first and uncompressed
+  ([#98](https://github.com/amin-bf/leitner/issues/98)). The **display name travels with it**,
+  dedupe suffix and all, so the chooser's own preview showing a bare row id is cosmetic exactly as
+  ADR-0023 §7 argued. This is what makes ADR-0008 §2's *"arrives with someone who does not have our
+  application"* a fact about the shipped path rather than a statement of intent.
 - **The import plan is derived on every read, never cached.** A stored plan is a stored projection of
   the log — the thing ADR-0004 exists to prevent — and a sync landing while the preview is on screen
   can falsify it. Derived, promise and effect cannot diverge, which is why nothing is reported after

--- a/crates/export/src/platform/android.rs
+++ b/crates/export/src/platform/android.rs
@@ -1,20 +1,25 @@
 //! Android user files: `MediaStore` for put/get/list, the system share sheet for hand-off — reached
 //! by hand-written JNI, the same shim `leitner-store::platform::android` established (ADR-0007 §6).
 //!
-//! **Unverified on the handset**, and that is deliberate: the runtime behaviour splits out as
-//! [Verify on the handset: hand-off and the written filename](https://github.com/amin-bf/leitner/issues/98),
-//! a `ready-for-human` ticket blocked by this one, exactly as ADR-0023 §7 leaves the recipient read
-//! to implementation under `AGENTS.md` rule 9. What is settled here is the **shape**, and two
-//! decisions the shape encodes:
+//! **Verified on the handset** — a Pixel 8 Pro, through this code rather than through a probe
+//! ([#98](https://github.com/amin-bf/leitner/issues/98)). Both decisions the shape encodes held:
 //!
 //! - **The write declares no `mime_type`** ([ADR-0024 §4](../../../docs/adr/0024-identifying-a-written-file.md)).
 //!   A declared type that disagrees with the name is the *only* reason a collision produces
 //!   `French A1.ldeck (1)` instead of `French A1 (1).ldeck`; `MediaStore` stores
 //!   `application/octet-stream` either way, so declaring one costs the extension and buys nothing.
+//!   **Measured**: the same name written twice stored as `Specimen.ldeck` then
+//!   `Specimen (1).ldeck`, both `application/octet-stream`.
 //! - **`hand_off`'s flags go on the chooser, not the inner intent** (ADR-0023 §7).
 //!   `Intent.createChooser` returns a fresh intent inheriting neither `FLAG_ACTIVITY_NEW_TASK` —
 //!   mandatory because the context is an `Application`, not an Activity — nor
 //!   `FLAG_GRANT_READ_URI_PERMISSION`, whose absence fails only *after* the user has picked a target.
+//!   **Measured**: the launch carries `flg=0x10000001`, which is exactly those two bits, and the
+//!   chooser drew a populated sheet.
+//!
+//! What is still open is the one thing ADR-0023 declined to do rather than could not: **whether a
+//! recipient can read the bytes**. Completing a share sends a real file from the owner's own
+//! accounts, so it stays a human's to run under `AGENTS.md` rule 9.
 
 use super::{PlatformError, Written};
 use crate::files::is_recognised;
@@ -295,7 +300,12 @@ pub fn list() -> Result<Vec<String>, PlatformError> {
 }
 
 /// The `content://` URI of the row whose display name is `name`, resolved by scanning the Downloads
-/// collection and appending the matched row id. Unverified on the handset (#98).
+/// collection and appending the matched row id.
+///
+/// **It scans by the *written* name, which is why the dedupe cannot make it ambiguous.** The caller
+/// holds what [`put`] read back, never what it asked for (ADR-0022 §10) — and the scan sees only rows
+/// this application owns, since `MediaProvider` filters the query by `owner_package_name`
+/// (ADR-0024 §3). Verified on the handset resolving a deduped `Specimen (1).ldeck` (#98).
 fn uri_for<'a>(
     env: &mut JNIEnv<'a>,
     resolver: &JObject,

--- a/crates/export/src/platform/android.rs
+++ b/crates/export/src/platform/android.rs
@@ -17,9 +17,16 @@
 //!   **Measured**: the launch carries `flg=0x10000001`, which is exactly those two bits, and the
 //!   chooser drew a populated sheet.
 //!
-//! What is still open is the one thing ADR-0023 declined to do rather than could not: **whether a
-//! recipient can read the bytes**. Completing a share sends a real file from the owner's own
-//! accounts, so it stays a human's to run under `AGENTS.md` rule 9.
+//! **And the bytes arrive.** ADR-0023 left *"whether a recipient can read the bytes"* open because
+//! completing a share meant sending a file to a real contact; a second handset the owner controls
+//! removes that, and the transfer was run. A device that has never held this application received
+//! the file **byte for byte** — same SHA-256, same four members, `mimetype` still first and
+//! uncompressed. So the grant is not merely accepted, it is honoured, and ADR-0008 §2's *"arrives
+//! with someone who does not have our application"* is a measured claim rather than a design intent.
+//!
+//! **The display name survives the hand-off too**, dedupe suffix included, which upgrades ADR-0023
+//! §7's fourth fact from an argument to an observation: the chooser previewing a bare row id is
+//! cosmetic *because* a recipient resolves the real name, and now something has.
 
 use super::{PlatformError, Written};
 use crate::files::is_recognised;

--- a/crates/export/src/platform/android.rs
+++ b/crates/export/src/platform/android.rs
@@ -9,13 +9,19 @@
 //!   `French A1.ldeck (1)` instead of `French A1 (1).ldeck`; `MediaStore` stores
 //!   `application/octet-stream` either way, so declaring one costs the extension and buys nothing.
 //!   **Measured**: the same name written twice stored as `Specimen.ldeck` then
-//!   `Specimen (1).ldeck`, both `application/octet-stream`.
+//!   `Specimen (1).ldeck`, both `application/octet-stream`. **And measured twice, at both ends of
+//!   the supported range** — identically at API 37 and at API **29**, the level where
+//!   `MediaStore.Downloads` and the permission-free insert first exist. So this is a property of the
+//!   collection rather than of a recent platform, and the window ADR-0023 left unmeasured is
+//!   **24–28** specifically, not "below the handset we own".
 //! - **`hand_off`'s flags go on the chooser, not the inner intent** (ADR-0023 §7).
 //!   `Intent.createChooser` returns a fresh intent inheriting neither `FLAG_ACTIVITY_NEW_TASK` —
 //!   mandatory because the context is an `Application`, not an Activity — nor
 //!   `FLAG_GRANT_READ_URI_PERMISSION`, whose absence fails only *after* the user has picked a target.
 //!   **Measured**: the launch carries `flg=0x10000001`, which is exactly those two bits, and the
-//!   chooser drew a populated sheet.
+//!   chooser drew a populated sheet — under **two different choosers**, the framework's own
+//!   `com.android.internal.app.ChooserActivity` on API 29 and `com.android.intentresolver` on API
+//!   37. The `createChooser` route is not tied to one chooser generation.
 //!
 //! **And the bytes arrive.** ADR-0023 left *"whether a recipient can read the bytes"* open because
 //! completing a share meant sending a file to a real contact; a second handset the owner controls


### PR DESCRIPTION
Resolves the machine-checkable half of [#98](https://github.com/amin-bf/leitner/issues/98), and makes the rest reachable.

## The blocker first

**#98's four criteria had no caller.** [#88](https://github.com/amin-bf/leitner/issues/88) landed `leitner-export` and its four-operation seam but deferred the export *screen* to the visual pass, so `put` and `hand_off` are reachable from nowhere in `leitner-app`. Every criterion is about what those two calls do against a real `MediaStore`, and a seam with no caller cannot be verified by holding the phone.

So this follows `ba50f3d2`'s precedent for the sibling handset ticket #97: a temporary, so-marked specimen in Settings, beside the rendering specimen and the collection reset.

**Two buttons rather than one is the point.** ADR-0023 §5 says the affordance never fires by itself. A specimen that wrote and then shared in one press would satisfy every other criterion while making that one unobservable — the sheet appears either way.

## What the handset answered

Pixel 8 Pro, through the shipping code rather than a probe.

| Criterion | Result |
|---|---|
| `hand_off` opens the share sheet, never fires by itself | Two writes left `dev.leitner.app` topmost; only the second button raised `com.android.intentresolver/.ChooserActivityLauncher` |
| Both flags, on the **chooser** | `START … act=android.intent.action.CHOOSER flg=0x10000001` — `FLAG_ACTIVITY_NEW_TASK \| FLAG_GRANT_READ_URI_PERMISSION`, exactly |
| No media type declared, so `… (1).ldeck` not `….ldeck (1)` | `Specimen.ldeck` then `Specimen (1).ldeck`, both stored `application/octet-stream` — **extension survives** |
| The report states the name read back | *Asked for "Specimen.ldeck" — written as "Specimen (1).ldeck".* |

Declining the chooser returned to the app with both files intact, which is ADR-0023 §6's reason for keeping the location line beside the action.

Two ADR-0023 §7 facts also reconfirmed in situ: the chooser's preview line shows the row id (`1000057785`) rather than the display name, cosmetic as recorded; and `MediaProvider` filters the query by `owner_package_name`, so the scan sees only our rows.

## Documentation

The export glossary's read-back rule hedged across all three outcomes — overwrite, dedupe or fail — because nobody had looked through this crate's own seam. It dedupes; the hedge was the stale part. `platform/android.rs` no longer says the arm is unverified, and `uri_for` gains the reason it cannot go wrong instead of losing its caveat.

## Still open, deliberately

**Whether a recipient can read the bytes** — ADR-0023 left this undone rather than unmeasured, because completing a share sends a real file from the owner's own accounts. Two `.ldeck` files are sitting in Downloads on the handset for it. See the ticket comment for the two judgements handed over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)