### PR TITLE
Design Pass / The Tied Leeches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -526,6 +526,25 @@ because they are validated findings, not because a web build ships.
     window size and the run produces perfectly valid captures of the *previous* screen under the next
     one's names. That silent miss has now arrived from four different sides (#122, #143, #153, #155);
     `%CX%`, `%LX+n%` and `%BY-n%` exist to close each of them.
+22. **A fixture may not depend on anything the card *identity* decides, because identity is random
+    per build.** A `NoteId` is `uuid_v4` from the OS, so it is stable across **devices sharing a
+    collection** — which is all any of the rules below it were ever for — and freshly random across
+    **builds of the same fixture definition**. Two places read it, and a fixture that lands near
+    either one is a coin flip rather than a state:
+    - `replay::leeches` breaks a rank tie on `CardRef::encode`. #160 found all three leeches given
+      identical histories, so both real keys tied, and every capture of the leech screen this
+      repository held showed an order the run had picked at random — two captures from *one* run
+      disagreed with each other. A fixture whose screen shows an order must **break the real keys**.
+    - `scheduling`'s interval fuzz is seeded from `CardRef::encode` (ADR-0027 §5, ADR-0001 §7), so a
+      card scheduled close to due is due on some builds and not others. The pre-#160 leech recovery
+      left as little as **two days** of margin against a fuzz that swings about three; it had simply
+      not lost the toss yet. Fixtures now leave **at least five days**, asserted directly, because
+      `Fixture::check` only ever sees the build it ran on and fails *intermittently* otherwise.
+
+    Both are the same shape as store rule 6 and the `%CX%` family: nothing errors, nothing looks
+    wrong, and the artifact is a valid picture of something nobody chose. **Measure, do not reason**
+    — the intervals are `fsrs`'s, so a new fixture's margin is found by installing it a few hundred
+    times, not by argument.
 
 ## The local store
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -529,22 +529,29 @@ because they are validated findings, not because a web build ships.
 22. **A fixture may not depend on anything the card *identity* decides, because identity is random
     per build.** A `NoteId` is `uuid_v4` from the OS, so it is stable across **devices sharing a
     collection** — which is all any of the rules below it were ever for — and freshly random across
-    **builds of the same fixture definition**. Two places read it, and a fixture that lands near
-    either one is a coin flip rather than a state:
+    **builds of the same fixture definition**. **Four** things read it on the way to a screen, and a
+    fixture that leaves any of them to decide is photographing a coin flip rather than a state:
     - `replay::leeches` breaks a rank tie on `CardRef::encode`. #160 found all three leeches given
       identical histories, so both real keys tied, and every capture of the leech screen this
       repository held showed an order the run had picked at random — two captures from *one* run
       disagreed with each other. A fixture whose screen shows an order must **break the real keys**.
+    - `session::compose` breaks the **due queue's** tie the same way, so it decides *which card a
+      sitting opens on*. This is the one that is still live: `backlog`'s twenty-five cards share one
+      history, so `checkpoint.txt` run twice photographs two different cards — measured, `le phare`
+      and `la marée` from the same storyboard minutes apart.
     - `scheduling`'s interval fuzz is seeded from `CardRef::encode` (ADR-0027 §5, ADR-0001 §7), so a
-      card scheduled close to due is due on some builds and not others. The pre-#160 leech recovery
-      left as little as **two days** of margin against a fuzz that swings about three; it had simply
-      not lost the toss yet. Fixtures now leave **at least five days**, asserted directly, because
-      `Fixture::check` only ever sees the build it ran on and fails *intermittently* otherwise.
+      card scheduled close to due is due on some builds and not others — and, through `due_day`, it
+      also perturbs the queue order above. The pre-#160 leech recovery left as little as **two days**
+      of margin against a fuzz that swings about three; it had simply not lost the toss yet. Fixtures
+      now leave **at least five days**, asserted directly, because `Fixture::check` only ever sees
+      the build it ran on and fails *intermittently* otherwise.
+    - `screens::review`'s suspended section sorts on identity too. No fixture suspends anything yet,
+      so this one is a trap rather than a defect — the first fixture that does inherits it.
 
-    Both are the same shape as store rule 6 and the `%CX%` family: nothing errors, nothing looks
+    All four are the same shape as store rule 6 and the `%CX%` family: nothing errors, nothing looks
     wrong, and the artifact is a valid picture of something nobody chose. **Measure, do not reason**
     — the intervals are `fsrs`'s, so a new fixture's margin is found by installing it a few hundred
-    times, not by argument.
+    times, not by argument, and a fixture whose order matters is checked by *installing it twice*.
 
 ## The local store
 

--- a/crates/app/src/CONTEXT.md
+++ b/crates/app/src/CONTEXT.md
@@ -301,9 +301,11 @@ checkpoint is not a fixture** and cannot be: it hangs off a sitting's monotonic 
 offers one lever that only ever *shortens* what ADR-0006 §1 names. A fixture is also **reproducible
 or it is not a fixture**: the bench exists so a re-run is comparable to the run before it, so nothing
 a fixture photographs may depend on the card *identity*, which is `uuid_v4` and therefore fresh on
-every build. Two things read it — `replay::leeches`' rank tie-break and `scheduling`'s interval fuzz
-— and #160 found the `leeches` fixture landing on the first, so two widths of one run ranked the
-same three cards differently (AGENTS.md, capture rule 22).
+every build. Four things read it on the way to a screen — the leech rank tie-break, the **due
+queue's** tie-break, the interval fuzz and the suspended section — and #160 found the `leeches`
+fixture landing on the first, so two widths of one run ranked the same three cards differently. The
+second is still live in `backlog`, whose twenty-five cards share one history (AGENTS.md, capture
+rule 22).
 _Avoid_: Seed, for a fixture — the seed is the six cards a real first install meets, and conflating
 the two is how "just extend the seed" gets proposed again; capture mode, which is the route this
 deliberately is not.

--- a/crates/app/src/CONTEXT.md
+++ b/crates/app/src/CONTEXT.md
@@ -298,7 +298,12 @@ Settings for the handset, where `getFilesDir()` is unwritable from outside and a
 first launch either. A fixture **verifies itself** and refuses a collection that is not empty, because
 the failure it exists to prevent is a plausible picture of the wrong screen. The **10-minute
 checkpoint is not a fixture** and cannot be: it hangs off a sitting's monotonic clock, so the bench
-offers one lever that only ever *shortens* what ADR-0006 §1 names.
+offers one lever that only ever *shortens* what ADR-0006 §1 names. A fixture is also **reproducible
+or it is not a fixture**: the bench exists so a re-run is comparable to the run before it, so nothing
+a fixture photographs may depend on the card *identity*, which is `uuid_v4` and therefore fresh on
+every build. Two things read it — `replay::leeches`' rank tie-break and `scheduling`'s interval fuzz
+— and #160 found the `leeches` fixture landing on the first, so two widths of one run ranked the
+same three cards differently (AGENTS.md, capture rule 22).
 _Avoid_: Seed, for a fixture — the seed is the six cards a real first install meets, and conflating
 the two is how "just extend the seed" gets proposed again; capture mode, which is the route this
 deliberately is not.

--- a/crates/app/src/fixtures.rs
+++ b/crates/app/src/fixtures.rs
@@ -235,19 +235,17 @@ impl Fixture {
             Fixture::CaughtUp => caught_up(coll, &mut history, 12)?,
             Fixture::Leeches => {
                 caught_up(coll, &mut history, 9)?;
-                // A leech that is **not due**: four failure days inside the ninety-day window, then
-                // a recovery long enough to schedule it ahead. Both halves are needed — a card whose
-                // *last* grade is a failure is due whatever its interval says (`session::compose`),
-                // so a leech that simply failed its way over the floor cannot coexist with a
-                // caught-up screen, and one that failed four times still has too little stability to
-                // leave the queue on a single pass.
-                for (front, back) in LEECH_WORDS {
-                    let card = note(coll, front, back)?;
-                    history.fails(card, [80, 60, 40, 20]);
-                    history.passes(
-                        card,
-                        [(18, Grade::Good), (10, Grade::Good), (3, Grade::Easy)],
-                    );
+                // Leeches that are **not due**: failure days inside the ninety-day window, then a
+                // recovery long enough to schedule each one ahead. Both halves are needed — a card
+                // whose *last* grade is a failure is due whatever its interval says
+                // (`session::compose`), so a leech that simply failed its way over the floor cannot
+                // coexist with a caught-up screen, and a card that has failed that often still has
+                // too little stability to leave the queue on a single pass. The three records
+                // differ from each other on purpose; [`LEECHES`] is where that is argued.
+                for leech in &LEECHES {
+                    let card = note(coll, leech.front, leech.back)?;
+                    history.fails(card, leech.fails);
+                    history.passes(card, leech.passes);
                 }
             }
             Fixture::Crossing => {
@@ -256,7 +254,7 @@ impl Fixture {
                 // one more *Forgot*, on a fourth distinct day, takes it over the floor during the
                 // sitting rather than before it.
                 let card = note(coll, "l'écureuil", "the squirrel")?;
-                history.fails(card, [40, 30, 20]);
+                history.fails(card, &[40, 30, 20]);
             }
             Fixture::Backlog => {
                 // One pass, long enough ago that the interval it bought has expired several times
@@ -264,27 +262,23 @@ impl Fixture {
                 // person who kept failing.
                 for (front, back) in BACKLOG_WORDS {
                     let card = note(coll, front, back)?;
-                    history.passes(card, [(60, Grade::Good)]);
+                    history.passes(card, &[(60, Grade::Good)]);
                 }
             }
             // **A composition of the two above, deliberately re-tuning neither.** The leeches are
-            // `Leeches`'s exactly — four failure days inside the window, then a recovery long
-            // enough to schedule them ahead — so they are leeches *and not due*, which is what lets
-            // due cards decide the screen. The due half is `Backlog`'s expired pass. Both sets of
-            // intervals are already asserted by their own fixtures, so this one adds no third claim
-            // about `fsrs` to keep true.
+            // `Leeches`'s exactly — [`LEECHES`] entire, ranks and all — so they are leeches *and not
+            // due*, which is what lets due cards decide the screen. The due half is `Backlog`'s
+            // expired pass. Both sets of intervals are already asserted by their own fixtures, so
+            // this one adds no third claim about `fsrs` to keep true.
             Fixture::DueWithLeeches => {
                 for (front, back) in BACKLOG_WORDS {
                     let card = note(coll, front, back)?;
-                    history.passes(card, [(60, Grade::Good)]);
+                    history.passes(card, &[(60, Grade::Good)]);
                 }
-                for (front, back) in LEECH_WORDS {
-                    let card = note(coll, front, back)?;
-                    history.fails(card, [80, 60, 40, 20]);
-                    history.passes(
-                        card,
-                        [(18, Grade::Good), (10, Grade::Good), (3, Grade::Easy)],
-                    );
+                for leech in &LEECHES {
+                    let card = note(coll, leech.front, leech.back)?;
+                    history.fails(card, leech.fails);
+                    history.passes(card, leech.passes);
                 }
             }
             Fixture::Cloze => {
@@ -455,15 +449,15 @@ struct History {
 
 impl History {
     /// Grade this card *Forgot* on each of these days — one **failure day** apiece (ADR-0010 §2).
-    fn fails<const N: usize>(&mut self, card: CardRef, days_ago: [i64; N]) {
-        for day in days_ago {
+    fn fails(&mut self, card: CardRef, days_ago: &[i64]) {
+        for &day in days_ago {
             self.rows.push((day, card, Grade::Forgot));
         }
     }
 
     /// Grade this card at the given days and grades, oldest first.
-    fn passes<const N: usize>(&mut self, card: CardRef, reviews: [(i64, Grade); N]) {
-        for (day, grade) in reviews {
+    fn passes(&mut self, card: CardRef, reviews: &[(i64, Grade)]) {
+        for &(day, grade) in reviews {
             self.rows.push((day, card, grade));
         }
     }
@@ -491,7 +485,7 @@ impl History {
 fn caught_up(coll: &mut Collection, history: &mut History, count: usize) -> Result<(), String> {
     for (front, back) in CAUGHT_UP_WORDS.iter().take(count) {
         let card = note(coll, front, back)?;
-        history.passes(card, [(20, Grade::Good), (2, Grade::Easy)]);
+        history.passes(card, &[(20, Grade::Good), (2, Grade::Easy)]);
     }
     Ok(())
 }
@@ -609,10 +603,93 @@ const CAUGHT_UP_WORDS: [(&str, &str); 12] = [
     ("le seuil", "the threshold"),
 ];
 
-const LEECH_WORDS: [(&str, &str); 3] = [
-    ("néanmoins", "nevertheless"),
-    ("désormais", "from now on"),
-    ("d'ailleurs", "besides"),
+/// One leech, and the record that ranks it.
+struct LeechSpec {
+    front: &'static str,
+    back: &'static str,
+    /// Days before now on which the card was graded *Forgot* — one **failure day** each, and the
+    /// primary rank key is how many of them there are (`replay::leeches`).
+    fails: &'static [i64],
+    /// The recovery that takes the card back out of the queue, oldest first. A card whose latest
+    /// grade is a failure is due whatever its interval says, so every leech here has to pass its
+    /// way out; the count also feeds the caption's second number, which is **not** a rank key.
+    passes: &'static [(i64, Grade)],
+}
+
+/// The three leeches, **deliberately unequal, and unequal in two different ways**.
+///
+/// They were identical until [#160](https://github.com/amin-bf/cairn/issues/160) — four failure days
+/// and the same last failure day apiece — so both of `replay::leeches`' rank keys tied and the order
+/// fell through to the card-identity tie-break. That key is stable across *devices sharing a
+/// collection* and freshly random across *builds of a fixture*, so every capture of this screen the
+/// repository held showed an order the run had picked at random, and a re-run produced a diff that
+/// read as a change and was not one.
+///
+/// The spread is chosen to photograph the rank **as it actually behaves**, not to make it look
+/// easy. `néanmoins` is worst on the visible key and leads. `désormais` and `d'ailleurs` **tie on
+/// it** and are separated only by which failed more recently — a key the screen does not draw — so
+/// the pair is the honest test of whether the caption can carry the order at all
+/// ([#156](https://github.com/amin-bf/cairn/issues/156)). Giving all three distinct counts would
+/// have hidden that question behind a fixture rigged to answer it.
+///
+/// Review counts differ too, and their **order is chosen against the rank**: the tied pair reads
+/// *"4 bad days · 9 reviews"* above *"4 bad days · 10 reviews"*, so one picture shows that the
+/// caption's second number is context and not the key that ordered the list. Ordering them the
+/// other way would have let a reader read the screen correctly for the wrong reason.
+///
+/// # The recoveries are sized, not guessed
+///
+/// Each record ends in enough successful reviews to put the card **7 to 14 days** clear of due, and
+/// that margin is the specification rather than slack. `scheduling`'s interval fuzz is seeded from
+/// the `CardRef` (ADR-0027 §5, ADR-0001 §7) — the same identity that is stable across devices and
+/// **random across builds** — so a leech scheduled close to the edge is due on some builds and not
+/// on others, and the fixture's own check then fails intermittently. Measured over 200 builds
+/// apiece, the recovery this fixture shipped before #160 left as little as **two days** of margin;
+/// these leave seven at worst. A future edit here should re-measure rather than reason: the
+/// intervals are `fsrs`'s, not ours.
+const LEECHES: [LeechSpec; 3] = [
+    // Six failure days: worst on the primary key, and first whatever the other two do.
+    LeechSpec {
+        front: "néanmoins",
+        back: "nevertheless",
+        fails: &[86, 71, 57, 43, 29, 15],
+        passes: &[
+            (36, Grade::Good),
+            (25, Grade::Good),
+            (16, Grade::Good),
+            (9, Grade::Easy),
+            (4, Grade::Easy),
+            (1, Grade::Easy),
+        ],
+    },
+    // Four failure days, the more recent last failure — second, on nine reviews.
+    LeechSpec {
+        front: "désormais",
+        back: "from now on",
+        fails: &[79, 62, 45, 22],
+        passes: &[
+            (40, Grade::Good),
+            (28, Grade::Good),
+            (17, Grade::Good),
+            (8, Grade::Easy),
+            (3, Grade::Easy),
+        ],
+    },
+    // Four failure days, the older last failure — third, on *more* reviews than the row above it,
+    // and the screen cannot say why it is third.
+    LeechSpec {
+        front: "d'ailleurs",
+        back: "besides",
+        fails: &[84, 68, 52, 36],
+        passes: &[
+            (30, Grade::Good),
+            (20, Grade::Good),
+            (13, Grade::Good),
+            (7, Grade::Good),
+            (3, Grade::Good),
+            (1, Grade::Easy),
+        ],
+    },
 ];
 
 const BACKLOG_WORDS: [(&str, &str); 25] = [
@@ -703,6 +780,140 @@ mod tests {
         let reached = Fixture::Leeches.install(&mut coll, NOW_MS).unwrap();
         assert_eq!(reached.state, ReviewState::CaughtUp);
         assert_eq!(reached.leeches, 3);
+    }
+
+    /// One ranked leech, read the way `screens::review` reads it — the prompt, the two rank keys,
+    /// and the review count the caption's second number comes from.
+    #[derive(Debug, PartialEq, Eq)]
+    struct RankedLeech {
+        prompt: String,
+        failure_days: u32,
+        last_failure_day: i64,
+        reviews: u32,
+    }
+
+    fn ranked_leeches(coll: &Collection, now_ms: i64) -> Vec<RankedLeech> {
+        let today = cairn_core::log::day_number(now_ms, DayScale::default());
+        let current = deck::current_cards(coll).unwrap();
+        let lines = coll.log_lines().unwrap();
+        let refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        let replayed = replay(&current, &refs);
+        leeches(&replayed, today)
+            .into_iter()
+            .map(|leech| RankedLeech {
+                prompt: deck::render(coll, leech.card)
+                    .unwrap()
+                    .expect("a leech's card is still generated")
+                    .prompt,
+                failure_days: leech.failure_days,
+                last_failure_day: leech.last_failure_day,
+                reviews: replayed
+                    .cards
+                    .get(&leech.card)
+                    .map_or(0, |state| state.review_count),
+            })
+            .collect()
+    }
+
+    /// **The leech order is a fact about the collection, and the same fact on every build.**
+    ///
+    /// Three things are pinned, because the defect [#160](https://github.com/amin-bf/cairn/issues/160)
+    /// found had three faces. The **order** is stated, so a fixture edit that reshuffles the screen
+    /// says so here rather than in a capture nobody diffs. The two rank keys are **distinct per
+    /// card**, which is the property that keeps the order reproducible — `replay::leeches` falls
+    /// through to card identity when they tie, and identity is `uuid_v4` per build, so a tied
+    /// fixture ranks differently every run. And no two **captions** are the same string, so the
+    /// three rows can be told apart in a picture.
+    ///
+    /// The second install is the half that can actually see the old defect: a single-install
+    /// assertion against three tied leeches passes one run in six.
+    #[test]
+    fn the_leeches_rank_in_a_stated_order_and_the_same_one_every_build() {
+        let (_d, _s, mut coll) = empty();
+        Fixture::Leeches.install(&mut coll, NOW_MS).unwrap();
+        let ranked = ranked_leeches(&coll, NOW_MS);
+
+        let order: Vec<&str> = ranked.iter().map(|l| l.prompt.as_str()).collect();
+        assert_eq!(
+            order,
+            ["néanmoins", "désormais", "d'ailleurs"],
+            "worst first (ADR-0010 §4): six failure days, then four and four split by recency"
+        );
+
+        let keys: HashSet<(u32, i64)> = ranked
+            .iter()
+            .map(|l| (l.failure_days, l.last_failure_day))
+            .collect();
+        assert_eq!(
+            keys.len(),
+            3,
+            "two leeches tying on both rank keys hand the order to a per-build random id"
+        );
+
+        let captions: Vec<(u32, u32)> =
+            ranked.iter().map(|l| (l.failure_days, l.reviews)).collect();
+        assert_eq!(
+            captions,
+            [(6, 12), (4, 9), (4, 10)],
+            "the screen draws '{{days}} bad days · {{reviews}} reviews' and nothing else per row: \
+             three distinct strings, and the review count deliberately *ascending* across the \
+             tied pair so it cannot be mistaken for what ordered them"
+        );
+
+        let (_d2, _s2, mut again) = empty();
+        Fixture::Leeches.install(&mut again, NOW_MS).unwrap();
+        assert_eq!(
+            ranked_leeches(&again, NOW_MS),
+            ranked,
+            "the same definition installed twice must rank the same way"
+        );
+    }
+
+    /// **Every leech sits well clear of due, and the margin is the assertion.**
+    ///
+    /// `Fixture::check` already refuses a `leeches` collection with anything due, but it only ever
+    /// sees the one build it ran on. The interval fuzz is seeded from the `CardRef` (ADR-0027 §5),
+    /// which is fresh per build, so a leech scheduled one day clear passes that check on most runs
+    /// and fails on the rest — an intermittent failure whose cause is three files away. This asserts
+    /// the *distance*, which is a property of the record rather than of the build that read it.
+    #[test]
+    fn every_leech_is_scheduled_days_clear_of_due_not_hours() {
+        let (_d, _s, mut coll) = empty();
+        Fixture::Leeches.install(&mut coll, NOW_MS).unwrap();
+        let today = cairn_core::log::day_number(NOW_MS, DayScale::default());
+        let current = deck::current_cards(&coll).unwrap();
+        let lines = coll.log_lines().unwrap();
+        let refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        let replayed = replay(&current, &refs);
+
+        for leech in leeches(&replayed, today) {
+            let state = &replayed.cards[&leech.card];
+            let margin = state.due_day - today;
+            let prompt = deck::render(&coll, leech.card).unwrap().unwrap().prompt;
+            assert!(
+                margin >= 5,
+                "{prompt} is {margin} days from due — the fuzz swings about three, so this \
+                 fixture would install differently on different builds"
+            );
+        }
+    }
+
+    /// [`Fixture::DueWithLeeches`] composes [`Fixture::Leeches`]' leeches unchanged, so it inherits
+    /// the order rather than re-tuning one. Pinned because the composition is the *reason* that
+    /// fixture exists, and a copy that drifted would put a second, differently-ranked leech screen
+    /// behind a picker that looks identical.
+    #[test]
+    fn the_composed_fixture_ranks_its_leeches_the_same_way() {
+        let (_d, _s, mut coll) = empty();
+        Fixture::Leeches.install(&mut coll, NOW_MS).unwrap();
+        let (_d2, _s2, mut composed) = empty();
+        Fixture::DueWithLeeches
+            .install(&mut composed, NOW_MS)
+            .unwrap();
+        assert_eq!(
+            ranked_leeches(&composed, NOW_MS),
+            ranked_leeches(&coll, NOW_MS)
+        );
     }
 
     /// The crossing fixture leaves its card **one failure day short**, and one *Forgot* today takes

--- a/crates/core/src/replay/mod.rs
+++ b/crates/core/src/replay/mod.rs
@@ -497,8 +497,18 @@ pub fn leeches(replayed: &Replayed, today: i64) -> Vec<Leech> {
         })
         .collect();
 
-    // Ranked worst first (ADR-0010 §4): most failure days, then most recent failure, then a stable
-    // card-identity tie-break so two devices reach the same order without communicating.
+    // Ranked worst first (ADR-0010 §4): most failure days, then most recent failure, then a
+    // card-identity tie-break.
+    //
+    // **Which stability that last key has is worth stating, because assuming the other one cost a
+    // ticket.** A `NoteId` is generated once and travels with the note, so it is stable across
+    // *devices sharing a collection* — which is what two devices reaching the same order without
+    // communicating actually need, and all this key was ever for. It is **not** stable across
+    // *builds of the same rows*: the id is `uuid_v4` from the OS, so a collection constructed twice
+    // from one definition gets fresh ids and this key orders the two runs differently. Anything
+    // that needs a reproducible order — the fixture bench above all — has to break the two keys
+    // above rather than lean on this one, which is what #160 changed after four captures of the
+    // leech screen turned out to be photographs of a coin flip.
     out.sort_by(|a, b| {
         b.failure_days
             .cmp(&a.failure_days)

--- a/scripts/storyboards/leeches.txt
+++ b/scripts/storyboards/leeches.txt
@@ -4,10 +4,16 @@
 # the screen carries a control at all, and therefore the only state in which ADR-0035 §1's reach line
 # has a second call site to be judged against (#155 owes that amendment).
 #
-# Reaching it needs a card **failed four times and then recovered**: a card whose latest grade is a
-# failure is due whatever its interval says, so a leech that merely failed its way over the floor
+# Reaching it needs a card **failed over the floor and then recovered**: a card whose latest grade is
+# a failure is due whatever its interval says, so a leech that merely failed its way over the floor
 # would put the screen back into the card state. That is why this is a fixture and not a storyboard
 # that grades a few cards.
+#
+# The three records are **deliberately unequal** — six failure days, then four and four split by
+# which failed more recently (#160). They were identical until then, so both of `replay::leeches`'
+# rank keys tied and the order fell through to a card identity that is fresh on every build: the two
+# widths of one run disagreed with each other, and this screen was the picture that showed it. What
+# is photographed here is the rank, so the rank has to be a fact about the collection.
 fixture leeches
 # The first click is spent giving the window keyboard focus and never reaches a widget, so it is
 # aimed at empty space.


### PR DESCRIPTION
Resolves #160.

The leech list's rank was arbitrary in every picture this repository held. `Fixture::Leeches` gave all three leeches `history.fails(card, [80, 60, 40, 20])`, so **both** of `replay::leeches`' rank keys tied and the order fell through to the third: card identity. That key is stable across *devices sharing a collection* — which is what two devices reconciling need, and all it was ever for — and freshly random across *builds of a fixture*, because a `NoteId` is `uuid_v4` from the OS and the bench builds a new collection every run.

The visible symptom was two captures from **one run** disagreeing: `1280x800/03-leech-screen.png` listed *d'ailleurs, néanmoins, désormais* and `560x860/03-leech-screen.png` listed *désormais, d'ailleurs, néanmoins*. A window width cannot reorder a ranked list.

## The three records are now unequal in two ways

`néanmoins` leads on **six** failure days. `désormais` and `d'ailleurs` **tie on four** and are split only by which failed more recently — a key the screen does not draw.

That partial tie is deliberate. #156 has staked its brief on *"the rank is stated as a caption and is the most important fact on the screen"*, so it needs the case where the caption **cannot** explain the order, not only the easy one. Giving all three distinct counts would have hidden that question behind a fixture rigged to answer it. Review counts are ordered *against* the rank — 9 above 10 — so one picture shows the caption's second number is context and not the key that sorted the list.

| | caption | rank keys |
|---|---|---|
| `néanmoins` | 6 bad days · 12 reviews | 6 failure days |
| `désormais` | 4 bad days · 9 reviews | 4, last failure 22d ago |
| `d'ailleurs` | 4 bad days · 10 reviews | 4, last failure 36d ago |

## The second instance of the same defect, one layer down

Card identity is read in **two** places, and the first candidate recovery kept failing `Fixture::check` intermittently — on the second install of a test, while four other installs in the same run passed.

`scheduling`'s interval fuzz is seeded from `CardRef::encode` too (ADR-0027 §5, ADR-0001 §7), so a leech scheduled close to due is due on some builds and not on others. Measured over 200 installs apiece, **the recovery this fixture shipped before this PR left as little as two days of margin** against a fuzz that swings about three. It was not wrong; it had simply not lost the toss yet. The new recoveries leave seven days at worst, and that distance is asserted directly, because `Fixture::check` only ever sees the build it ran on.

## Pinned

Three tests, plus one for the margin:

- the stated order, so a fixture edit that reshuffles the screen says so here rather than in a capture nobody diffs;
- the two rank keys **distinct per card**, which is the property that keeps the order reproducible;
- **the same definition installed twice ranking the same way** — the only assertion that can see the old defect, which a single install passed one run in six;
- every leech at least five days clear of due.

`Fixture::DueWithLeeches` composes the same set and inherits the order, asserted rather than assumed.

## Verified

- `cargo test --workspace` — 396 passed, and the fixture tests run **60 consecutive times with zero failures** (the defect was intermittent, so passing once proves nothing).
- `cargo clippy --workspace --all-targets` clean, `cargo fmt --check` clean.
- Re-captured at **both** widths: 1280x800 and 560x860 now list *néanmoins, désormais, d'ailleurs* — identical. Captures left in `target/capture/` and not committed; `docs/design/mark-2026-09-05/` is a dated record of what the app drew that day and is deliberately untouched.

## What outlives the ticket

AGENTS.md capture **rule 22** and the `Fixture` vocabulary entry: a fixture may not depend on anything card identity decides, both places that read it, the margin a new fixture owes, and *measure, do not reason* — the intervals are `fsrs`'s.

## Scope

The fixture, the comment at `replay/mod.rs` that made this invisible, and the storyboard note that said "failed four times". **Not** the ranking rule, the leech floor, or the caption's wording — the first is correct, the second is ADR-0010 §2's, and the third belongs to #156. No ADR: nothing here was a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHi44wcUwEp9ckmDxHD3gV