### PR TITLE
Design Pass / The Vertical Anchor

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -121,7 +121,7 @@ Read the ADR sections in your row. Read the whole ADR only if you are changing t
 | `store` | [0007](./docs/adr/0007-the-local-store.md) | 0004 §11, 0003 §5, 0013 §9, 0016 §3, 0016 §7, 0019 §6, 0020 §3, 0020 §4, 0028 §5 |
 | `export` | [0008](./docs/adr/0008-the-deck-export-format.md), [0016](./docs/adr/0016-backup-and-restore.md), [0022](./docs/adr/0022-the-import-preview-and-export-report.md), [0023](./docs/adr/0023-sending-a-written-file.md), [0024](./docs/adr/0024-identifying-a-written-file.md) | 0005, 0002 §9, 0004 §11, 0011 §7, 0020 §4, 0021 §3, 0028 §3 §3a |
 | `sync` | [0013](./docs/adr/0013-the-sync-transport.md) | 0004 §2, 0004 §7, 0004 §10, 0007, 0014 §7, 0015 §2, 0015 §4, 0016 §10, 0019 §4, 0019 §6, 0020 §5, 0020 §6, 0020 §7 |
-| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md), [0010](./docs/adr/0010-leeches.md), [0011](./docs/adr/0011-new-card-rate-and-daily-limits.md), [0012](./docs/adr/0012-the-note-authoring-experience.md), [0014](./docs/adr/0014-when-parameter-optimisation-runs.md), [0015](./docs/adr/0015-the-sync-experience.md), [0018](./docs/adr/0018-the-card-pane-ordering.md), [0019](./docs/adr/0019-naming-the-account-at-enrolment.md), [0021](./docs/adr/0021-note-ordering-saving-and-the-note-list.md), [0022](./docs/adr/0022-the-import-preview-and-export-report.md), [0025](./docs/adr/0025-the-authoring-screen-under-a-soft-keyboard.md), [0026](./docs/adr/0026-the-per-tap-keyboard-re-pop.md), [0029](./docs/adr/0029-editing-a-note-from-the-review-screen.md), [0030](./docs/adr/0030-the-first-finish-pass-decisions.md), [0031](./docs/adr/0031-the-page-frame.md), [0032](./docs/adr/0032-the-type-scale-and-the-rhythm.md), [0033](./docs/adr/0033-the-card.md) | 0002 §4, 0016 §5, 0016 §6, 0016 §11, 0016 §12, 0017 §5, 0017 §6, 0020 §7, 0023 §5, 0023 §6, 0024 §3, 0028 §1 §2 |
+| `ui` | [0003](./docs/adr/0003-client-stack.md), [0006](./docs/adr/0006-the-review-session-experience.md), [0010](./docs/adr/0010-leeches.md), [0011](./docs/adr/0011-new-card-rate-and-daily-limits.md), [0012](./docs/adr/0012-the-note-authoring-experience.md), [0014](./docs/adr/0014-when-parameter-optimisation-runs.md), [0015](./docs/adr/0015-the-sync-experience.md), [0018](./docs/adr/0018-the-card-pane-ordering.md), [0019](./docs/adr/0019-naming-the-account-at-enrolment.md), [0021](./docs/adr/0021-note-ordering-saving-and-the-note-list.md), [0022](./docs/adr/0022-the-import-preview-and-export-report.md), [0025](./docs/adr/0025-the-authoring-screen-under-a-soft-keyboard.md), [0026](./docs/adr/0026-the-per-tap-keyboard-re-pop.md), [0029](./docs/adr/0029-editing-a-note-from-the-review-screen.md), [0030](./docs/adr/0030-the-first-finish-pass-decisions.md), [0031](./docs/adr/0031-the-page-frame.md), [0032](./docs/adr/0032-the-type-scale-and-the-rhythm.md), [0033](./docs/adr/0033-the-card.md), [0034](./docs/adr/0034-the-controls.md), [0035](./docs/adr/0035-the-vertical-anchor.md) | 0002 §4, 0016 §5, 0016 §6, 0016 §11, 0016 §12, 0017 §5, 0017 §6, 0020 §7, 0023 §5, 0023 §6, 0024 §3, 0028 §1 §2 |
 | *the workspace itself* | [0009](./docs/adr/0009-crate-and-workspace-layout.md), [0027](./docs/adr/0027-the-scheduler-dependency.md), [0028](./docs/adr/0028-the-application-is-named-cairn.md) | 0013 §11, 0013 §12, 0015 §15, 0016 §5 |
 
 **`replay` having no ADR of its own is why it is a context.** Its rules were each written for another
@@ -244,6 +244,30 @@ top-right is a footnote in Latin and the first thing seen in Persian. And §3 **
 since filled buttons outweigh every candidate card and making the card recede without them makes it
 worse. It also lands 0030 §4's lower-case `box 3`, which that ADR recorded as shipped and which never
 was.
+
+**[0034](./docs/adr/0034-the-controls.md) is what a control is *made of*, and the answer is a role
+rather than a treatment**: `faint_bg_color` for an ordinary control (quieter than the card, which
+discharges 0033 §3), the old heavier rung kept as `primary` for **the one way forward on a screen
+with no card**, and one frameless `text_action` beside a primary. Ask `controls` for a role, never a
+`Button` with a fill. Read it before adding any control anywhere. Applying one flat treatment
+everywhere satisfies §3 on the review screen and guts the screens with no card, where the only mass
+on the page ends up reading as disabled — that is the trap, and it is why there are three weights and
+not one. §4 also makes the 10-minute checkpoint **compact and above the card**, implementing 0006 §1
+for the first time: it had been an `else if` that replaced the card since it was written, with nothing
+failing because reaching that state needs ten real minutes no test waits for.
+
+**[0035](./docs/adr/0035-the-vertical-anchor.md) is where the controls *sit*, and it is the frame's
+first vertical number**: the last cluster on a screen ends **165px above the bottom of the page**
+whenever there is room, *Edit note* rides directly under the card, and under a **thumb** the four
+grades stack instead of taking 0034 §1's segmented row. Read it before placing anything vertically or
+touching the grade row. 165 was measured — the cluster was dragged into place by thumb twice, at two
+different heights, and its bottom edge landed within 7px both times — so the rule is a *line above the
+bottom*, never a gap below the card. Two traps it records: **`Ui::available_height` returns zero
+inside a `ScrollArea`** (the content Ui is sized to its content; use `frame::page_room`, which reads
+the clip rect), and the card **must not move on reveal**, which is what struck both arrangements the
+ticket originally proposed. The touch test is read off `platform::SoftKeyboard` rather than a new seam
+or a `#[cfg]`, and the ADR states the rule as *touch* so a native client can implement it without
+inheriting egui's way of noticing.
 
 0028 also carries the one item in that change that cannot be taken back, the Android package id. Its
 extension rename **is** discharged: `.cdeck` and `.ccoll` were measured on the handset at API 37 and

--- a/crates/app/src/frame.rs
+++ b/crates/app/src/frame.rs
@@ -78,6 +78,55 @@ fn frame_of_width<R>(ui: &mut egui::Ui, cap: f32, add: impl FnOnce(&mut egui::Ui
     .inner
 }
 
+/// How far above the bottom of the page the last control on a screen sits, when the page is tall
+/// enough to place it there.
+///
+/// **The frame's third number, and the first one a thumb chose.** #131 fixed the two horizontal
+/// numbers and left the vertical unasked, because at the 860px window every capture in the design
+/// pass was taken at there is no leftover height to place. On a handset there are ~1100px of it, and
+/// [#125](https://github.com/amin-bf/cairn/issues/125) found it all pooled below the content, where
+/// it costs the reach of every control on the screen.
+///
+/// **165 is measured, not chosen.** In two sittings on a Pixel 8 Pro the control cluster was dragged
+/// into place by thumb, once at 148px tall and once at 184px, and its **bottom edge** landed at 162
+/// and 169 — a round apart, with different contents, converging within 7px. So what the thumb picks
+/// is a *line above the bottom of the page*, not a gap below the card, and the cluster grows upward
+/// from it. That is why this is one number rather than a gap plus a cluster height.
+///
+/// It is an absolute distance rather than a fraction of the page on purpose: the band it clears is
+/// where the hand **grips**, and a grip is physical. A proportion would put the line too high on a
+/// tall screen and too low on a short one.
+pub const REACH_LINE: f32 = 165.0;
+
+/// How much page is left below the cursor, measured against the **visible viewport**.
+///
+/// **`Ui::available_height` is the obvious call and it returns zero here.** Inside a `ScrollArea`
+/// the content `Ui` is sized to its *content* — that is what scrolling means — so "available" is
+/// what the widgets already drawn have claimed, never what the screen has left. The clip rect is the
+/// viewport, and the viewport is what a thumb can reach. This was found by a prototype rendering
+/// pixel-identically to the thing it was varying, with nothing failing.
+///
+/// The viewport already excludes the gesture bar: the inset band is a panel reserved *before* the
+/// scroll area (`crate::keyboard`, ADR-0025 §1), so this measures usable page and not glass.
+pub fn page_room(ui: &egui::Ui) -> f32 {
+    (ui.clip_rect().bottom() - ui.cursor().top()).max(0.0)
+}
+
+/// The space to leave above a `block` of controls so its bottom edge lands on [`REACH_LINE`] —
+/// falling back to `floor` on a page with no room to spare.
+///
+/// **The fallback is the rule's other half, not defensiveness.** A page too short to place the
+/// cluster is a page with no leftover height, which is the state in which this ticket's question
+/// does not arise: the controls simply follow the card, exactly as they did before. So one
+/// expression covers the handset, the desktop window and everything between, with no breakpoint —
+/// the gap absorbs whatever is left over and stops at the stated gap when there is nothing left.
+/// Takes the room rather than the `Ui` so the rule is arithmetic a test can state: the one thing
+/// worth pinning here is *where the bottom edge lands*, and a test that has to build a window to ask
+/// would be testing egui.
+pub fn slack_above(room: f32, block: f32, floor: f32) -> f32 {
+    (room - block - REACH_LINE).max(floor)
+}
+
 /// The **window** width at or above which the note editor draws its two panes side by side.
 ///
 /// This is measured against the window and never against a column, and the distinction is the whole
@@ -138,6 +187,42 @@ mod tests {
         assert_eq!(PAGE_MARGIN, 28.0);
         assert_eq!(MEASURE, 640.0);
         assert_eq!(TWO_COLUMN_MIN_WIDTH, 900.0);
+        assert_eq!(REACH_LINE, 165.0);
+    }
+
+    /// **ADR-0035 §1, stated as the thing a thumb actually chose.** On a page with room, the
+    /// cluster's *bottom edge* lands on the reach line — whatever the cluster contains and however
+    /// tall it is. That invariant is the whole finding: two sittings placed clusters of 148 and 184
+    /// and both put the bottom edge in the same place.
+    ///
+    /// Nothing fails when this drifts. Get the arithmetic wrong by the cluster's height and the
+    /// screen still renders, still looks deliberate, and is simply wrong by 184px on the one axis
+    /// the ADR is about.
+    #[test]
+    fn the_cluster_bottom_lands_on_the_reach_line_whatever_it_holds() {
+        const ROOM: f32 = 800.0;
+        const FLOOR: f32 = 24.0;
+        for block in [148.0_f32, 184.0, 36.0] {
+            let bottom_edge = ROOM - (slack_above(ROOM, block, FLOOR) + block);
+            assert_eq!(
+                bottom_edge, REACH_LINE,
+                "a {block}px cluster should still end {REACH_LINE}px above the page bottom"
+            );
+        }
+    }
+
+    /// **The other half of the same rule**: a page with no leftover height places nothing, and the
+    /// controls follow the card exactly as they did before this ADR.
+    ///
+    /// This is what makes it one rule rather than a breakpoint — the desktop window the design pass
+    /// judges at reaches this arm by arithmetic, not by asking what it is running on.
+    #[test]
+    fn a_page_with_no_room_falls_back_to_the_stated_gap() {
+        const FLOOR: f32 = 24.0;
+        assert_eq!(slack_above(300.0, 184.0, FLOOR), FLOOR);
+        assert_eq!(slack_above(0.0, 184.0, FLOOR), FLOOR);
+        // And the boundary: exactly enough room for the cluster, the line and the gap.
+        assert_eq!(slack_above(184.0 + REACH_LINE + FLOOR, 184.0, FLOOR), FLOOR);
     }
 
     /// **The measure must be under the two-column threshold, and by a real margin.** This is the

--- a/crates/app/src/keyboard.rs
+++ b/crates/app/src/keyboard.rs
@@ -90,6 +90,17 @@ impl Band {
         self.insets.keyboard.is_up()
     }
 
+    /// Whether this device is operated by a **thumb** rather than a pointer — read off the same
+    /// stored insets, for the same reason and at the same cost as [`Band::keyboard_is_up`].
+    ///
+    /// The review screen asks it to decide the grades' axis
+    /// ([ADR-0035 §3](../../../docs/adr/0035-the-vertical-anchor.md)). See
+    /// [`crate::platform::SoftKeyboard::exists`] for why the soft keyboard is the thing being asked
+    /// about and what it is a proxy for.
+    pub(crate) fn is_touch(&self) -> bool {
+        self.insets.keyboard.exists()
+    }
+
     /// **Guard 1** — keep the focused field inside the viewport, *in the same frame it shrinks*.
     ///
     /// Not a nicety. Reserving the band clips the focused field, which stops its IME output, which

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -533,6 +533,10 @@ impl eframe::App for CairnApp {
         // The area is taken *before* the closure so it carries guard 1's forced offset without
         // holding a borrow of `band` across the frame the destinations are drawn in.
         let area = self.band.scroll_area();
+        // Whether a thumb is driving this (ADR-0035 §3). Read once here, from the insets this frame
+        // already took, and passed down — so the screens ask a value rather than a platform, and
+        // nothing below this line acquires a reason to know what it is running on.
+        let touch = self.band.is_touch();
         let mut reset_requested = false;
         let out = area.show(ui, |ui| {
             ui.add_space(spacing::gap(1));
@@ -557,6 +561,7 @@ impl eframe::App for CairnApp {
                             &mut self.session_pointer,
                             now_ms,
                             today,
+                            touch,
                         )
                     });
                     if let Some(note) = opened {

--- a/crates/app/src/platform/mod.rs
+++ b/crates/app/src/platform/mod.rs
@@ -158,6 +158,23 @@ impl SoftKeyboard {
         matches!(self, Self::Up { .. })
     }
 
+    /// Whether this platform has a soft keyboard **at all** — which is this client's way of asking
+    /// *is this thing operated by a thumb*.
+    ///
+    /// [ADR-0035 §3](../../../../docs/adr/0035-the-vertical-anchor.md) needs that question answered
+    /// and deliberately does not add a seam function for it: a platform that raises a keyboard on
+    /// screen is a platform with no pointer, and this type already carries the distinction because
+    /// ADR-0026 §5 forced it to. **The proxy is exact for the two targets that exist** — Android has
+    /// one, the desktop has none — and it is a proxy rather than a truth, which is why the ADR
+    /// states the rule as *touch* and names this only as how this client reads it. A native client
+    /// asks its own platform directly and needs none of this.
+    ///
+    /// Not a compile-time capability constant, deliberately: the existing one (ADR-0015 §9) exists
+    /// to make a limitation visible and never to vary behaviour, and this varies behaviour.
+    pub fn exists(self) -> bool {
+        !matches!(self, Self::Absent)
+    }
+
     /// What it is covering, in physical pixels — zero when it is down or does not exist.
     pub fn height(self) -> f32 {
         match self {

--- a/crates/app/src/screens/review.rs
+++ b/crates/app/src/screens/review.rs
@@ -11,11 +11,11 @@ use cairn_core::scheduling::Grade;
 use cairn_store::Collection;
 
 use crate::session::{self, Offered, ReviewState};
-use crate::{bidi, controls, spacing, typography};
 use crate::{
-    Sitting, badge, body, box_badge_wording, deck, field_label, full_width_button, heading, surface,
-    text,
+    Sitting, badge, body, box_badge_wording, deck, field_label, full_width_button, heading,
+    surface, text,
 };
+use crate::{bidi, controls, frame, spacing, typography};
 
 /// Draw the whole review destination for this frame: the count picker when no sitting is running,
 /// otherwise the current card. Returns the note the user asked to **edit**, if any — the review
@@ -23,6 +23,10 @@ use crate::{
 /// a revealed card** (ADR-0029 §1). Nothing is flipped on the way out: ADR-0021 §6's "counts as a
 /// reveal" is retired with the pre-reveal control that needed it, so ADR-0006 §4's guarantee holds by
 /// there being no route rather than by a side-effect.
+// Each screen threads its own `&mut` slice of `CairnApp` state plus the frame's facts — `now_ms`,
+// `today`, and now whether a thumb is driving (ADR-0035 §3). Grouping them behind a struct would
+// relocate the same fields, not reduce them; the same trade `settings_screen` makes.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn review(
     ui: &mut egui::Ui,
     coll: &mut Collection,
@@ -31,6 +35,7 @@ pub(crate) fn review(
     session_pointer: &mut Option<usize>,
     now_ms: i64,
     today: i64,
+    touch: bool,
 ) -> Option<NoteId> {
     // Everything on screen is derived from the log this frame — there is no cached session state to
     // fall out of step with it. The new-card rate and the notes' authored positions ride the mutable
@@ -208,21 +213,32 @@ pub(crate) fn review(
             }
 
             if s.revealed {
-                ui.add_space(spacing::gap(3));
-                let pressed = grade_buttons(ui, &offered, today);
-
-                // Edit this note — offered **only now the card is revealed** (ADR-0029 §1). The
-                // honest diagnosis of most leeches is a defective card (ADR-0010 §7), and its three
-                // named forms — ambiguous, too large, testing two facts at once — are all judgements
-                // about the *pair*, so all three are post-reveal findings already.
+                // **Edit note rides directly under the card, and the grades sit on the reach line**
+                // (ADR-0035 §1, §2). The order is still the reading order — prompt, answer, then
+                // the controls — but the *distance* is not: the page's leftover height falls
+                // between the card and the grades rather than below everything, so the controls
+                // pressed on every card land where the thumb already is and the one pressed rarely
+                // does not.
+                //
+                // **Above the slack rather than below the grades, and above the card was the other
+                // candidate.** Both keep it out of the thumb's zone; this one is cheaper, because
+                // nothing above it moves when it appears. Placed above the card it has to reserve
+                // an empty row before the reveal or the card jumps down at the exact moment the eye
+                // goes to the answer — judged in the hand and rejected there (ADR-0035 §2).
+                //
+                // Offered **only now the card is revealed** (ADR-0029 §1). The honest diagnosis of
+                // most leeches is a defective card (ADR-0010 §7), and its three named forms —
+                // ambiguous, too large, testing two facts at once — are all judgements about the
+                // *pair*, so all three are post-reveal findings already.
                 //
                 // **Nothing flips the card here, and that absence is the decision.** ADR-0021 §6's
-                // "entering the editor counts as a reveal" is retired with the pre-reveal control it
-                // existed for: a full-width button under the card, which is itself the reveal target,
-                // made a mis-tap spend the reveal on a card nobody chose to look at. So ADR-0006 §4's
-                // "no grading before the answer is seen" now holds because there is **no route** into
-                // the editor before the reveal — put this control back outside the `revealed` branch
-                // and the guarantee is silently false again, with no rule left to catch it.
+                // "entering the editor counts as a reveal" is retired with the pre-reveal control
+                // it existed for: a full-width button under the card, which is itself the reveal
+                // target, made a mis-tap spend the reveal on a card nobody chose to look at. So
+                // ADR-0006 §4's "no grading before the answer is seen" now holds because there is
+                // **no route** into the editor before the reveal — put this control back outside
+                // the `revealed` branch and the guarantee is silently false again, with no rule
+                // left to catch it.
                 //
                 // An edit that makes the card dormant still needs no mechanism: the next frame
                 // re-derives the queue and simply does not offer it (ADR-0006 §2).
@@ -230,6 +246,13 @@ pub(crate) fn review(
                 if full_width_button(ui, "Edit note").clicked() {
                     edit_request = Some(offered.card.note);
                 }
+
+                ui.add_space(frame::slack_above(
+                    frame::page_room(ui),
+                    grade_cluster_height(touch),
+                    spacing::gap(3),
+                ));
+                let pressed = grade_buttons(ui, &offered, today, touch);
 
                 if let Some(grade) = pressed {
                     let duration_ms = s.card_shown.elapsed().as_millis() as u64;
@@ -564,7 +587,7 @@ fn start_wording(available: usize) -> String {
 /// label with its interval still fits inside 118. So a later change to
 /// [ADR-0001](../../../../docs/adr/0001-scheduling-algorithm-and-grade-scale.md)'s scale does not
 /// have to reopen this arrangement.
-fn grade_buttons(ui: &mut egui::Ui, offered: &Offered, today: i64) -> Option<Grade> {
+fn grade_buttons(ui: &mut egui::Ui, offered: &Offered, today: i64, touch: bool) -> Option<Grade> {
     let label = |ui: &egui::Ui, grade: Grade, name: &str| {
         let days = session::interval_preview(offered, grade, today);
         controls::grade_label(ui, name, &format!("{days}d"))
@@ -575,16 +598,40 @@ fn grade_buttons(ui: &mut egui::Ui, offered: &Offered, today: i64) -> Option<Gra
         .clicked()
         .then_some(Grade::Forgot);
 
-    // Two units hold the passes apart from *Forgot*. Three was the old stacked break and it is more
-    // than a row needs: the row is already a different shape, so the gap only has to separate, not
-    // to carry the whole distinction on its own.
-    ui.add_space(spacing::gap(2));
-
     const PASSES: [(Grade, &str); 3] = [
         (Grade::Barely, "Barely"),
         (Grade::Good, "Good"),
         (Grade::Easy, "Easy"),
     ];
+
+    // **Under a thumb the passes stack; under a pointer they stay a row** (ADR-0035 §3). A thumb
+    // travels up and down freely and sideways badly, so the two ends of a segmented row flip
+    // between comfortable and a stretch depending on which hand holds the phone — which is not a
+    // sizing problem and cannot be fixed by a bigger target. A pointer has no such axis and crosses
+    // 208px for nothing, so it keeps the row ADR-0034 §1 chose.
+    //
+    // *Forgot* is held apart either way, which is the half of §1 that survives: **three** units
+    // here, because in a stack the gap carries the whole distinction on its own rather than sharing
+    // it with a change of shape.
+    if touch {
+        ui.add_space(spacing::gap(3));
+        for (i, (grade, name)) in PASSES.iter().enumerate() {
+            if i > 0 {
+                ui.add_space(spacing::gap(1));
+            }
+            let job = label(ui, *grade, name);
+            if controls::control_job(ui, job, ui.available_width()).clicked() {
+                pressed = Some(*grade);
+            }
+        }
+        return pressed;
+    }
+
+    // Two units hold the passes apart from *Forgot*. Three was the old stacked break and it is more
+    // than a row needs: the row is already a different shape, so the gap only has to separate, not
+    // to carry the whole distinction on its own.
+    ui.add_space(spacing::gap(2));
+
     let labels = PASSES
         .iter()
         .map(|(grade, name)| label(ui, *grade, name))
@@ -593,6 +640,21 @@ fn grade_buttons(ui: &mut egui::Ui, offered: &Offered, today: i64) -> Option<Gra
         pressed = Some(PASSES[i].0);
     }
     pressed
+}
+
+/// How tall the grade cluster draws, which [`frame::slack_above`] needs **before** drawing it.
+///
+/// Computed rather than measured: the cluster is a fixed composition of controls at a fixed height
+/// with stated gaps, so its height is arithmetic. A prototype that varied the composition had to
+/// remember last frame's measurement and carry a frame of lag; one composition needs neither.
+fn grade_cluster_height(touch: bool) -> f32 {
+    if touch {
+        // Forgot, the break, then three passes a unit apart.
+        controls::HEIGHT * 4.0 + spacing::gap(3) + spacing::gap(1) * 2.0
+    } else {
+        // Forgot, the break, then the segmented row.
+        controls::HEIGHT * 2.0 + spacing::gap(2)
+    }
 }
 
 /// The caught-up floor: the statement, centred and given the screen (ADR-0034 §3).
@@ -702,6 +764,7 @@ mod tests {
                     &mut pointer,
                     now_ms,
                     TODAY,
+                    false,
                 );
             })
         };
@@ -781,6 +844,7 @@ mod tests {
                     &mut pointer,
                     now_ms,
                     TODAY,
+                    false,
                 );
             })
         };
@@ -829,6 +893,96 @@ mod tests {
     fn the_entrance_names_what_starting_commits_to() {
         assert_eq!(start_wording(6), "Start — all 6");
         assert_eq!(start_wording(1), "Start — the one card");
+    }
+
+    /// **ADR-0035 §3, and the only thing that keeps the two axes apart.** Under a thumb every grade
+    /// is a full-width control; under a pointer the three passes share one row.
+    ///
+    /// Asserted on the **widths actually drawn**, not on the branch taken, because the defect this
+    /// guards against is a control that renders perfectly at the wrong width. Deleting the `touch`
+    /// argument and always drawing the row compiles, passes every other test, and silently returns
+    /// the handset to a grade row whose two ends flip between comfortable and a stretch depending on
+    /// which hand is holding the phone — the finding #141 was opened for.
+    #[test]
+    fn the_grades_stack_under_a_thumb_and_stay_a_row_under_a_pointer() {
+        const WIDTH: f32 = 392.0; // the handset's column: 448dp less two 28dp margins.
+
+        fn control_widths(width: f32, touch: bool) -> Vec<f32> {
+            let ctx = egui::Context::default();
+            crate::theme::install(&ctx);
+            crate::typography::install(&ctx);
+            crate::spacing::install(&ctx);
+
+            let offered = Offered {
+                card: CardRef {
+                    note: NoteId([0; 16]),
+                    ordinal: 0,
+                },
+                box_: 1,
+                is_new: true,
+                memory: None,
+                last_day: 0,
+            };
+            let out = ctx.run_ui(Default::default(), |ui| {
+                ui.set_width(width);
+                grade_buttons(ui, &offered, 0, touch);
+            });
+
+            fn walk(shape: &egui::Shape, fill: egui::Color32, into: &mut Vec<f32>) {
+                match shape {
+                    egui::Shape::Rect(r) if r.fill == fill => into.push(r.rect.width().round()),
+                    egui::Shape::Vec(shapes) => shapes.iter().for_each(|s| walk(s, fill, into)),
+                    _ => {}
+                }
+            }
+            let mut widths = Vec::new();
+            for clipped in &out.shapes {
+                walk(&clipped.shape, crate::theme::control_fill(), &mut widths);
+            }
+            widths
+        }
+
+        let stacked = control_widths(WIDTH, true);
+        assert_eq!(
+            stacked.len(),
+            4,
+            "a thumb gets four separate controls — drew {stacked:?}"
+        );
+        assert!(
+            stacked.iter().all(|w| *w == WIDTH.round()),
+            "every stacked grade takes the whole column — drew {stacked:?}"
+        );
+
+        let row = control_widths(WIDTH, false);
+        assert_eq!(
+            row.len(),
+            4,
+            "a pointer still gets four controls, three of them sharing a row — drew {row:?}"
+        );
+        assert!(
+            row.iter().filter(|w| **w == WIDTH.round()).count() == 1,
+            "only *Forgot* spans the column under a pointer — drew {row:?}"
+        );
+        assert!(
+            row.iter().filter(|w| **w < WIDTH.round() / 2.0).count() == 3,
+            "the three passes share one row, so each is well under half the column — drew {row:?}"
+        );
+    }
+
+    /// The cluster's height is what [`frame::slack_above`] is given, so the two must agree or the
+    /// bottom edge lands somewhere the ADR does not describe. Computed rather than measured, which
+    /// makes this checkable without a window — and worth checking, because the arithmetic is the
+    /// kind that stays plausible while being wrong by one gap.
+    #[test]
+    fn the_cluster_height_matches_what_the_cluster_draws() {
+        let stacked = controls::HEIGHT * 4.0 + spacing::gap(3) + spacing::gap(1) * 2.0;
+        let row = controls::HEIGHT * 2.0 + spacing::gap(2);
+        assert_eq!(grade_cluster_height(true), stacked);
+        assert_eq!(grade_cluster_height(false), row);
+        assert!(
+            grade_cluster_height(true) > grade_cluster_height(false),
+            "the stack is the taller of the two, which is what the slack has to absorb"
+        );
     }
 
     #[test]

--- a/docs/adr/0035-the-vertical-anchor.md
+++ b/docs/adr/0035-the-vertical-anchor.md
@@ -1,0 +1,154 @@
+# ADR-0035: The vertical anchor — the reach line, and the axis a thumb has
+
+- **Status**: Accepted
+- **Date**: 2026-08-16
+- **Resolves**: [Design Pass: The Vertical Anchor — What the Leftover Height Does](https://github.com/amin-bf/cairn/issues/141)
+- **Related**: [ADR-0031](0031-the-page-frame.md) (the page frame, whose two horizontal numbers this
+  joins with a vertical one it left unasked), [ADR-0034 §1](0034-the-controls.md) (the segmented
+  grade row, which §3 supersedes under a thumb and keeps under a pointer),
+  [ADR-0033 §1 §4](0033-the-card.md) (the card is one object at a fixed height, which §1 relies on
+  and §2 protects), [ADR-0029 §1](0029-editing-a-note-from-the-review-screen.md) (*when* the edit
+  entrance is offered, which §2 moves the *where* of and does not reopen),
+  [ADR-0026 §5](0026-the-per-tap-keyboard-re-pop.md) (the soft-keyboard state type §3 reads),
+  [ADR-0025 §1](0025-the-authoring-screen-under-a-soft-keyboard.md) (the reserved inset bands the
+  reach line is measured from the top of)
+- **Evidence**: two sittings on a physical Pixel 8 Pro, in the hand, with the control cluster
+  **dragged into position by thumb** and the resulting distance read off a live on-screen readout.
+  Thirteen desktop captures of six candidate arrangements at 448×997 precede them, preserved with
+  the prototype as the tag `prototypes/issue-141`, readme at
+  [`docs/design/prototype-141/README.md`](../design/prototype-141/README.md).
+
+## Context
+
+[ADR-0031](0031-the-page-frame.md) decided what the leftover **width** does — nothing — and never
+asked what the leftover **height** does, because at the 860px window every capture in the design pass
+was taken at, there isn't any. On a handset there is a great deal of it.
+
+[#125](https://github.com/amin-bf/cairn/issues/125)'s sitting on the physical device found where it
+goes and what that costs. Measured there: the control cluster ended at **y=1880 of 2992**, so the
+card, the grades and *Edit note* occupied the top 63% of the page and the bottom ~1100px — the part a
+thumb owns — was empty. The screen was judged to *look* calm and to *be* a stretch one-handed, and
+those are the same fact: it looks calm because everything is up top.
+
+**No target was undersized.** The centre segment of the grade row was comfortable in either hand and
+nothing was mis-hit. This is placement alone — which is the first time the design pass's own rule,
+*hit targets and density follow touch, not the pointer*, had met an actual thumb. The rule was
+honoured in **sizing** — a 36px control is still 36px — and the arrangement was laid out for a
+pointer regardless, which is a gap the rule as written does not close.
+
+Two constraints came with the ticket. **The card must not absorb the slack**: `surface::REVIEW_HEIGHT`
+is a constant 300 logical px and ADR-0033 §1 makes the card a well cut into the page, so a well
+stretched to a 997dp page reads as a container that failed to fill. And **horizontal reach is a
+second axis**: *Barely* and *Easy* sit at the two extremes of the segmented row and flip between
+comfortable and a stretch depending on which hand holds the phone.
+
+## Decision
+
+### 1. The last control on a screen sits on a **reach line**, 165px above the bottom of the page
+
+> **`frame::REACH_LINE` is 165.** When the page has the room, the bottom edge of the final control
+> cluster lands there and the leftover height falls **between the card and the controls**. When it
+> does not, the controls follow the card at the ordinary stated gap and nothing is placed.
+
+**165 is measured, not chosen, and the measurement is the finding.** The prototype made the cluster
+*draggable* rather than offering fixed candidates, because the round before it came back as "closer,
+but the very bottom is still a stretch" — which is an answer about a distance nobody had a number
+for. It was then placed by thumb twice, a round apart, with different contents:
+
+| round | cluster | height | bottom edge above the page bottom |
+|---|---|---|---|
+| two | *Forgot* over a segmented row | 148 | **162** |
+| three | four grades stacked | 184 | **169** |
+
+Two placements, two shapes, converging within 7px. So what a thumb picks is **a line above the
+bottom of the page**, not a gap below the card: the cluster grows upward from that line and the slack
+absorbs the difference. That is why this ADR names one number rather than a gap plus a cluster
+height, and why the arithmetic subtracts the cluster's own height rather than adding a margin.
+
+**It is an absolute distance, not a fraction of the page.** The band it clears is where the hand
+*grips*, and a grip is physical. A proportion would put the line too high on a tall screen and too
+low on a short one.
+
+**And it is one rule, not a breakpoint.** The same expression covers the handset, the desktop window
+and everything between: the gap absorbs whatever is left over and stops at the stated gap when there
+is nothing left. The 860px window the design pass judges at reaches that arm by arithmetic, without
+anything having to ask what it is running on — which is what keeps
+[#124](https://github.com/amin-bf/cairn/issues/124)'s *one arrangement, centred, at every width*
+intact here.
+
+### 2. ***Edit note* rides directly under the card**
+
+> The reading order is unchanged — prompt, answer, then the controls — and the **distance** is not:
+> the slack falls between *Edit note* and the grades, so the rarest control on the screen keeps the
+> worst reach and the ones pressed on every card take the zone the thumb owns.
+
+The ticket proposed two candidates and **the sitting struck both**, on a rule it produced while
+being judged: **the card must not move when it is revealed.** *Reading order held* bottom-anchors the
+whole stack, so the card rises on reveal to make room for the grades; *frequency maps to reach* puts
+*Edit note* above the card, so the card is pushed down when that control appears. Both move the card
+at the exact moment the eye is going to the answer, which is the one moment on this screen when
+nothing should move.
+
+Under the card, the same aim costs nothing: the control appears below everything already drawn, so
+nothing above it shifts. Above the card the position is only tenable with an **empty reserved row**
+before the reveal, which was drawn, judged, and beaten by this.
+
+This moves *where* the entrance is drawn and does not touch **when**: ADR-0029 §1 still offers it
+only on a revealed card, and ADR-0006 §4's guarantee still holds by there being no route into the
+editor before the reveal.
+
+### 3. Under a thumb the grades **stack**; under a pointer they stay a row
+
+> Four full-width controls, *Forgot* held apart by three units and the three passes a unit apart, on
+> a touch-operated platform. On a pointer platform, ADR-0034 §1's arrangement is unchanged.
+
+**This supersedes ADR-0034 §1 for touch**, and the reason is one sentence from the sitting: *a thumb
+travels up and down freely and sideways badly*. That is why the horizontal axis the ticket carried is
+**dissolved rather than answered** — a stack has no extremes, so there is nothing left at one for a
+hand to fail to reach. Narrowing and centring the row was the alternative and it was drawn; it treats
+the symptom and keeps the axis.
+
+§1 is not wrong about what it argued. It chose the row on an argument about **the scale** — four
+stacked controls read as four rungs of one ladder, which puts the failure grade on a scale it is not
+on — and it measured its widths at 208px and 163px, which are comfortable. What it never had was a
+thumb, and the axis it chose is the axis a thumb is worst on. **The half of §1 that survives is
+*Forgot* held apart**, now carried by a three-unit gap rather than by a change of shape, because in a
+stack the gap is doing that work alone.
+
+**The rule is *touch*, and the soft keyboard is how this client reads it.** A platform that raises a
+keyboard on the screen is a platform with no pointer, and `platform::SoftKeyboard` already
+distinguishes *absent* from *down* because ADR-0026 §5 forced it to — so this needs no new seam
+function, no capability constant and no `#[cfg]` at a call site. The proxy is exact for the two
+targets that exist. **A native client asks its own platform directly**: this section states the
+decision in terms of touch precisely so that a Kotlin or Swift client implements the same rule
+without inheriting egui's way of noticing.
+
+## Consequences
+
+- **The frame gains its first vertical number.** `frame` now owns `REACH_LINE`, `page_room` and
+  `slack_above` beside `PAGE_MARGIN` and `MEASURE` — one naming site for the page's geometry in both
+  axes, on the same argument ADR-0031 made for the horizontal pair.
+- **`Ui::available_height` is unusable inside a `ScrollArea` and this is written down in `frame`.**
+  It returns **zero**: the content `Ui` is sized to its content — that is what scrolling means — so
+  "available" is what the widgets already drawn have claimed, never what the screen has left. The
+  clip rect is the viewport. Found by a prototype variant rendering pixel-identically to the thing it
+  was varying, with nothing failing and no test that could have caught it.
+- **Two tests carry the rule**, both of which fail on a change that renders perfectly. One pins that
+  the cluster's bottom edge lands on the line *whatever the cluster holds*; the other asserts the
+  grades' **drawn widths** under each platform, because dropping the touch argument and always
+  drawing the row compiles, passes everything else, and silently returns the handset to the state
+  #141 was opened for.
+- **The Review screen now has three vertical regions rather than one stack**: the card and its
+  entrance at the top, the slack, the grades on the line. Every other screen is untouched — none of
+  them has a control cluster the hand returns to dozens of times in a sitting, which is the property
+  that earns the placement. Whether the note list and Settings want it is the Notes and Settings
+  slices' question, not this one.
+- **An uninstall is not a first launch on Android.** Found while deploying the prototype: `data_dir`
+  is `getFilesDir()`, which ADR-0007 §6 deliberately puts *in* the Auto Backup set, so a reinstall
+  restored the previous collection and the prototype's seed silently did not run. Any handset
+  checkpoint that assumes a fresh install gives a fresh collection is wrong; `adb shell pm clear`
+  is the thing that does.
+- **The design pass's *targets follow touch* rule now covers arrangement too.** It was honoured in
+  sizing and silent about placement, which is how a screen sized for a thumb ended up arranged for a
+  pointer with nothing failing. §1 and §3 are the two halves of closing that: where the controls sit,
+  and which axis they are spread along.


### PR DESCRIPTION
Resolves #141, the fifth slice of the Review vertical on [the design pass map](https://github.com/amin-bf/cairn/issues/121).

## What this decides

**The last control cluster on a screen ends 165px above the bottom of the page** when there is room, and follows the card at the ordinary gap when there is not — one rule, no breakpoint, the desktop window reaching the second arm by arithmetic. ***Edit note* rides directly under the card**, above the slack. And **under a thumb the four grades stack** instead of taking ADR-0034 §1's segmented row.

Recorded as [ADR-0035](https://github.com/amin-bf/cairn/blob/DesignPass/TheReachLine/docs/adr/0035-the-vertical-anchor.md).

## 165 is measured, not chosen

The prototype made the cluster **draggable** rather than offering fixed candidates, because the round before came back as *"closer, but the very bottom is still a stretch"* — an answer about a distance nobody had a number for. It was then placed by thumb twice on a physical Pixel 8 Pro, a round apart, with different contents:

| round | cluster | height | bottom edge above the page bottom |
|---|---|---|---|
| two | *Forgot* over a segmented row | 148 | 162 |
| three | four grades stacked | 184 | 169 |

Converging within 7px across two shapes. So a thumb picks a **line above the bottom of the page**, not a gap below the card — which is why the ADR names one number rather than a gap plus a cluster height.

## What the sitting struck

Both arrangements the ticket itself proposed, on a rule it produced while being judged: **the card must not move when it is revealed**. *Reading order held* raises the card on reveal to make room for the grades; *frequency maps to reach* pushes it down when *Edit note* appears above it. Both move the card at the moment the eye goes to the answer.

The ticket's second axis — *Barely* and *Easy* flipping between hands at the two ends of the row — is **dissolved rather than answered**: a stack has no extremes.

## Two traps recorded

- **`Ui::available_height` returns zero inside a `ScrollArea`.** The content `Ui` is sized to its content, so "available" is what the widgets already drawn have claimed, never what the screen has left. Found by a prototype variant rendering pixel-identically to the thing it was varying, with nothing failing.
- **An uninstall is not a first launch on Android.** `data_dir` is `getFilesDir()`, which ADR-0007 §6 deliberately puts *in* the Auto Backup set, so a reinstall restored the previous collection and the prototype's seed silently did not run.

## Also here

**ADR-0034 is added to `CONTEXT-MAP.md`**, which #134 never did — the workspace rule is that an ADR missing from that table is invisible to the agent it was written for, and it has been missing since it was accepted.

## Verification

`cargo test --workspace` (256 pass, 4 new), `cargo clippy --workspace --all-targets` and `cargo fmt --check` all clean. Both paths photographed: the pointer arrangement in the nested-compositor harness at 448×997, the touch arrangement on the physical handset, with the cluster's bottom edge measured at 165 in both.

Two tests carry the rule and both fail on a change that renders perfectly — the bottom edge landing on the line whatever the cluster holds, and the grades' **drawn widths** differing by platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)