### PR TITLE
Capture / Fix Storyboard Exports and Unpin the Captured Binary

### DIFF
--- a/scripts/capture-desktop-session.sh
+++ b/scripts/capture-desktop-session.sh
@@ -76,7 +76,13 @@ while IFS= read -r line || [ -n "$line" ]; do
       ;;
     sh\ *)
       echo "session: sh ${line#sh }"
-      eval "${line#sh }" 2>&1 | sed 's/^/session:   /'
+      # **Not piped.** A pipeline runs its left-hand side in a subshell, so `sh export FOO=bar`
+      # would set the variable somewhere that dies at the end of the line — and the next `restart`
+      # would relaunch the app with the *old* environment. That failure is silent in the worst way
+      # the harness has: every subsequent `shot` succeeds and photographs the previous screen under
+      # the new screen's name, which is exactly the class of fault `%CX%` was introduced to kill.
+      # The `sed` prefix on the output is not worth paying for it.
+      eval "${line#sh }" 2>&1
       ;;
     *)
       echo "session: xdotool $line"

--- a/scripts/capture-desktop.sh
+++ b/scripts/capture-desktop.sh
@@ -36,7 +36,11 @@ height="${3:-800}"
 export CAIRN_SETTLE="${4:-6}"
 export CAIRN_WIDTH="$width"
 export CAIRN_HEIGHT="$height"
-export CAIRN_BIN="$root/target/debug/cairn"
+# Overridable so the same harness can photograph something *other* than the shipped app — the
+# throwaway prototypes a design ticket builds to be reacted to. The harness's value is that a
+# capture costs the operator no window and no focus, and that is worth exactly as much to a
+# prototype as to the app.
+export CAIRN_BIN="${CAIRN_BIN:-$root/target/debug/cairn}"
 export CAIRN_STORYBOARD="$(cd "$(dirname "$storyboard")" && pwd)/$(basename "$storyboard")"
 export CAIRN_SHOTS="${CAIRN_SHOTS:-$root/target/capture/${width}x${height}}"
 


### PR DESCRIPTION
Two bugs in the desktop capture harness, found while driving it for #124. Neither is design work — they are defects in a tool the repo keeps, so they land on their own rather than riding along with a prototype.

## A storyboard's `sh export …` was silently discarded

`eval "${line#sh }" 2>&1 | sed …` runs the eval in a **subshell**, because the left-hand side of a pipeline always does. So `sh export PROTO_SCREEN=question` set the variable somewhere that died at the end of the line, and the `restart` after it relaunched the app with the **old** environment.

That is the harness's worst failure shape rather than a cosmetic one. Every subsequent `shot` still succeeds, and each photographs the **previous screen under the new screen's name** — precisely the fault `%CX%` was introduced to kill (`488b85d0`), arriving by a different route. It was found the same way that one was: by looking at the images rather than counting them.

The `sed` output prefix is not worth paying for it.

## `CAIRN_BIN` was pinned to the shipped app

It was hard-coded to `target/debug/cairn`, so the only thing the harness could photograph was the app itself.

The property that makes this harness worth having — a capture costs the operator no window, no focus, and no risk to their real collection — is worth exactly as much to a throwaway prototype as to the app. A design ticket whose method is "make a cheap concrete thing to react to" has to photograph that thing; without this it either builds its variants into the real app behind a flag, or is judged by description.

Defaulted with `${CAIRN_BIN:-…}`, so no existing caller changes.

## Verification

Both were exercised end to end across ~90 captures for #124: five variants × five states × two widths, plus a storyboard that drives the interactive mode through start → reveal → grade. Before the first fix, four-shot runs produced four copies of the same screen under four different names; after it, each shot is the screen it claims to be.

The prototype that exposed them is preserved as the tag `prototypes/issue-124`, per this repo's convention, and is deliberately not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)