### PR TITLE
Deck Export / Apply an Import Into the Store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -638,6 +638,40 @@ A `.cdeck` file is a **zip archive** carrying deck content and never review prog
     emitted `AndroidManifest.xml`, never the source. The filter matches on **type**, but the extension
     still gates arrival one step upstream: it is what `MediaStore` derives that type from (rule 13), so
     the extension decides reachability without the filter ever reading it.
+16. **Applying an import re-derives it; it never executes a plan the screen computed.** ADR-0022 §5
+    makes the plan derived on every read and *never* stored, so a plan handed to apply is a stored
+    projection of the log — the precise thing ADR-0004 exists to prevent — and a sync landing under the
+    preview falsifies it. `import::read` therefore returns the plan **and** its writes from one pass,
+    and `inbound::apply` calls it again rather than keeping the first result. **The one-pass shape is
+    the point**: the *"1,202 already yours"* line and the notes apply skips come off the same `match`
+    arm, so they cannot part company. Derive them separately and nothing fails — the numbers simply
+    stop describing the writes, which is a preview that lies while every test still passes.
+17. **A held note id is never re-imported on either path — only its membership follows the file.**
+    ADR-0022 §3's table cites ADR-0005 §2's *"not re-imported"* against the **update**-path example, so
+    the collision rule is not the create path's alone: an update moves a held note between decks (one
+    `deck` write, ADR-0005 §8) and leaves its content exactly as the user holds it. This reads like a
+    contradiction with ADR-0008 §11's *"§9 applies in full"* and with §3's *"5,000 stamped values"*
+    worry, both of which sound like content following the file. Under this rule an author's edit to an
+    existing note does **not** propagate; retraction plus a new note is the route ADR-0008 §5 leaves
+    them. Written down because the other reading is the natural one and nothing catches it.
+18. **A field name arriving in a file becomes a mutable-surface attribute name, so the reserved ones
+    are dropped.** A field called `deck` would refile the note it arrives on — reaching past rule 3's
+    branches from inside the payload — and `deleted` would retract a note with no tombstone; `kind`,
+    `position` and the `tag:` prefix are the same hazard quieter. Nothing in the shipped kinds collides
+    with these, which is exactly why this looks like dead defensiveness: the names come from an
+    **acquired** kind definition, which is a stranger's data (ADR-0008 §7).
+19. **A rename alone is a change, and the digest cannot see it.** `deck_digest` excludes the deck name
+    on purpose (rule 5, ADR-0008 §4) so a rename does not bump the revision — so a `no_change` judged
+    on revision and digest alone reads *"nothing will change"* while apply renames the deck. The
+    no-change test carries the name for that reason, and dropping it puts the one line ADR-0022 §3
+    requires (*"renaming your X to Y"*) behind a `continue`.
+20. **The revision gate is only a gate because an import writes the revision back.** ADR-0008 §9 keeps
+    `{revision, digest}` on the deck's authoring slot, and until an import wrote it there every held
+    deck read as revision 0 — so an older file was never refused, an unchanged one never read as
+    *nothing will change*, and equal-revision-different-digest never reported. Three correct decisions
+    sitting behind a value nobody wrote. The attribute names are `cairn-export`'s
+    (`DECK_REVISION_ATTR` and friends) because the writer and the reader naming them separately is how
+    a written revision quietly stops being the one the gate consults.
 
 ## Sync
 

--- a/crates/app/src/inbound.rs
+++ b/crates/app/src/inbound.rs
@@ -107,22 +107,99 @@ pub fn read(inbound: &Inbound, coll: &Collection) -> Result<Report, StoreError> 
     })
 }
 
+/// What an accepted import did — the little the application needs after the fact, and deliberately
+/// not a report to show the user.
+///
+/// [ADR-0022 §5](../../../docs/adr/0022-the-import-preview-and-export-report.md) owes **nothing**
+/// after the commit: the numbers were stated while the user could still say no, which is strictly
+/// stronger than the *after* ADR-0008 §11 would have allowed. So this carries no counts to render —
+/// only where the application goes next, and a written tally the tests read to prove idempotence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Applied {
+    /// The deck the note list's filter is set to
+    /// ([ADR-0021 §2](../../../docs/adr/0021-note-ordering-saving-and-the-note-list.md)) — `Some`
+    /// when the file carried exactly one deck, `None` when it carried several and the list is left
+    /// unfiltered (ADR-0022 §5). The user lands looking at what arrived rather than at a screen
+    /// asserting that it did.
+    pub filter_to: Option<DeckId>,
+    /// How many values were actually written. **Zero is the expected result of re-importing an
+    /// unchanged file** (ADR-0008 §3) — it is not a failure, and nothing surfaces it.
+    pub written: usize,
+}
+
+/// Apply an inbound file to the collection, or return the [`Refusal`] that stands in place of a
+/// preview — the other half of ADR-0022 §1's gate.
+///
+/// **This re-derives; it never replays a [`Plan`] the screen computed.** ADR-0022 §5 makes the plan
+/// derived on every read and never stored, so the file is read again here against the collection as
+/// it stands at the moment the user pressed Import. A sync landing under the preview changes what is
+/// written, which is the point: promise and effect cannot diverge because there is only one
+/// derivation, run twice. §5 accepts that cost explicitly.
+///
+/// Every value goes through [`Collection::mutable_set_if_changed`], so **only values whose content
+/// actually differs are restamped** (ADR-0008 §3) and re-importing an unchanged file writes nothing.
+///
+/// **Declining leaves nothing behind** — there is no decline path to write, because nothing happens
+/// until this is called. No partial state, no record that a file was looked at, and no file removed
+/// ([ADR-0016 §5](../../../docs/adr/0016-backup-and-restore.md)'s seam has no delete).
+pub fn apply(
+    inbound: &Inbound,
+    coll: &mut Collection,
+) -> Result<Result<Applied, Refusal>, StoreError> {
+    let snapshot = snapshot(coll)?;
+    let import = match import::read(&inbound.bytes, &snapshot) {
+        Ok(import) => import,
+        Err(refusal) => return Ok(Err(refusal)),
+    };
+
+    let mut written = 0;
+    for write in &import.writes {
+        if coll.mutable_set_if_changed(
+            write.entity,
+            &write.entity_id,
+            &write.attr,
+            write.value.as_deref(),
+        )? {
+            written += 1;
+        }
+    }
+
+    // The file carried one deck → the note list filters to it; several → it is left unfiltered
+    // (ADR-0022 §5). Read off the plan, which names the decks the file declared.
+    let filter_to = match import.plan.decks.as_slice() {
+        [only] => Some(only.id),
+        _ => None,
+    };
+
+    Ok(Ok(Applied { filter_to, written }))
+}
+
 /// Build the pure diff snapshot the describe stage needs from the mutable surface (ADR-0022 §5):
 /// held decks, each held note's deck reference, and the kinds acquired beyond the shipped set. Built
 /// afresh on every [`read`] and never held, so it cannot fall out of step with the log.
 ///
-/// **Revisions and digests are absent here, and that is a property of the store rather than a gap in
-/// this snapshot.** The mutable surface records a deck's `{ id, name }` and a note's `deck`
-/// reference, but not the revision or content digest of any last export — those are computed at
-/// export time and never written back. So a held deck enters the snapshot at revision 0 with an
-/// empty digest, which is honest for the create path a received file almost always takes (its deck
-/// id is new, ADR-0008 §11) and where the specimen is legible; the revision gate against a *matching*
-/// held id is the real import path's to complete, not this specimen's.
+/// **The revision and digest are read back from the deck's authoring slot**, which is what makes the
+/// revision gate a gate. They are held per deck id on the mutable surface (ADR-0008 §9), written
+/// there by [`apply`] and by an export, and a deck that has never been either enters at revision 0
+/// with an empty digest — honest for the create path a received file almost always takes, its deck
+/// id being new (ADR-0008 §11).
+///
+/// Until an import wrote them there was nothing to read, so this said 0 and `""` for every deck and
+/// **three decisions could never fire**: an older file was never refused, an unchanged one never read
+/// as *nothing will change*, and an equal-revision-different-digest file never reported the one
+/// revision fact ADR-0022 §4 shows. All three were correct code sitting behind a value nobody wrote.
 fn snapshot(coll: &Collection) -> Result<import::Collection, StoreError> {
     let mut snapshot = import::Collection::new();
 
     for (id, name) in coll.decks()? {
-        snapshot = snapshot.with_deck(id, &name, 0, "");
+        let revision = coll
+            .mutable_get("deck", &id.0, cairn_export::DECK_REVISION_ATTR)?
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(0);
+        let digest = coll
+            .mutable_get("deck", &id.0, cairn_export::DECK_DIGEST_ATTR)?
+            .unwrap_or_default();
+        snapshot = snapshot.with_deck(id, &name, revision, &digest);
     }
 
     // Every held, non-deleted note contributes its id so a collision is seen, and its deck reference
@@ -137,6 +214,14 @@ fn snapshot(coll: &Collection) -> Result<import::Collection, StoreError> {
             .unwrap_or(UNFILED);
         snapshot = snapshot.with_note(row.id, deck);
         snapshot = snapshot.with_acquired_kind(&row.kind);
+    }
+
+    // The end of the authored order, which imported notes are placed after (ADR-0021 §3). Read from
+    // the whole surface rather than from the rows above: a **deleted** note keeps its `position`, so
+    // taking the maximum of the listed rows alone could hand back a key an existing value already
+    // sits on.
+    if let Some(last) = coll.last_position()? {
+        snapshot = snapshot.with_last_position(&last);
     }
 
     Ok(snapshot)
@@ -195,6 +280,18 @@ mod tests {
 
     /// A real `.cdeck`, assembled by the export path so the reader is tested against the writer.
     fn real_deck(id: DeckId, name: &str, notes: &[(NoteId, &str)]) -> Vec<u8> {
+        deck_file(id, name, notes, &[], &Metadata::default())
+    }
+
+    /// The same, with tombstones and file metadata — the two halves of an *update* that the create
+    /// path never reaches.
+    fn deck_file(
+        id: DeckId,
+        name: &str,
+        notes: &[(NoteId, &str)],
+        tombstones: &[NoteId],
+        metadata: &Metadata,
+    ) -> Vec<u8> {
         let content = DeckContent {
             id,
             name: name.to_owned(),
@@ -210,11 +307,44 @@ mod tests {
                     ],
                 })
                 .collect(),
-            tombstones: Vec::new(),
+            tombstones: tombstones
+                .iter()
+                .map(|id| cairn_export::Tombstone { id: *id })
+                .collect(),
         };
         let digest = deck_digest(&content).unwrap();
         let revision = next_revision(None, &digest);
-        build_deck(&Metadata::default(), &[DeckExport { content, revision }]).unwrap()
+        build_deck(metadata, &[DeckExport { content, revision }]).unwrap()
+    }
+
+    /// Put a deck on the mutable surface **under an id we choose**, which `Collection::create_deck`
+    /// cannot do — it mints a fresh UUIDv4 (ADR-0005 §4). Authority follows the deck id (ADR-0008
+    /// §11), so a test that wants the *update* path has to hold the file's own id.
+    fn hold_deck(coll: &mut Collection, id: DeckId, name: &str) {
+        coll.mutable_set("deck", &id.0, "name", Some(name)).unwrap();
+    }
+
+    /// A note held under an id we choose, filed in `deck` — the same reason as [`hold_deck`]:
+    /// `create_note` mints its own id (ADR-0002 §6) and a collision test needs the file's.
+    fn hold_note(coll: &mut Collection, id: NoteId, deck: Option<DeckId>, front: &str) {
+        let position = coll.last_position().unwrap();
+        let position = cairn_core::content::order::between(position.as_deref(), None);
+        coll.mutable_set("note", &id.0, "kind", Some("basic"))
+            .unwrap();
+        coll.mutable_set("note", &id.0, "position", Some(&position))
+            .unwrap();
+        coll.mutable_set("note", &id.0, "Front", Some(front))
+            .unwrap();
+        coll.mutable_set("note", &id.0, "Back", Some("held"))
+            .unwrap();
+        if let Some(deck) = deck {
+            coll.mutable_set("note", &id.0, "deck", Some(&deck.to_canonical()))
+                .unwrap();
+        }
+    }
+
+    fn value(coll: &Collection, entity: &str, id: [u8; 16], attr: &str) -> Option<String> {
+        coll.mutable_get(entity, &id, attr).unwrap()
     }
 
     fn inbound(bytes: Vec<u8>) -> Inbound {
@@ -306,5 +436,383 @@ mod tests {
             (second.decks[0].new_notes, second.decks[0].already_yours),
             (0, 1)
         );
+    }
+
+    // ---- Applying -------------------------------------------------------------------------------
+    //
+    // The two cases below go first deliberately (#165): they are the two the preview's most alarming
+    // lines describe, the two #89 ticked without executing, and the two nothing in this repository
+    // had ever run.
+
+    /// **A tombstone deletes a note the collection holds** (ADR-0008 §5) — on the update path only,
+    /// and as a **flag**, never a row removal (ADR-0004 §7), so the note keeps its `deck` reference
+    /// and a later deck-scoped export can still select its tombstone.
+    #[test]
+    fn a_tombstone_retracts_a_held_note_and_leaves_its_deck_reference() {
+        let (mut coll, _d, _s) = open();
+        let deck = DeckId([0xa1; 16]);
+        hold_deck(&mut coll, deck, "Shared");
+        hold_note(&mut coll, nid(1), Some(deck), "doomed");
+        hold_note(&mut coll, nid(2), Some(deck), "spared");
+        assert_eq!(
+            notes::list(&coll, &notes::Filter::default()).unwrap().len(),
+            2
+        );
+
+        // The author retracts note 1 and keeps note 2 — the same deck id, so the update path.
+        let file = deck_file(
+            deck,
+            "Shared",
+            &[(nid(2), "a")],
+            &[nid(1)],
+            &Metadata::default(),
+        );
+        let applied = apply(&inbound(file), &mut coll).unwrap().unwrap();
+        assert!(applied.written > 0);
+
+        assert_eq!(
+            value(&coll, "note", nid(1).0, "deleted").as_deref(),
+            Some("true")
+        );
+        // The reference survives the retraction (ADR-0008's amendment to ADR-0004 §7).
+        assert_eq!(
+            value(&coll, "note", nid(1).0, "deck").as_deref(),
+            Some(deck.to_canonical().as_str())
+        );
+        // Deleted means not listed; the note the file kept is untouched.
+        let rows = notes::list(&coll, &notes::Filter::default()).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, nid(2));
+        // Held, and already in this deck: not re-imported (ADR-0005 §2), so it keeps the user's own
+        // text rather than the "q" the file carries — the *"already yours"* line, executed.
+        assert_eq!(
+            value(&coll, "note", nid(2).0, "Front").as_deref(),
+            Some("spared")
+        );
+    }
+
+    /// **A note moves deck when the file says so, and that is one write** (ADR-0008 §11, ADR-0005
+    /// §8, §9) — membership is a `deck` reference on the note, so a move costs one value and the
+    /// note's own content is left exactly as the user holds it.
+    #[test]
+    fn an_update_moves_a_held_note_between_decks_without_touching_its_content() {
+        let (mut coll, _d, _s) = open();
+        let german = DeckId([0xb1; 16]);
+        let french = DeckId([0xb2; 16]);
+        hold_deck(&mut coll, german, "German");
+        hold_deck(&mut coll, french, "French A1");
+        hold_note(&mut coll, nid(3), Some(german), "mine");
+
+        // The author's update claims the note for French A1 — a deck id the collection already
+        // holds, so the file may reorganise into it.
+        let file = real_deck(french, "French A1", &[(nid(3), "a")]);
+        let plan = read(&inbound(file.clone()), &coll)
+            .unwrap()
+            .outcome
+            .unwrap();
+        assert_eq!(plan.decks[0].moving_in[0].count, 1);
+        assert_eq!(plan.decks[0].moving_in[0].from.as_deref(), Some("German"));
+
+        apply(&inbound(file), &mut coll).unwrap().unwrap();
+
+        assert_eq!(
+            value(&coll, "note", nid(3).0, "deck").as_deref(),
+            Some(french.to_canonical().as_str())
+        );
+        // Content is the user's, not the file's: the file carries "q", the collection keeps "mine".
+        assert_eq!(
+            value(&coll, "note", nid(3).0, "Front").as_deref(),
+            Some("mine")
+        );
+    }
+
+    /// The create path never reaches into decks the user already holds (ADR-0005 §2, ADR-0008 §11):
+    /// a colliding id is skipped whole — not moved, not overwritten — and the preview's
+    /// *"already yours"* count is exactly the notes that produced no write.
+    #[test]
+    fn a_create_path_file_never_moves_or_rewrites_a_held_note() {
+        let (mut coll, _d, _s) = open();
+        let mine = DeckId([0xc1; 16]);
+        hold_deck(&mut coll, mine, "Mine");
+        hold_note(&mut coll, nid(4), Some(mine), "mine");
+
+        // A deck id the collection does not hold — a fork carrying a note the user already has.
+        let file = real_deck(DeckId([0xc2; 16]), "Fork", &[(nid(4), "a"), (nid(5), "b")]);
+        let plan = read(&inbound(file.clone()), &coll)
+            .unwrap()
+            .outcome
+            .unwrap();
+        assert_eq!(
+            (plan.decks[0].new_notes, plan.decks[0].already_yours),
+            (1, 1)
+        );
+
+        apply(&inbound(file), &mut coll).unwrap().unwrap();
+
+        // The held note stayed where it was, with the text the user holds.
+        assert_eq!(
+            value(&coll, "note", nid(4).0, "deck").as_deref(),
+            Some(mine.to_canonical().as_str())
+        );
+        assert_eq!(
+            value(&coll, "note", nid(4).0, "Front").as_deref(),
+            Some("mine")
+        );
+        // The genuinely new one arrived, filed in the file's own deck.
+        assert_eq!(
+            value(&coll, "note", nid(5).0, "Front").as_deref(),
+            Some("q")
+        );
+        assert_eq!(
+            value(&coll, "note", nid(5).0, "kind").as_deref(),
+            Some("basic")
+        );
+    }
+
+    /// **Re-importing an unchanged file is a genuine no-op** (ADR-0008 §3): the second apply writes
+    /// nothing at all, so it produces nothing to sync, and the plan behind it states that nothing
+    /// will change (ADR-0022 §4).
+    #[test]
+    fn re_importing_an_unchanged_file_writes_nothing() {
+        let (mut coll, _d, _s) = open();
+        let arrived = inbound(real_deck(DeckId([0xd1; 16]), "Deck", &[(nid(6), "a")]));
+
+        let first = apply(&arrived, &mut coll).unwrap().unwrap();
+        assert!(first.written > 0);
+
+        let plan = read(&arrived, &coll).unwrap().outcome.unwrap();
+        assert!(plan.decks[0].no_change);
+
+        let second = apply(&arrived, &mut coll).unwrap().unwrap();
+        assert_eq!(second.written, 0);
+    }
+
+    /// An imported note is placed **at the end of the collection's authored order** (ADR-0021 §3),
+    /// in the file's own line order — the file carries line order, not the key (ADR-0008 §12 as
+    /// amended), so the keys are minted here and each note costs exactly one `position` write.
+    #[test]
+    fn imported_notes_land_at_the_end_of_the_authored_order_in_file_order() {
+        let (mut coll, _d, _s) = open();
+        hold_note(&mut coll, nid(9), None, "already here");
+
+        // Positions "a" and "b" fix the file's emission order (ADR-0011 §7).
+        let file = real_deck(
+            DeckId([0xe1; 16]),
+            "Deck",
+            &[(nid(10), "a"), (nid(11), "b")],
+        );
+        apply(&inbound(file), &mut coll).unwrap().unwrap();
+
+        let order: Vec<NoteId> = notes::list(&coll, &notes::Filter::default())
+            .unwrap()
+            .into_iter()
+            .map(|r| r.id)
+            .collect();
+        assert_eq!(order, vec![nid(9), nid(10), nid(11)]);
+    }
+
+    /// **Apply re-derives; it never replays the plan the screen computed** (ADR-0022 §5). A note the
+    /// preview called *new* that the collection acquires before the press is a collision by the time
+    /// apply runs — so it is skipped, and the user's own copy is not overwritten.
+    #[test]
+    fn apply_re_derives_rather_than_replaying_the_plan_the_preview_showed() {
+        let (mut coll, _d, _s) = open();
+        let arrived = inbound(real_deck(DeckId([0xf1; 16]), "Deck", &[(nid(12), "a")]));
+
+        let plan = read(&arrived, &coll).unwrap().outcome.unwrap();
+        assert_eq!(plan.decks[0].new_notes, 1);
+
+        // A sync lands under the preview: the collection now holds that very note (ADR-0015 §2).
+        hold_note(&mut coll, nid(12), None, "arrived by sync");
+
+        apply(&arrived, &mut coll).unwrap().unwrap();
+
+        // The stale plan would have written the file's "q" over it; the re-derivation does not.
+        assert_eq!(
+            value(&coll, "note", nid(12).0, "Front").as_deref(),
+            Some("arrived by sync")
+        );
+    }
+
+    /// A refused file writes nothing — the gate is one derivation, so the refusal that stands in
+    /// place of a preview (ADR-0022 §4) also stands in place of every write.
+    #[test]
+    fn a_refused_file_writes_nothing() {
+        let (mut coll, _d, _s) = open();
+        let before = coll.entity_ids("note").unwrap().len();
+
+        let refusal = apply(&inbound(b"not a deck at all".to_vec()), &mut coll)
+            .unwrap()
+            .expect_err("an unreadable file is refused");
+        assert_eq!(refusal, Refusal::Unreadable);
+        assert_eq!(coll.entity_ids("note").unwrap().len(), before);
+    }
+
+    /// The file wins the deck name over the user's own rename (ADR-0005 §9), and the authoring
+    /// values — `{revision, digest}` (ADR-0008 §9) and the metadata beside them (ADR-0022 §8) — are
+    /// adopted, which is what lets an unmodified relay re-emit the same file at the same revision.
+    #[test]
+    fn the_file_wins_the_deck_name_and_its_authoring_values_are_adopted() {
+        let (mut coll, _d, _s) = open();
+        let deck = DeckId([0x1a; 16]);
+        hold_deck(&mut coll, deck, "My French");
+
+        let metadata = Metadata {
+            author: "Marjan Rahimi".to_owned(),
+            description: "A1 vocabulary.".to_owned(),
+            licence: "CC BY-SA 4.0".to_owned(),
+        };
+        let file = deck_file(deck, "French A1", &[(nid(13), "a")], &[], &metadata);
+        let plan = read(&inbound(file.clone()), &coll)
+            .unwrap()
+            .outcome
+            .unwrap();
+        assert_eq!(plan.decks[0].renamed_from.as_deref(), Some("My French"));
+
+        apply(&inbound(file), &mut coll).unwrap().unwrap();
+
+        assert_eq!(
+            value(&coll, "deck", deck.0, "name").as_deref(),
+            Some("French A1")
+        );
+        assert_eq!(
+            value(&coll, "deck", deck.0, "revision").as_deref(),
+            Some("1")
+        );
+        assert!(value(&coll, "deck", deck.0, "digest").is_some());
+        assert_eq!(
+            value(&coll, "deck", deck.0, "author").as_deref(),
+            Some("Marjan Rahimi")
+        );
+        assert_eq!(
+            value(&coll, "deck", deck.0, "licence").as_deref(),
+            Some("CC BY-SA 4.0")
+        );
+    }
+
+    /// **A deleted deck is fully recoverable by re-import**
+    /// ([ADR-0016 §4](../../../docs/adr/0016-backup-and-restore.md)). Deletion is a flag, never a row
+    /// removal (ADR-0005 §7), so the deck reads as unheld and the file takes the create path — which
+    /// has to clear the flag, or the import lands and stays invisible.
+    #[test]
+    fn a_deleted_deck_comes_back_by_re_import() {
+        let (mut coll, _d, _s) = open();
+        let deck = DeckId([0x2a; 16]);
+        let file = real_deck(deck, "Gone", &[(nid(14), "a")]);
+        apply(&inbound(file.clone()), &mut coll).unwrap().unwrap();
+
+        // The user deletes the deck; every note in it derives deleted (ADR-0005 §7).
+        coll.mutable_set("deck", &deck.0, "deleted", Some("true"))
+            .unwrap();
+        assert!(
+            notes::list(&coll, &notes::Filter::default())
+                .unwrap()
+                .is_empty()
+        );
+
+        apply(&inbound(file), &mut coll).unwrap().unwrap();
+
+        assert_eq!(value(&coll, "deck", deck.0, "deleted"), None);
+        let rows = notes::list(&coll, &notes::Filter::default()).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, nid(14));
+    }
+
+    /// A note the file carries **live**, whose id the collection holds only as a tombstone, reads as
+    /// unheld — a deleted note is not in the note list — so the plan calls it new and the apply has
+    /// to make it visible again rather than write content nobody can reach.
+    #[test]
+    fn a_retracted_note_returns_when_the_file_carries_it_live_again() {
+        let (mut coll, _d, _s) = open();
+        let deck = DeckId([0x3a; 16]);
+        hold_deck(&mut coll, deck, "Deck");
+        hold_note(&mut coll, nid(15), Some(deck), "was here");
+        coll.mutable_set("note", &nid(15).0, "deleted", Some("true"))
+            .unwrap();
+
+        let file = real_deck(deck, "Deck", &[(nid(15), "a")]);
+        let plan = read(&inbound(file.clone()), &coll)
+            .unwrap()
+            .outcome
+            .unwrap();
+        assert_eq!(plan.decks[0].new_notes, 1);
+
+        apply(&inbound(file), &mut coll).unwrap().unwrap();
+
+        assert_eq!(value(&coll, "note", nid(15).0, "deleted"), None);
+        assert_eq!(
+            value(&coll, "note", nid(15).0, "Front").as_deref(),
+            Some("q")
+        );
+    }
+
+    /// **The revision gate fires only because an import writes the revision back.** ADR-0008 §4
+    /// refuses a file strictly older than the one held, and ADR-0008 §9 keeps that number on the
+    /// deck's authoring slot — so until something wrote it there, every held deck read as revision 0
+    /// and no file was ever old enough to refuse. Import it, edit it down, and the gate refuses.
+    #[test]
+    fn an_older_copy_of_a_deck_already_imported_is_refused() {
+        let (mut coll, _d, _s) = open();
+        let deck = DeckId([0x5a; 16]);
+
+        // Revision 1 arrives and is applied, so the collection now holds a revision to compare to.
+        let first = deck_file(
+            deck,
+            "French A1",
+            &[(nid(17), "a")],
+            &[],
+            &Metadata::default(),
+        );
+        apply(&inbound(first), &mut coll).unwrap().unwrap();
+
+        // A second file for the same deck id, carrying a revision below the one held.
+        let older = older_deck(deck, "French A1", nid(18));
+        let refusal = apply(&inbound(older), &mut coll)
+            .unwrap()
+            .expect_err("an older copy is refused, never applied");
+        assert_eq!(
+            refusal,
+            Refusal::Older {
+                deck: "French A1".to_owned()
+            }
+        );
+        // Refused means nothing written: the note the older file carried never arrived.
+        assert_eq!(value(&coll, "note", nid(18).0, "kind"), None);
+    }
+
+    /// A deck file stamped at revision 0 — below anything an export ever emits, since
+    /// [`next_revision`] starts a never-exported deck at 1.
+    fn older_deck(id: DeckId, name: &str, note: NoteId) -> Vec<u8> {
+        let content = DeckContent {
+            id,
+            name: name.to_owned(),
+            notes: vec![NoteContent {
+                id: note,
+                position: "a".to_owned(),
+                kind: "basic".to_owned(),
+                fields: vec![("Front".to_owned(), "old".to_owned())],
+            }],
+            tombstones: Vec::new(),
+        };
+        let revision = cairn_export::DeckRevision {
+            revision: 0,
+            digest: deck_digest(&content).unwrap(),
+        };
+        build_deck(&Metadata::default(), &[DeckExport { content, revision }]).unwrap()
+    }
+
+    /// The note list's deck filter is set to the imported deck when the file carried one, and left
+    /// unfiltered when it carried several (ADR-0022 §5).
+    #[test]
+    fn a_single_deck_file_names_the_deck_the_note_list_filters_to() {
+        let (mut coll, _d, _s) = open();
+        let deck = DeckId([0x4a; 16]);
+        let applied = apply(
+            &inbound(real_deck(deck, "One", &[(nid(16), "a")])),
+            &mut coll,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(applied.filter_to, Some(deck));
     }
 }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -290,6 +290,11 @@ pub struct CairnApp {
     /// (ADR-0022 §5). This is the *file*, never a cached plan: `inbound::read` runs the whole
     /// gate-then-describe read against the live collection each time the specimen draws.
     inbound: Option<inbound::Inbound>,
+    /// **Temporary** — what the inbound specimen's development *Import* control last did, held only
+    /// so a store failure is not swallowed. The specified surface owes **nothing** after an import
+    /// (ADR-0022 §5); this is the specimen reporting to whoever is holding the phone, and it goes
+    /// when [#167](https://github.com/amin-bf/cairn/issues/167) draws the real gate.
+    import_outcome: Option<String>,
     /// Whether the launch intent has been consulted yet (`platform::launch_file` is a one-shot read,
     /// so it is asked once as the app comes up — which is where cold start is satisfied, ADR-0016 §5).
     launch_checked: bool,
@@ -351,6 +356,7 @@ impl CairnApp {
             file_list: FileList::default(),
             bench: Bench::default(),
             inbound: None,
+            import_outcome: None,
             launch_checked: false,
         }
     }
@@ -678,6 +684,7 @@ impl eframe::App for CairnApp {
                             &mut self.optimise_done,
                             &mut self.handoff,
                             &mut self.inbound,
+                            &mut self.import_outcome,
                             &mut self.file_list,
                             &mut self.bench,
                             now_ms,

--- a/crates/app/src/screens/settings.rs
+++ b/crates/app/src/screens/settings.rs
@@ -80,6 +80,7 @@ pub(crate) fn settings_screen(
     optimise_done: &mut bool,
     handoff: &mut HandOff,
     inbound: &mut Option<inbound::Inbound>,
+    import_outcome: &mut Option<String>,
     file_list: &mut FileList,
     bench: &mut Bench,
     now_ms: i64,
@@ -164,7 +165,7 @@ pub(crate) fn settings_screen(
     ui.add_space(spacing::gap(3));
     ui.separator();
     ui.add_space(spacing::gap(2));
-    inbound_specimen(ui, coll, inbound.as_ref());
+    inbound_specimen(ui, coll, inbound.as_ref(), import_outcome);
 
     request
 }
@@ -497,7 +498,12 @@ fn handoff_specimen(ui: &mut egui::Ui, state: &mut HandOff) {
 /// the numbers rather than staling them. Every string the file carries is already bounded plain text
 /// (ADR-0022 §7) and is drawn through [`bidi::job`] like all chrome — a stranger's string can never
 /// style the screen it is previewed on (client-stack rule 1).
-fn inbound_specimen(ui: &mut egui::Ui, coll: &Collection, inbound: Option<&inbound::Inbound>) {
+fn inbound_specimen(
+    ui: &mut egui::Ui,
+    coll: &mut Collection,
+    inbound: Option<&inbound::Inbound>,
+    import_outcome: &mut Option<String>,
+) {
     body(
         ui,
         "Development control — what the platform handed us to open. Drop a .cdeck on this window, or \
@@ -506,20 +512,24 @@ fn inbound_specimen(ui: &mut egui::Ui, coll: &Collection, inbound: Option<&inbou
     );
     ui.add_space(spacing::gap(2));
 
-    let Some(inbound) = inbound else {
+    let Some(file) = inbound else {
         body(ui, "Nothing has arrived yet.");
         return;
     };
 
-    field_label(ui, &format!("Arrived: {}", inbound.arrival.label()));
-    match &inbound.name {
+    // Whether the read ended in a plan — the one condition under which the gate offers an Import
+    // (ADR-0022 §1, §4). Set below, and read after the borrow of `coll` the read needs has ended.
+    let mut apply = false;
+
+    field_label(ui, &format!("Arrived: {}", file.arrival.label()));
+    match &file.name {
         Some(name) => field_label(ui, &format!("Name it gave: \"{name}\"")),
         // A share may carry none, and identity never needs it (ADR-0024 §1).
         None => field_label(ui, "Name it gave: none — identified by its bytes."),
     }
 
     // Derived on the spot against the collection as it stands (ADR-0022 §5), never stored.
-    match inbound::read(inbound, coll) {
+    match inbound::read(file, coll) {
         Err(e) => body(
             ui,
             &format!("Could not read the collection to diff against: {e}"),
@@ -545,9 +555,49 @@ fn inbound_specimen(ui: &mut egui::Ui, coll: &Collection, inbound: Option<&inbou
                         }
                         body(ui, &line);
                     }
+                    apply = true;
                 }
             }
         }
+    }
+
+    if !apply {
+        return;
+    }
+
+    // **The development half of ADR-0022 §1's gate**, and the *shape* of the real one: a control that
+    // appears only where a plan does, so a refusal is never importable. What #167 draws is the pair —
+    // Import beside Cancel, under the plan — with the wording, weight and placement decided there;
+    // what is proven here is that pressing it writes what the lines above promised.
+    //
+    // **The lines re-derive on the next frame** (ADR-0022 §5), so a second press is the whole of
+    // ADR-0008 §3's idempotence, live: the plan flips to *"Nothing will change."* and a further press
+    // writes nothing. No state is held to make that happen — it falls out of never caching the plan.
+    ui.add_space(spacing::gap(2));
+    if compact_button(ui, "Import (development control)").clicked() {
+        *import_outcome = Some(match inbound::apply(file, coll) {
+            Err(e) => format!("Could not write the import: {e}"),
+            // A refusal here means the file stopped being importable between the draw and the press,
+            // which is the derivation doing its job rather than a failure to report cleverly.
+            Ok(Err(refusal)) => refusal_wording(&refusal),
+            Ok(Ok(applied)) => format!(
+                "Imported. {} value(s) written; the note list would filter to {}.",
+                applied.written,
+                match applied.filter_to {
+                    Some(_) => "the deck the file carried",
+                    None => "nothing — the file carried several decks",
+                }
+            ),
+        });
+    }
+
+    // **Not the post-import report ADR-0022 §5 refuses.** §5 owes the user nothing after the fact
+    // because the numbers were stated while they could still say no; this line reports to whoever is
+    // holding the phone that the write happened at all, and above all surfaces a store error that
+    // would otherwise be swallowed. It goes with the rest of the specimen when #167 lands.
+    if let Some(outcome) = import_outcome {
+        ui.add_space(spacing::gap(1));
+        body(ui, outcome);
     }
 }
 

--- a/crates/export/src/CONTEXT.md
+++ b/crates/export/src/CONTEXT.md
@@ -133,6 +133,23 @@ The import plan, shown, with the import declinable. The one gate in this specifi
 because a regretted import is the one destructive act no archive and no peer can undo.
 _Avoid_: Confirmation dialog — this repo refuses those twice, and for reasons that do not reach here.
 
+**Apply**:
+Writing an import into the collection, once the user has accepted the preview. It is the plan's
+**own derivation run a second time**, never the plan the screen held — so the file is read again
+against the collection as it stands at the press. Every effect reduces to one assignment on the
+mutable surface, and only values whose content actually differs are written.
+_Avoid_: Commit — it names a transaction boundary, and this is a set of independently settling
+values rather than one atomic act.
+
+**Authoring values**:
+The deck-id-keyed values that describe a deck as a **published artifact** rather than as content:
+`{revision, digest}` and the author, description and licence. They sync between the user's own
+devices, are never exported as deck content, and never appear in the review log. An import adopts
+them; an export reads them back, which is what lets an unmodified relay re-emit the byte-identical
+file at the same revision.
+_Avoid_: Deck metadata — the deck-id-keyed slot also holds *personal* values, and the two halves have
+different rules about whether syncing is even an open question.
+
 **Gate / describe**:
 The two stages of reading a file. The **gate** reads the central directory only and refuses a file
 this build must not act on — unknown format integer, wrong profile, revision below the one held, a
@@ -189,7 +206,11 @@ The slot's other half is **personal** values, whose syncing is still open and wh
 - **The import plan is derived on every read, never cached.** A stored plan is a stored projection of
   the log — the thing ADR-0004 exists to prevent — and a sync landing while the preview is on screen
   can falsify it. Derived, promise and effect cannot diverge, which is why nothing is reported after
-  an import commits.
+  an import commits. **Applying re-derives too**, and the plan and its writes come out of *one* pass
+  so the counts stated and the values written cannot part company.
+- **A held note id is never re-imported; only its membership follows the file.** On the update path a
+  held note moves deck — one write — and keeps the content the user holds. So an author's edit to an
+  existing note does not reach a recipient; retraction and a fresh note is the route.
 - **The preview states effects, not file contents.** The manifest's counts are the wrong numbers in
   exactly the cases that matter: a file whose notes you almost all hold already, and a file whose
   retractions match nothing you have. The manifest is for **gating**; the payload is for describing.

--- a/crates/export/src/import.rs
+++ b/crates/export/src/import.rs
@@ -10,17 +10,25 @@
 //! ([§3](../../../docs/adr/0022-the-import-preview-and-export-report.md)): how many notes are
 //! genuinely new after the collision skip, how many move deck, how many tombstones match a note held.
 //!
-//! The whole read is one function, [`preview`], because the plan is **derived on every read and never
+//! The whole read is one function, [`read`], because the plan is **derived on every read and never
 //! cached** (§5): a stored plan is a stored projection of the log, and a sync landing while the
 //! preview is on screen would falsify it. A file is **identified by sniffing its `mimetype` member**,
 //! never by its extension (ADR-0024 §1) — on Android both profiles store as `application/octet-stream`
 //! so the member is the sole authority.
+//!
+//! **Applying an import is that same derivation run again, never the [`Plan`] the screen computed**
+//! (§5). [`read`] returns the plan *and* the [`Write`]s that realise it from **one pass**, so the
+//! numbers the preview stated and the values the apply writes are the same branches — the
+//! *"1,202 already yours"* line and the notes apply skips agree **by construction** rather than by
+//! two implementations happening to match. The caller executes the writes against the store and
+//! **restamps only values whose content actually differs** (ADR-0008 §3), which is what makes
+//! re-importing an unchanged file a genuine no-op.
 
 use crate::container::{
     self, COLLECTION_MEDIA_TYPE, DECK_MEDIA_TYPE, FORMAT, KINDS_PREFIX, MANIFEST_MEMBER,
     NOTES_MEMBER,
 };
-use cairn_core::content::{DeckId, NoteId, SHIPPED_KINDS};
+use cairn_core::content::{DeckId, NoteId, SHIPPED_KINDS, order};
 use cairn_core::log::Json;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::Cursor;
@@ -121,6 +129,11 @@ pub struct Collection {
     note_deck: HashMap<NoteId, DeckId>,
     /// Kind ids acquired from earlier imports (ADR-0008 §7), beyond the shipped set.
     acquired_kinds: HashSet<String>,
+    /// The largest `position` order key the collection holds, or `None` for a collection with no
+    /// positioned note. An imported note is placed **at the end of the authored order**
+    /// (ADR-0021 §3), and the file carries line order rather than the key itself (ADR-0008 §12 as
+    /// amended by ADR-0021 §3) — so the keys are minted here, chained from this one.
+    last_position: Option<String>,
 }
 
 impl Collection {
@@ -145,6 +158,14 @@ impl Collection {
 
     pub fn with_acquired_kind(mut self, id: &str) -> Collection {
         self.acquired_kinds.insert(id.to_owned());
+        self
+    }
+
+    /// The collection's current largest `position` key, which imported notes are chained after
+    /// (ADR-0021 §3). Left unset for an empty collection, where the first imported note takes the
+    /// first key.
+    pub fn with_last_position(mut self, key: &str) -> Collection {
+        self.last_position = Some(key.to_owned());
         self
     }
 
@@ -211,6 +232,9 @@ pub struct MovingIn {
 /// a screen of zeroes buries the one line that is not zero.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeckPlan {
+    /// The deck's identity, which is what authority follows (ADR-0008 §11) and what the note list's
+    /// deck filter is set to after a single-deck import (ADR-0022 §5). Never shown.
+    pub id: DeckId,
     /// The deck's name as the file declares it, bounded plain text (ADR-0022 §7).
     pub name: String,
     pub path: Path,
@@ -226,8 +250,17 @@ pub struct DeckPlan {
     /// The user's own deck name about to be overwritten by the update (ADR-0005 §9). `None` when the
     /// name is unchanged or the deck is newly created.
     pub renamed_from: Option<String>,
-    /// The file carries the same revision and the same content digest as the held deck: importing it
-    /// changes nothing (ADR-0008 §3). The preview still appears, stating exactly that (ADR-0022 §4).
+    /// The file carries the same revision, the same content digest **and the same name** as the held
+    /// deck: importing it changes nothing (ADR-0008 §3). The preview still appears, stating exactly
+    /// that (ADR-0022 §4).
+    ///
+    /// **The name is part of this test although it is deliberately outside the digest.**
+    /// [`crate::deck_digest`] excludes the deck name so that *"a rename is metadata, not content"*
+    /// and does not bump the revision (ADR-0008 §4) — but a rename **is** an effect on the user's
+    /// collection, is the one ADR-0005 §9 concedes *"will feel lost"*, and is a line ADR-0022 §3
+    /// requires the preview to state. Judged on the digest alone, a file that renames a deck and
+    /// changes nothing else reads as *"nothing will change"* while the apply renames it — promise
+    /// and effect diverging in the one place ADR-0022 §5 exists to make impossible.
     pub no_change: bool,
     /// The file carries the same revision as the held deck but a **different** digest — the one
     /// revision fact the user sees, reportable rather than silent (ADR-0008 §4, ADR-0022 §4).
@@ -249,6 +282,93 @@ pub struct Plan {
     pub emptied_decks: Vec<String>,
 }
 
+/// One assignment an import makes on the mutable surface (ADR-0004 §7) — the whole of what applying
+/// an import does, because everything ADR-0022's plan describes reduces to
+/// `Collection::mutable_set(entity, entity_id, attr, value)`: a deck's name and its authoring values,
+/// a note's `kind`, `position` and fields, membership (a note attribute, so a note moving deck is one
+/// write) and a tombstone (a `deleted` flag, never a row removal, ADR-0007 §4).
+///
+/// **A `None` value is a clear, not a skip** — a value change settling by stamp like any other
+/// (ADR-0007 §4). It is how a deck or a note the file carries **live** loses a `deleted` flag it was
+/// carrying, which is what makes ADR-0016 §4's *"a deleted deck is fully recoverable by re-import"*
+/// literally true rather than aspirational.
+///
+/// The caller writes these **only where the value differs from the one already settled**
+/// (ADR-0008 §3): restamping everything would put a 5,000-note deck's worth of stamped values onto
+/// the surface and propagate them to the user's own devices as a wall of edits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Write {
+    /// The mutable-surface entity — `"deck"` or `"note"`.
+    pub entity: &'static str,
+    /// The entity's id as the sixteen canonical bytes the surface keys on (ADR-0002 §6).
+    pub entity_id: [u8; 16],
+    pub attr: String,
+    pub value: Option<String>,
+}
+
+impl Write {
+    fn set(entity: &'static str, entity_id: [u8; 16], attr: &str, value: &str) -> Write {
+        Write {
+            entity,
+            entity_id,
+            attr: attr.to_owned(),
+            value: Some(value.to_owned()),
+        }
+    }
+
+    fn clear(entity: &'static str, entity_id: [u8; 16], attr: &str) -> Write {
+        Write {
+            entity,
+            entity_id,
+            attr: attr.to_owned(),
+            value: None,
+        }
+    }
+}
+
+/// One read of a file: what it **would** do, and the writes that do it — derived together in one
+/// pass so the two cannot disagree (ADR-0022 §5).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Import {
+    pub plan: Plan,
+    pub writes: Vec<Write>,
+}
+
+/// Attribute names on a note that the mutable surface gives its own meaning, and which a **field**
+/// arriving in a stranger's file may therefore never take.
+///
+/// A field name in the payload becomes an attribute name verbatim, so without this a file could
+/// declare a field called `deck` and refile the note it is importing, or one called `deleted` and
+/// retract a note without a tombstone — reaching past ADR-0008 §11's branches from inside the
+/// payload. `kind` and `position` are the same hazard one step quieter. The `tag:` prefix is
+/// ADR-0002 §10's set-union storage, so a field named `tag:x` would silently tag the note. A field
+/// with one of these names is **dropped**, matching [`parse_notes`]'s posture that a malformed
+/// payload diffs to fewer effects rather than to a panic.
+const RESERVED_NOTE_ATTRS: [&str; 4] = ["deck", "deleted", "kind", "position"];
+const TAG_ATTR_PREFIX: &str = "tag:";
+
+/// The two mutable-surface entity names an import writes under (ADR-0004 §7).
+const DECK_ENTITY: &str = "deck";
+const NOTE_ENTITY: &str = "note";
+
+/// The **authoring** half of the deck-id-keyed slot (ADR-0005 §5 as amended): `{revision, digest}`
+/// (ADR-0008 §9) and the author, description and licence beside them (ADR-0022 §8). Named here
+/// because an import writes them and the snapshot the next import is diffed against reads them —
+/// two sites for one set of names is how a written revision quietly stops being the one the gate
+/// consults, which is a gate that never fires and nothing failing.
+///
+/// All five **sync and none of them export**: they are never deck content and never appear in the
+/// review log.
+pub const DECK_REVISION_ATTR: &str = "revision";
+pub const DECK_DIGEST_ATTR: &str = "digest";
+pub const DECK_AUTHOR_ATTR: &str = "author";
+pub const DECK_DESCRIPTION_ATTR: &str = "description";
+pub const DECK_LICENCE_ATTR: &str = "licence";
+
+fn field_name_is_writable(name: &str) -> bool {
+    !RESERVED_NOTE_ATTRS.contains(&name) && !name.starts_with(TAG_ATTR_PREFIX)
+}
+
 /// One deck as the manifest declares it, read from the central directory alone.
 struct ManifestDeck {
     id: DeckId,
@@ -257,18 +377,38 @@ struct ManifestDeck {
     digest: String,
 }
 
-/// One live note the payload carries: its id and the deck its `deck` reference names.
+/// One live note the payload carries: its id, the deck its `deck` reference names, and — for the
+/// notes an import actually creates — the content that becomes its mutable-surface values.
+///
+/// A tombstone parses into the same shape with empty content: it carries an id and a deck reference
+/// and nothing else (ADR-0008 §5).
 struct FileNote {
     id: NoteId,
     deck: DeckId,
+    kind: String,
+    /// Field name → value, in the file's own key order, with the names of [`RESERVED_NOTE_ATTRS`]
+    /// already dropped.
+    fields: Vec<(String, String)>,
 }
 
-/// Read a received file and derive the [`Plan`] the preview shows, or the [`Refusal`] shown in its
-/// place — the whole of the import read, gate then describe, in one derivation (ADR-0022 §5).
+/// The [`Plan`] a received file's preview shows, or the [`Refusal`] shown in its place — [`read`]
+/// with the writes discarded, for the surface that only states what would happen.
+pub fn preview(bytes: &[u8], collection: &Collection) -> Result<Plan, Refusal> {
+    read(bytes, collection).map(|import| import.plan)
+}
+
+/// Read a received file and derive both what it **would** do and the [`Write`]s that do it, or the
+/// [`Refusal`] shown in place of a preview — the whole of the import, gate then describe, in one
+/// derivation (ADR-0022 §5).
 ///
 /// A refusal returns **before** `notes.jsonl` is inflated (ADR-0022 §2): the gate consults the
 /// `mimetype` member, the member-name list and the small `manifest.json` only.
-pub fn preview(bytes: &[u8], collection: &Collection) -> Result<Plan, Refusal> {
+///
+/// **Applying calls this, never a plan held from a previous call.** A plan computed while the
+/// preview was on screen is a stored projection of the log (ADR-0004), and a sync landing underneath
+/// it turns a note it called *new* into one the collection holds. ADR-0022 §5 accepts the cost of
+/// computing the import twice for exactly this.
+pub fn read(bytes: &[u8], collection: &Collection) -> Result<Import, Refusal> {
     // Sniff: identity is in the bytes, never the name (ADR-0024 §1). A `collection` archive is the
     // wrong profile for deck import — its stamps travel byte for byte and must never restamp here.
     match sniff(bytes) {
@@ -389,25 +529,57 @@ fn parse_notes(text: &str) -> (Vec<FileNote>, Vec<FileNote>) {
         ) else {
             continue;
         };
-        let record = FileNote { id, deck };
         if obj.get("deleted").is_some() {
-            tombstones.push(record);
-        } else {
-            notes.push(record);
+            tombstones.push(FileNote {
+                id,
+                deck,
+                kind: String::new(),
+                fields: Vec::new(),
+            });
+            continue;
         }
+        notes.push(FileNote {
+            id,
+            deck,
+            kind: obj
+                .get("kind")
+                .and_then(Json::as_str)
+                .unwrap_or_default()
+                .to_owned(),
+            fields: note_fields(&obj),
+        });
     }
     (notes, tombstones)
 }
 
-/// Diff the file against the collection to build the plan — the describe stage (ADR-0022 §3). This is
-/// where "effects on this collection" are computed, which are not the manifest's counts.
+/// A note line's `fields` object as `(name, value)` pairs in the file's own key order, dropping any
+/// name the mutable surface reserves ([`field_name_is_writable`]) and any value that is not a string.
+fn note_fields(obj: &Json) -> Vec<(String, String)> {
+    let Some(Json::Obj(entries)) = obj.get("fields") else {
+        return Vec::new();
+    };
+    entries
+        .iter()
+        .filter(|(name, _)| field_name_is_writable(name))
+        .filter_map(|(name, value)| Some((name.clone(), value.as_str()?.to_owned())))
+        .collect()
+}
+
+/// Diff the file against the collection to build the plan **and the writes that realise it** — the
+/// describe stage (ADR-0022 §3). This is where "effects on this collection" are computed, which are
+/// not the manifest's counts.
+///
+/// Every count the plan states and every write the apply makes come off the **same** branch of the
+/// same `match`, which is what makes *"1,202 already yours"* and the notes apply skips agree by
+/// construction rather than by two implementations happening to keep step.
 fn describe(
     decks: &[ManifestDeck],
     notes: &[FileNote],
     tombstones: &[FileNote],
     manifest: &Json,
     collection: &Collection,
-) -> Plan {
+) -> Import {
+    let header = header(manifest);
     let held_ids: HashSet<DeckId> = decks
         .iter()
         .filter(|d| collection.deck(&d.id).is_some())
@@ -425,6 +597,16 @@ fn describe(
     }
 
     let mut deck_plans = Vec::new();
+    let mut deck_writes = Vec::new();
+    // The note ids the file creates, and the ones it merely refiles — decided in the loop below and
+    // realised after it, so the decision is made in exactly one place.
+    let mut created: HashMap<NoteId, DeckId> = HashMap::new();
+    let mut moved: Vec<(NoteId, DeckId)> = Vec::new();
+    let mut retracted: Vec<NoteId> = Vec::new();
+    // A note id the file states twice is malformed input; the repeat is dropped whole rather than
+    // counted twice and written once, which would put the plan's numbers out of step with the writes.
+    let mut seen: HashSet<NoteId> = HashSet::new();
+
     for d in decks {
         let update = held_ids.contains(&d.id);
         let path = if update { Path::Update } else { Path::Create };
@@ -434,14 +616,23 @@ fn describe(
         let mut moving: BTreeMap<Option<String>, usize> = BTreeMap::new();
 
         for note in notes.iter().filter(|n| n.deck == d.id) {
+            if !seen.insert(note.id) {
+                continue;
+            }
             match collection.note_deck.get(&note.id) {
-                None => new_notes += 1,
+                None => {
+                    new_notes += 1;
+                    created.insert(note.id, d.id);
+                }
                 Some(current) if *current == d.id => already_yours += 1,
                 Some(current) => {
                     if update {
-                        // The file relocates a held note into this deck (ADR-0008 §11).
+                        // The file relocates a held note into this deck (ADR-0008 §11). Membership is
+                        // a `deck` reference on the note (ADR-0005 §8), so the move is one write and
+                        // the note's own content is left exactly as the user holds it.
                         let from = collection.deck(current).map(|h| h.name.clone());
                         *moving.entry(from).or_default() += 1;
+                        moved.push((note.id, d.id));
                     } else {
                         // Create path: a held id is skipped and never moved (ADR-0005 §2).
                         already_yours += 1;
@@ -452,22 +643,30 @@ fn describe(
 
         // Tombstones bite only on the update path, and only where they match a note held
         // (ADR-0008 §5) — a create-path file has no authority over notes held elsewhere.
-        let deleted = if update {
-            tombstones
+        let mut deleted = 0;
+        if update {
+            for t in tombstones
                 .iter()
                 .filter(|t| t.deck == d.id && collection.holds_note(&t.id))
-                .count()
-        } else {
-            0
-        };
+            {
+                if seen.insert(t.id) {
+                    deleted += 1;
+                    retracted.push(t.id);
+                }
+            }
+        }
 
         let held = collection.deck(&d.id);
         let renamed_from = held.filter(|h| h.name != d.name).map(|h| h.name.clone());
-        let no_change = held.is_some_and(|h| h.revision == d.revision && h.digest == d.digest);
+        let no_change = held
+            .is_some_and(|h| h.revision == d.revision && h.digest == d.digest && h.name == d.name);
         let revision_conflict =
             held.is_some_and(|h| h.revision == d.revision && h.digest != d.digest);
 
+        deck_writes.extend(deck_values(d, &header, update, no_change));
+
         deck_plans.push(DeckPlan {
+            id: d.id,
             name: d.name.clone(),
             path,
             new_notes,
@@ -483,12 +682,126 @@ fn describe(
         });
     }
 
-    Plan {
-        header: header(manifest),
-        decks: deck_plans,
-        adopted_kinds: adopted_kinds(manifest, collection),
-        emptied_decks: emptied_decks(collection, &relocated),
+    let mut writes = deck_writes;
+    writes.extend(note_writes(
+        notes,
+        &created,
+        &moved,
+        &retracted,
+        collection.last_position.as_deref(),
+    ));
+
+    Import {
+        plan: Plan {
+            header,
+            decks: deck_plans,
+            adopted_kinds: adopted_kinds(manifest, collection),
+            emptied_decks: emptied_decks(collection, &relocated),
+        },
+        writes,
     }
+}
+
+/// The values one deck in the file writes onto the mutable surface.
+///
+/// The **name** is authored content and the file wins for it, over the user's own rename
+/// (ADR-0005 §9) — and it is the *bounded* name the preview showed, never the raw string, so what is
+/// written is what the user agreed to (ADR-0022 §7). The **authoring values** — `{revision, digest}`
+/// (ADR-0008 §9) and the author, description and licence beside them (ADR-0022 §8) — are adopted on
+/// both paths, which is what lets an unmodified relay re-emit the byte-identical file at the same
+/// revision instead of inflating the counter.
+///
+/// **A `no_change` deck writes nothing at all.** ADR-0008 §3 makes re-importing an unchanged file
+/// *"a genuine no-op: silent, idempotent, and producing nothing to sync"*, and ADR-0022 §4 reads
+/// *silent* as *"it writes nothing and syncs nothing"* — a stronger claim than restamping-only-what-
+/// differs alone would give, because the file's metadata sits outside the digest and could otherwise
+/// differ while its content did not.
+fn deck_values(d: &ManifestDeck, header: &Header, update: bool, no_change: bool) -> Vec<Write> {
+    if no_change {
+        return Vec::new();
+    }
+    let id = d.id.0;
+    let mut writes = vec![
+        Write::set(DECK_ENTITY, id, "name", &d.name),
+        Write::set(DECK_ENTITY, id, DECK_REVISION_ATTR, &d.revision.to_string()),
+        Write::set(DECK_ENTITY, id, DECK_DIGEST_ATTR, &d.digest),
+        Write::set(DECK_ENTITY, id, DECK_AUTHOR_ATTR, &header.author),
+        Write::set(DECK_ENTITY, id, DECK_DESCRIPTION_ATTR, &header.description),
+        Write::set(DECK_ENTITY, id, DECK_LICENCE_ATTR, &header.licence),
+    ];
+    if !update {
+        // A deck the collection does not hold **live** is created by this file (ADR-0005 §9), and one
+        // it holds only as a `deleted` flag is exactly that case: deletion is a flag, never a row
+        // removal (ADR-0005 §7), so creating the deck means clearing it. This is what discharges
+        // ADR-0016 §4's *"a deleted deck is fully recoverable by re-import"* — without it the deck
+        // and every note in it derive deleted (ADR-0005 §7) and the import is invisible.
+        writes.push(Write::clear(DECK_ENTITY, id, "deleted"));
+    }
+    writes
+}
+
+/// The values the notes write: the created notes in the file's own line order, then the refilings,
+/// then the retractions.
+///
+/// **Order carries meaning for exactly one attribute.** A created note is placed at the end of the
+/// collection's authored order (ADR-0021 §3), and the file carries **line order rather than the key**
+/// (ADR-0008 §12 as amended), so the keys are minted here by chaining
+/// [`cairn_core::content::order::between`] after the collection's current last — one write per note
+/// and never a renumber.
+fn note_writes(
+    notes: &[FileNote],
+    created: &HashMap<NoteId, DeckId>,
+    moved: &[(NoteId, DeckId)],
+    retracted: &[NoteId],
+    last_position: Option<&str>,
+) -> Vec<Write> {
+    let mut writes = Vec::new();
+    let mut last = last_position.map(str::to_owned);
+    // The deck loop already dropped a repeated note id from the *counts*; this drops it from the
+    // writes, which is the same guard at the other end. Without it a file stating one note twice
+    // reads as one new note and mints two order keys for it — the plan's numbers and the writes
+    // parting company over malformed input, which is the one thing deriving them together is for.
+    let mut done: HashSet<NoteId> = HashSet::new();
+
+    for note in notes {
+        let Some(deck) = created.get(&note.id) else {
+            continue;
+        };
+        if !done.insert(note.id) {
+            continue;
+        }
+        let position = order::between(last.as_deref(), None);
+        let id = note.id.0;
+        writes.push(Write::set(NOTE_ENTITY, id, "kind", &note.kind));
+        writes.push(Write::set(NOTE_ENTITY, id, "position", &position));
+        writes.push(Write::set(NOTE_ENTITY, id, "deck", &deck.to_canonical()));
+        // A note the file carries **live** is live: an id held only as a tombstone reads as unheld
+        // (a deleted note is not in the collection's note list), so the plan called it new and the
+        // apply must make it visible again rather than write content nobody can reach.
+        writes.push(Write::clear(NOTE_ENTITY, id, "deleted"));
+        for (name, value) in &note.fields {
+            writes.push(Write::set(NOTE_ENTITY, id, name, value));
+        }
+        last = Some(position);
+    }
+
+    for (note, deck) in moved {
+        writes.push(Write::set(
+            NOTE_ENTITY,
+            note.0,
+            "deck",
+            &deck.to_canonical(),
+        ));
+    }
+
+    // A retraction is a flag, never a row removal (ADR-0004 §7), and the note keeps its `deck`
+    // reference so a deck-scoped export can still select its tombstone (ADR-0008's amendment to
+    // ADR-0004 §7).
+    for note in retracted {
+        writes.push(Write::set(NOTE_ENTITY, note.0, "deleted", "true"));
+    }
+
+    writes
 }
 
 /// The file's header claims, each bounded plain text (ADR-0022 §7).
@@ -877,5 +1190,207 @@ mod tests {
         members.push(Member::deflated("media/hello.mp3", b"audio".to_vec()));
         let with_media = container::build(&members);
         assert!(preview(&with_media, &Collection::new()).is_ok());
+    }
+
+    // ---- The writes -----------------------------------------------------------------------------
+
+    /// Every write for one entity and attribute, as the derivation emits it.
+    fn written(import: &Import, entity: &str, id: [u8; 16], attr: &str) -> Vec<Option<String>> {
+        import
+            .writes
+            .iter()
+            .filter(|w| w.entity == entity && w.entity_id == id && w.attr == attr)
+            .map(|w| w.value.clone())
+            .collect()
+    }
+
+    /// **A field arriving in a file may never take a name the mutable surface reserves.** A field
+    /// called `deck` would otherwise refile the note it arrives on, reaching past ADR-0008 §11's
+    /// branches from inside the payload; `deleted` would retract a note with no tombstone.
+    #[test]
+    fn a_field_may_not_take_an_attribute_name_the_surface_reserves() {
+        let deck = did(1);
+        let elsewhere = did(9);
+        let content = DeckContent {
+            id: deck,
+            name: "D".to_owned(),
+            notes: vec![NoteContent {
+                id: nid(1),
+                position: "a".to_owned(),
+                kind: "basic".to_owned(),
+                fields: vec![
+                    ("Front".into(), "q".into()),
+                    ("deck".into(), elsewhere.to_canonical()),
+                    ("deleted".into(), "true".into()),
+                    ("position".into(), "zzz".into()),
+                    ("tag:leech".into(), "true".into()),
+                ],
+            }],
+            tombstones: Vec::new(),
+        };
+        let bytes = crate::deck::build_deck(
+            &Default::default(),
+            &[DeckExport {
+                content,
+                revision: DeckRevision {
+                    revision: 1,
+                    digest: "d".to_owned(),
+                },
+            }],
+        )
+        .unwrap();
+
+        let import = read(&bytes, &Collection::new()).unwrap();
+
+        // The note is filed where the *file's own deck reference* says, never where a field claims.
+        assert_eq!(
+            written(&import, "note", nid(1).0, "deck"),
+            vec![Some(deck.to_canonical())]
+        );
+        // The `deleted` write is the create path's clear, not the field's "true".
+        assert_eq!(written(&import, "note", nid(1).0, "deleted"), vec![None]);
+        // `position` is the key **minted here** — the first key in an empty collection — never the
+        // file's own string and never the field's "zzz" (ADR-0008 §12 as amended by ADR-0021 §3).
+        assert_eq!(
+            written(&import, "note", nid(1).0, "position"),
+            vec![Some(order::between(None, None))]
+        );
+        assert!(
+            !import.writes.iter().any(|w| w.attr.starts_with("tag:")),
+            "a field may not tag the note it arrives on"
+        );
+        // The genuine field still lands.
+        assert_eq!(
+            written(&import, "note", nid(1).0, "Front"),
+            vec![Some("q".to_owned())]
+        );
+    }
+
+    /// **A rename alone is a change**, although the digest cannot see it: [`crate::deck_digest`]
+    /// excludes the deck name on purpose (ADR-0008 §4), so judged on the digest alone a renaming
+    /// file reads as *"nothing will change"* while the apply renames the deck — promise and effect
+    /// diverging in the one place ADR-0022 §5 exists to make impossible.
+    #[test]
+    fn a_rename_alone_is_not_a_no_change() {
+        let held = Collection::new().with_deck(did(1), "My French", 4, "same");
+        let bytes = real_deck(did(1), "French A1", &[(nid(1), "a")], &[], 4, "same");
+
+        let import = read(&bytes, &held).unwrap();
+        let d = &import.plan.decks[0];
+        assert!(!d.no_change);
+        assert_eq!(d.renamed_from.as_deref(), Some("My French"));
+        assert_eq!(
+            written(&import, "deck", did(1).0, "name"),
+            vec![Some("French A1".to_owned())]
+        );
+    }
+
+    /// The no-op writes **nothing at all** — ADR-0022 §4 reads ADR-0008 §3's *silent* as *"it writes
+    /// nothing and syncs nothing"*, which is stronger than restamping-only-what-differs alone would
+    /// give: the file's metadata sits outside the digest and could otherwise differ while the
+    /// content did not.
+    #[test]
+    fn an_unchanged_file_derives_no_writes_at_all() {
+        let held = Collection::new()
+            .with_deck(did(1), "French", 4, "same")
+            .with_note(nid(1), did(1));
+        let bytes = real_deck(did(1), "French", &[(nid(1), "a")], &[], 4, "same");
+
+        let import = read(&bytes, &held).unwrap();
+        assert!(import.plan.decks[0].no_change);
+        assert!(import.writes.is_empty(), "{:?}", import.writes);
+    }
+
+    /// The counts and the writes come off one pass, so a note the plan calls *already yours* is a
+    /// note nothing is written for (ADR-0005 §2) — the agreement ADR-0022 §5 needs is structural,
+    /// not two implementations keeping step.
+    #[test]
+    fn an_already_yours_note_produces_no_write() {
+        let held = Collection::new()
+            .with_deck(did(1), "French", 1, "d")
+            .with_note(nid(1), did(1));
+        let bytes = real_deck(
+            did(1),
+            "French",
+            &[(nid(1), "a"), (nid(2), "b")],
+            &[],
+            2,
+            "new",
+        );
+
+        let import = read(&bytes, &held).unwrap();
+        assert_eq!(
+            (
+                import.plan.decks[0].new_notes,
+                import.plan.decks[0].already_yours
+            ),
+            (1, 1)
+        );
+        assert!(
+            !import
+                .writes
+                .iter()
+                .any(|w| w.entity == "note" && w.entity_id == nid(1).0),
+            "the colliding note is skipped, not re-imported"
+        );
+        assert_eq!(
+            written(&import, "note", nid(2).0, "kind"),
+            vec![Some("basic".to_owned())]
+        );
+    }
+
+    /// A note the file states twice is malformed input: the repeat is dropped **whole**, so it is
+    /// not counted twice and written once — which would put the plan's numbers out of step with the
+    /// writes the user agreed to.
+    #[test]
+    fn a_note_stated_twice_is_counted_once_and_written_once() {
+        let manifest = manifest_json(1, "deck", &[(did(1), "D", 1)], &["basic"]);
+        let line = format!(
+            r#"{{"deck":"{}","fields":{{"Front":"q"}},"kind":"basic","n":"{}"}}"#,
+            did(1).to_canonical(),
+            nid(1).to_canonical()
+        );
+        let bytes = craft(
+            DECK_MEDIA_TYPE,
+            vec![
+                Member::deflated(MANIFEST_MEMBER, manifest.into_bytes()),
+                Member::deflated(NOTES_MEMBER, format!("{line}\n{line}\n").into_bytes()),
+            ],
+        );
+
+        let import = read(&bytes, &Collection::new()).unwrap();
+        assert_eq!(import.plan.decks[0].new_notes, 1);
+        assert_eq!(
+            written(&import, "note", nid(1).0, "position").len(),
+            1,
+            "one note, one position write — never a renumber (ADR-0021 §3)"
+        );
+    }
+
+    /// Imported notes take **minted** order keys chained after the collection's current last
+    /// (ADR-0021 §3), in the file's own line order — the file carries line order, not the key
+    /// (ADR-0008 §12 as amended).
+    #[test]
+    fn imported_positions_are_minted_after_the_collections_last_and_strictly_increase() {
+        let held = Collection::new().with_last_position("m");
+        let bytes = real_deck(
+            did(1),
+            "D",
+            &[(nid(1), "a"), (nid(2), "b"), (nid(3), "c")],
+            &[],
+            1,
+            "d",
+        );
+
+        let import = read(&bytes, &held).unwrap();
+        let keys: Vec<String> = import
+            .writes
+            .iter()
+            .filter(|w| w.entity == "note" && w.attr == "position")
+            .map(|w| w.value.clone().unwrap())
+            .collect();
+        assert_eq!(keys.len(), 3);
+        assert!(keys[0].as_str() > "m", "{keys:?}");
+        assert!(keys[0] < keys[1] && keys[1] < keys[2], "{keys:?}");
     }
 }

--- a/crates/export/src/lib.rs
+++ b/crates/export/src/lib.rs
@@ -42,8 +42,9 @@ pub use deck::{
 };
 pub use files::{COLLECTION_EXTENSION, is_recognised};
 pub use import::{
-    Collection, DeckPlan, Header, HeldDeck, MovingIn, Path, Plan, Profile, Refusal, plain, preview,
-    sniff,
+    Collection, DECK_AUTHOR_ATTR, DECK_DESCRIPTION_ATTR, DECK_DIGEST_ATTR, DECK_LICENCE_ATTR,
+    DECK_REVISION_ATTR, DeckPlan, Header, HeldDeck, Import, MovingIn, Path, Plan, Profile, Refusal,
+    Write, plain, preview, read, sniff,
 };
 pub use name::{DECK_EXTENSION, export_filename, sanitise};
 pub use platform::{PlatformError, Written};

--- a/crates/store/src/collection.rs
+++ b/crates/store/src/collection.rs
@@ -532,6 +532,41 @@ impl Collection {
         Ok(())
     }
 
+    /// Set one value **only where it differs from the value already settled** — the rule an import
+    /// writes under (ADR-0008 §3), returning whether anything was written.
+    ///
+    /// Restamping a value with the content it already has is not a no-op: [`Collection::mutable_set`]
+    /// takes a fresh Lamport counter, so an equal-valued write is a **new stamp** that propagates to
+    /// the user's own devices as an edit. Importing a 5,000-note deck would send 5,000 of them, and
+    /// re-importing the same file would send them all again. Reading the settled value first costs
+    /// one indexed lookup per value and is what makes ADR-0008 §3's *"re-importing the same file is a
+    /// genuine no-op: silent, idempotent, and producing nothing to sync"* true rather than nearly
+    /// true.
+    ///
+    /// **Absent and SQL NULL are the same value here**, exactly as [`Collection::mutable_get`]
+    /// reports them: clearing an attribute that was never set writes nothing.
+    pub fn mutable_set_if_changed(
+        &mut self,
+        entity: &str,
+        entity_id: &[u8],
+        attr: &str,
+        value: Option<&str>,
+    ) -> Result<bool, StoreError> {
+        if self.mutable_get(entity, entity_id, attr)?.as_deref() == value {
+            return Ok(false);
+        }
+        self.mutable_set(entity, entity_id, attr, value)?;
+        Ok(true)
+    }
+
+    /// The largest `position` order key the collection holds, or `None` when no note carries one —
+    /// the key a newly placed note is chained after (ADR-0021 §3). Byte order over the key alphabet
+    /// **is** the total order (`content::order`), so `MAX(value)` names the current last without
+    /// decoding anything.
+    pub fn last_position(&self) -> Result<Option<String>, StoreError> {
+        self.max_position()
+    }
+
     /// Mint a note and write its kind, `position` and fields onto the mutable surface, returning its
     /// fresh id.
     ///

--- a/crates/store/tests/collection.rs
+++ b/crates/store/tests/collection.rs
@@ -838,6 +838,46 @@ fn an_optimisation_run_writes_a_parameter_row_only_when_the_vector_changes() {
     assert_eq!(again, None, "the same vector a second time writes nothing");
 }
 
+/// **Restamping only what differs is a stamp rule, not a convenience** (ADR-0008 §3). Writing a
+/// value with the content it already has takes a fresh Lamport counter, so it is a new edit that
+/// propagates — importing a 5,000-note deck would send 5,000 of them and re-importing the same file
+/// would send them all again. The differing-only write is what makes the re-import silent.
+#[test]
+fn a_write_of_the_value_already_settled_takes_no_new_stamp() {
+    let (mut coll, _d, _s) = open();
+    let id = note(1);
+
+    assert!(
+        coll.mutable_set_if_changed("note", &id.0, "Front", Some("bonjour"))
+            .unwrap(),
+        "the first write lands"
+    );
+
+    assert!(
+        !coll
+            .mutable_set_if_changed("note", &id.0, "Front", Some("bonjour"))
+            .unwrap(),
+        "the same content a second time writes nothing"
+    );
+
+    // A genuine change still lands, and clearing a value that was never set is itself a no-op —
+    // absent and SQL NULL are the same value (ADR-0007 §4).
+    assert!(
+        coll.mutable_set_if_changed("note", &id.0, "Front", Some("salut"))
+            .unwrap()
+    );
+    assert!(
+        !coll
+            .mutable_set_if_changed("note", &id.0, "Back", None)
+            .unwrap(),
+        "clearing an attribute that was never set writes nothing"
+    );
+    assert_eq!(
+        coll.mutable_get("note", &id.0, "Front").unwrap().as_deref(),
+        Some("salut")
+    );
+}
+
 /// Copy `collection.db` (and any WAL sidecars) from one data dir to another — a restore.
 fn copy_collection(from: &std::path::Path, to: &std::path::Path) {
     for name in ["collection.db", "collection.db-wal", "collection.db-shm"] {


### PR DESCRIPTION
Resolves [#165](https://github.com/amin-bf/cairn/issues/165) — the apply half of ADR-0022 §1's gate, deferred in [#89](https://github.com/amin-bf/cairn/issues/89)'s closing comment and owned by nobody since.

## What lands

**One derivation, two outputs.** `import::read` returns the plan *and* the mutable-surface writes that realise it, from one pass. That is what makes the preview's *"1,202 already yours"* line and the notes apply skips agree **by construction**: they come off the same `match` arm. `preview` is now that function with the writes discarded, and `inbound::apply` calls it again at the press rather than executing anything the screen held — ADR-0022 §5 accepts the cost of computing the import twice for exactly this reason.

**Writes only where the value differs** (`Collection::mutable_set_if_changed`). Restamping a value with the content it already has takes a fresh Lamport counter, so it propagates as an edit; a 5,000-note deck would send 5,000 of them and a re-import would send them all again. Re-importing an unchanged file now writes nothing.

## What it found

**The revision gate was never a gate.** `{revision, digest}` live on the deck's authoring slot (ADR-0008 §9) and nothing had ever written them, so every held deck entered the snapshot at revision 0 — an older file was never refused, an unchanged one never read as *nothing will change*, and equal-revision-different-digest never reported the one revision fact ADR-0022 §4 shows. Three correct decisions sitting behind a value nobody wrote. Now that apply adopts them, all three fire; `an_older_copy_of_a_deck_already_imported_is_refused` pins it.

**A rename alone is a change, and the digest cannot see it.** `deck_digest` excludes the deck name on purpose, so `no_change` judged on revision and digest alone read *"nothing will change"* while the apply renamed the deck — and the screen's `continue` swallowed the *"renaming your X to Y"* line ADR-0022 §3 requires. The no-change test now carries the name.

**A field name arriving in a file becomes an attribute name.** A field called `deck` would refile the note it arrives on, reaching past ADR-0008 §11's branches from inside the payload; `deleted` would retract a note with no tombstone. Nothing in the shipped kinds collides with these, which is why it looks like dead defensiveness — the names come from an **acquired** kind definition, which is a stranger's data.

**A held note id is never re-imported on either path** — only its membership follows the file. ADR-0022 §3's table cites ADR-0005 §2's *"not re-imported"* against the *update*-path example, so the collision rule is not the create path's alone. This reads like a contradiction with ADR-0008 §11's *"§9 applies in full"*, and the consequence is real: an author's edit to an existing note does not propagate, and retraction plus a fresh note is the route ADR-0008 §5 leaves them. Recorded in `AGENTS.md` rather than absorbed.

## Out of scope, and said out loud

**Acquired-kind persistence is not here**, although #89's closing comment listed it. `KindDefinition` is `&'static` throughout `cairn-core`, so an ownable definition is a content-model change — capability, not glue — and the map's scope seam sends it to *Out of scope* as a named follow-on rather than absorbing it. The kind **id** persists on the note, so an imported note of an unknown kind arrives, lists and edits; it generates no cards, exactly as `cards.rs` already documents.

## How it is judged

By tests: no window, no capture, no handset. 22 new tests across the three crates — a temp-directory collection, a built `.cdeck`, apply, assert. The tombstone and deck-move cases went first, as #165 asks: they are the two the preview's most alarming lines describe, the two #89 ticked without executing, and the two nothing in this repository had ever run.

`cargo test --workspace` — 412 passing, 0 failing. `cargo clippy --workspace --all-targets` and `cargo fmt --check` clean.

The inbound specimen gains a development *Import* control so the path is exercisable in the running app and on the handset. Pressing it twice is ADR-0008 §3's idempotence live: the lines re-derive and flip to *"Nothing will change."* It goes with the rest of the specimen when [#167](https://github.com/amin-bf/cairn/issues/167) draws the real gate.

**No ADR moves.** ADR-0022 and ADR-0008 already specify every behaviour above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKbinPz1whPUYgJfC7NosQ