### PR TITLE
Deck Export / Discharge the Inbound Share and Name Reachability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,6 +254,15 @@ because they are validated findings, not because a web build ships.
    `cargo apk build` needs a **JDK on `PATH`** — `apksigner` is a `java` wrapper, and its absence
    surfaces only at the signing step, *after* a full NDK compile, as
    `apksigner: line 97: exec: java: not found`.
+   **And an intent fired from `am` is not the intent an application sends.**
+   `FLAG_GRANT_READ_URI_PERMISSION` reaches the intent's `data` URI and its `ClipData`, never a bare
+   Parcelable extra; real senders escape that only because `Activity.startActivity` migrates
+   `EXTRA_STREAM` into the clip on the way out, and **`am start --eu` does not**. So a shell-fired
+   `ACTION_SEND` measures the harness rather than the application — and where the receiving code
+   degrades to a refusal by design, it presents as the file simply never arriving, with nothing in
+   `logcat` either. **Send a file the application itself wrote**, which needs no grant at all, to tell
+   a broken reader from a harness that cannot hand one over
+   ([ADR-0024 §5.7](./docs/adr/0024-identifying-a-written-file.md)).
 10. **A backgrounded Android app is frozen, not slowed.** The process moves to the `/background`
     cpuset (~13× the CPU time) and is then frozen outright — `isFrozen=true`, `utime` stopped dead —
     so long work *stops* rather than running slowly: 303 s of wall clock for 4.3 s of work, measured

--- a/crates/export/src/CONTEXT.md
+++ b/crates/export/src/CONTEXT.md
@@ -48,6 +48,21 @@ never fires, and the bytes never arrive to be sniffed
 _Avoid_: Detect, guess — the member is written by us at a known position, so nothing here is
 heuristic.
 
+**Reachability**:
+Whether a file can be **offered** to this application at all — settled before, and independently of,
+what the file is. On Android the **extension** decides it: `MediaStore` derives the stored media type
+from the name, and the type is what the broad filter matches. So a byte-identical deck named `.txt`
+types as `text/plain`, resolves to none of our filters, and is *unreachable rather than misnamed*; a
+**stripped** name still types as `application/octet-stream` and still arrives. This is the extension's
+one real authority and the sniff's blind spot — measured on the handset (Pixel 8 Pro, API 37) for
+[#106](https://github.com/amin-bf/leitner/issues/106) and again for
+[#99](https://github.com/amin-bf/leitner/issues/99), where five fixtures typed `application/octet-stream`
+resolved to us and the `.txt` one resolved to nothing
+([ADR-0024 §1](../../../docs/adr/0024-identifying-a-written-file.md)).
+_Avoid_: Hidden, unreadable, permission-denied — an unreachable file is none of those. It is never
+offered, so there is no refusal to show and no permission a user could grant. Naming it as a
+visibility or permission problem is what sends someone after a fix that does not exist.
+
 **Collection archive**:
 A `.lcoll` zip archive carrying the whole collection: the log verbatim, plus everything that settles,
 minus device identity and credentials. The artifact a user keeps for themselves.

--- a/docs/adr/0024-identifying-a-written-file.md
+++ b/docs/adr/0024-identifying-a-written-file.md
@@ -208,6 +208,17 @@ cost this ADR a build cycle each.
 6. **`cargo apk build` needs a JDK on `PATH`.** `apksigner` is a `java` wrapper, and its absence
    surfaces only at the signing step — after a full NDK compile — as
    `apksigner: line 97: exec: java: not found`.
+7. **The read grant reaches the *data* URI, never a bare `EXTRA_STREAM` extra — so an `ACTION_SEND`
+   fired from a shell measures the harness, not the application.**
+   `FLAG_GRANT_READ_URI_PERMISSION` covers the intent's `data` URI and its `ClipData`; a URI sitting
+   only in a Parcelable extra is covered by neither. Real senders never meet this, because
+   `Activity.startActivity` calls `Intent.migrateExtraStreamToClipData()` and the extra is copied into
+   the clip on the way out — **`am start --eu` does not**. The failure is silent twice over: the
+   system logs nothing, and every JNI arm in the launch read degrades to `None` by design, so it
+   presents as the file simply never arriving. **Distinguish the two by sending a file this
+   application owns**, which needs no grant at all — if that arrives and a shell-owned one does not,
+   the reader is correct and the harness is the thing that cannot deliver a grant. Measured both ways
+   while working [#99](https://github.com/amin-bf/leitner/issues/99).
 
 ## Amendments to accepted ADRs
 
@@ -299,7 +310,30 @@ touch.
 
 | Item | Owner |
 |---|---|
-| **Whether an inbound `ACTION_SEND` delivers a readable URI.** The filter is decided here; that the grant arrives is not measured, because completing a share needed a real send from a real account | Implementation, under `AGENTS.md` rule 9 |
+| ~~**Whether an inbound `ACTION_SEND` delivers a readable URI.**~~ The filter is decided here; that the grant arrives is not measured, because completing a share needed a real send from a real account | **Discharged** — see below |
 | **The API 24–28 path.** Scoped storage and `MediaStore.Downloads` as measured are API 29+; `min_sdk_version` is 24. Inherited from [ADR-0016 §5](0016-backup-and-restore.md), not created here | Implementation |
 | **Whether a recipient can read the bytes** — carried forward unchanged from [ADR-0023](0023-sending-a-written-file.md) | Implementation, under `AGENTS.md` rule 9 |
 | Visual treatment of the refusal when an unrecognised file is opened | **Out of scope** — *the visual design pass*, ruled out by [the map](https://github.com/amin-bf/leitner/issues/1) on 2026-07-31 |
+
+### The inbound share, discharged
+
+> **The grant arrives.** A `.ldeck` shared to this application through `ACTION_SEND` was read,
+> sniffed and planned — `Arrived: shared (ACTION_SEND)`, `Sniffed: a deck`
+> ([#99](https://github.com/amin-bf/leitner/issues/99), Pixel 8 Pro, API 37).
+
+**What blocked it was the sender, not a real account.** This item assumed a share could only be
+completed from a messaging application signed into the owner's own accounts. That was too narrow: the
+grant is a property of *any* sender that goes through `Activity.startActivity`, because that is what
+migrates `EXTRA_STREAM` into the intent's `ClipData` (§5.7). A file manager's own share is therefore
+a sufficient sender, and needs no account, no contact and no network.
+
+**It nearly recorded the opposite.** The same share fired from `am start --eu` does *not* arrive, and
+with every JNI arm degrading to `None` that is indistinguishable from a broken reader. What separated
+them was sending a file this application **owns** — readable with no grant at all — which arrived
+through the identical code path. The reader was never in question; the harness simply could not hand
+over a grant. That asymmetry is now §5.7 so the next person does not spend the diagnosis again.
+
+**`ACTION_VIEW` and the Open-with sheet are discharged with it.** §2 accepted appearing in the sheet
+for unrecognised files as the price of having any inbound route, having watched the
+extension-matched filter *fail* to put us there. Under the broad filter we are in that sheet — first,
+above the same four applications §2 recorded us missing from.


### PR DESCRIPTION
Records what [#99](https://github.com/amin-bf/leitner/issues/99) measured on the handset, now that its three blockers have closed. **No decision changes here** — three documents catch up with what the device said, and one open item retires.

## What the handset answered

Pixel 8 Pro, API 37, against `main` at `42479a9b`. The on-device `base.apk` and the locally built one share md5 `a31d68e9…`, and `pm list packages --user all` returns one `dev.leitner.app` under one user — so every result below is that exact build, with no second copy that could be answering.

**The corridor [#89](https://github.com/amin-bf/leitner/issues/89) left unbuilt is now built.** The previous run found the intent arriving complete and nothing reading it; [#107](https://github.com/amin-bf/leitner/issues/107) and [#108](https://github.com/amin-bf/leitner/issues/108) closed that gap.

| Criterion | Result |
|---|---|
| The **emitted** manifest is checked, never the source | Both filters intact under `aapt2 dump xmltree` — broad `application/octet-stream` and precise `application/vnd.leitner.deck+zip`, each carrying VIEW and SEND with DEFAULT and BROWSABLE |
| No filter matches on an extension | Holds **by absence** — no `scheme`, `host`, `path`, `pathPattern`, `GLOB` or `PATTERN` anywhere, so none of §5's three traps can bite |
| Arrives through VIEW and SEND; in the Open-with sheet | Both arrive. One tap draws *Leitner · Google · Google Wallet · KeePassDX · Sparkasse* — **Leitner first** |
| Identified by sniffing `mimetype`; a stripped or wrong name still resolves | Five fixtures pairing name against content; the sniff wins in both directions |
| The list shows only files this application wrote | Six shell-owned files in `Downloads`; the list returns exactly the five `Specimen*.ldeck` we wrote |

The Open-with row is the direct reversal of §2, which watched that same four-application sheet under the extension-matched filter and recorded *"Leitner is not in the list."*

## The sniff against the name

Fixtures seeded in code through the shipped export path and pushed as `com.android.shell`, so each is genuinely a file another application wrote. The pairing **is** the test:

| Fixture | Name says | Bytes are | Sniffed |
|---|---|---|---|
| `Inbound.lcoll` | collection | **deck** | **a deck** |
| `Archive.ldeck` | deck | **collection** | **a collection archive** — refused as *"This is a collection archive, not a deck file."* |
| `Inbound` | *nothing* | deck | a deck |

## The finding that nearly went in backwards

An `ACTION_SEND` fired from `am start --eu` **does not arrive**, and since every JNI arm in the launch read degrades to `None` by design and the system logs nothing, that is indistinguishable from a broken reader.

It is the harness. `FLAG_GRANT_READ_URI_PERMISSION` covers the intent's `data` URI and its `ClipData`, never a bare Parcelable extra; real senders escape it only because `Activity.startActivity` migrates `EXTRA_STREAM` into the clip, and `am` does not. Triangulated with the same code and flag throughout:

| URI owner | Route | Result |
|---|---|---|
| `com.android.shell` | VIEW, URI in `getData()` | arrives |
| `com.android.shell` | SEND, URI in `EXTRA_STREAM` | **does not arrive** |
| `dev.leitner.app` | SEND, URI in `EXTRA_STREAM` | arrives |

Row 3 settles it — a file we own needs no grant and arrives through the identical path. That becomes **ADR-0024 §5.7**, and `AGENTS.md` client-stack rule 9 carries the same warning, since the trap is about driving the handset at all rather than about file identification.

## The open item, and why it retired on narrower terms

ADR-0024 handed onward *"whether an inbound `ACTION_SEND` delivers a readable URI"*, deferred because completing a share *"needed a real send from a real account."* That was too narrow: the grant belongs to **any** sender going through `Activity.startActivity`. A file manager's own share is sufficient — no account, no contact, no network. Measured: `Arrived: shared (ACTION_SEND)`, `Sniffed: a deck`.

## Reachability gets a headword

#99's criterion 4 read *"a stripped **or wrong** name still resolves to the right profile"* — one phrase over two facts that behave oppositely. An extension the platform does **not** recognise still types `application/octet-stream`, arrives, and is corrected by the sniff. One it **does** recognise never arrives at all, and no sniff can reach it: `Inbound.txt`, byte-identical to `Inbound.ldeck`, types `text/plain` and resolves to **zero** handlers of ours.

§1's correction already drew that line and the export glossary stated it only in prose under **Sniff**, which is why one word could cover both. Naming it is what stops the next criterion being written the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
