### PR TITLE
Client Stack / Fix the Broken Main, and the Row That Ignored Its Own Words

### DIFF
--- a/crates/app/src/controls.rs
+++ b/crates/app/src/controls.rs
@@ -197,20 +197,35 @@ fn band_text(ui: &mut Ui, rect: egui::Rect, text: &str, caption: Option<&str>) {
             .max_rect(inner)
             .layout(egui::Layout::top_down(align)),
     );
-    child.label(crate::bidi::job(
-        text,
-        egui::TextStyle::Button.resolve(child.style()),
-        child.visuals().text_color(),
-    ));
+    // **`selectable(false)`, and it is the difference between a row that opens and one that does
+    // not.** `ui.label` is `Label::selectable`d by default, and a selectable label senses *click and
+    // drag* so it can put a text cursor in itself — so the label sitting on the band ate every press
+    // that landed on the note's own words, which is the most natural place on the row to aim. The
+    // band still opened when clicked on its **empty** part, so every capture looked right and the
+    // storyboards that drove it from the far side of a short preview passed.
+    //
+    // Found by a probe rather than by looking: `%LX+19%` lands on `chien` and did nothing, `%LX+200%`
+    // lands past it and opened the editor, with the two screens identical.
+    child.add(
+        egui::Label::new(crate::bidi::job(
+            text,
+            egui::TextStyle::Button.resolve(child.style()),
+            child.visuals().text_color(),
+        ))
+        .selectable(false),
+    );
     if let Some(caption) = caption {
         // The caption follows the **row's** direction rather than its own script: it is a footnote
         // on that line, and one that changed sides from the line above it would read as a second
         // object rather than as part of the same one.
-        child.label(crate::bidi::job(
-            caption,
-            egui::TextStyle::Small.resolve(child.style()),
-            child.visuals().weak_text_color(),
-        ));
+        child.add(
+            egui::Label::new(crate::bidi::job(
+                caption,
+                egui::TextStyle::Small.resolve(child.style()),
+                child.visuals().weak_text_color(),
+            ))
+            .selectable(false),
+        );
     }
 }
 
@@ -661,5 +676,59 @@ mod tests {
                 row_height(ui, true)
             );
         });
+    }
+    /// **A row opens when it is clicked on its own words**, which is the most natural place to aim
+    /// and was the one place it did not work (ADR-0039 §1).
+    ///
+    /// `ui.label` is selectable by default and a selectable label senses **click and drag**, so it
+    /// can put a text cursor in itself. Sitting on the band, it ate every press that landed on the
+    /// note's preview — and the band still opened on its **empty** part, so the screen was identical,
+    /// every capture looked right, and the storyboards that happened to aim past a short preview
+    /// passed. It was found by probing two x coordinates on one row.
+    ///
+    /// This drives real pointer events rather than inspecting a flag, because what broke was not the
+    /// value of a `Sense` but *which widget won the interaction*, and that is only answerable by
+    /// asking egui.
+    #[test]
+    fn a_row_opens_when_clicked_on_its_own_text() {
+        fn press_at(x: f32) -> bool {
+            let ctx = egui::Context::default();
+            typography::install(&ctx);
+            spacing::install(&ctx);
+            theme::install(&ctx, theme::ThemeChoice::Dark);
+            let at = egui::pos2(x, 20.0);
+            let mut opened = false;
+            // **Three passes, and the first one is why this test is written and not obvious.** egui
+            // resolves an interaction against the rects the *previous* frame allocated, so a widget
+            // drawn for the first time in the same frame as the press is not there to be pressed.
+            // Frame one only moves the pointer; then press, then release, because a click is
+            // reported on release.
+            for event in [None, Some(true), Some(false)] {
+                let mut events = vec![egui::Event::PointerMoved(at)];
+                if let Some(pressed) = event {
+                    events.push(egui::Event::PointerButton {
+                        pos: at,
+                        button: egui::PointerButton::Primary,
+                        pressed,
+                        modifiers: Default::default(),
+                    });
+                }
+                let input = egui::RawInput {
+                    events,
+                    ..Default::default()
+                };
+                let _ = ctx.run_ui(input, |ui| {
+                    ui.set_width(400.0);
+                    if row(ui, "chien", None, &[]).opened {
+                        opened = true;
+                    }
+                });
+            }
+            opened
+        }
+
+        // Over the word, and over the empty band past it. Both are the row.
+        assert!(press_at(20.0), "a click on the row's own text opens it");
+        assert!(press_at(200.0), "a click past the text opens it too");
     }
 }

--- a/crates/app/src/screens/notes.rs
+++ b/crates/app/src/screens/notes.rs
@@ -12,7 +12,7 @@ use crate::{
     editor, field_label, fonts, frame, full_width_button, heading, raise_keyboard, sync, text,
     text_field,
 };
-use crate::{controls, spacing, surface};
+use crate::{spacing, surface};
 
 /// The **Notes** destination (ADR-0021 §2): the browse surface and the app's authoring home. Shows
 /// the editor when one is open, otherwise the note list — create, the text search, and the rows,

--- a/scripts/storyboards/motion-light.txt
+++ b/scripts/storyboards/motion-light.txt
@@ -52,18 +52,18 @@ shot 04-stepdown-open
 # 1.125 — so it is also where a wrong value has nowhere to hide.
 mousemove %LX+86% 11 click 1
 sleep 1.5
-mousemove %LX+300% 165 click 1
+mousemove %LX+300% 137 click 1
 sleep 0.5
 sh xdotool type --delay 40 'Cuisine'
 sleep 0.5
-mousemove %LX+36% 165 click 1
+mousemove %LX+36% 137 click 1
 sleep 1
-mousemove %LX+300% 165 click 1
+mousemove %LX+300% 137 click 1
 sleep 0.5
 sh xdotool type --delay 40 'Voyage'
 sleep 0.5
-mousemove %LX+36% 165 click 1
+mousemove %LX+36% 137 click 1
 sleep 1
-mousemove %LX+50% 145 click 1
+mousemove %LX+50% 109 click 1
 sleep 1
 shot 05-overlay

--- a/scripts/storyboards/motion.txt
+++ b/scripts/storyboards/motion.txt
@@ -12,7 +12,8 @@
 #   the entrance's one primary: %CX% y=129 — full width, so the centre reaches it at either width
 #   the card: %CX% y=254 — the whole face is the reveal target (ADR-0006 §3)
 #   the grades: %CX% %BY-183% reaches *Good*
-#   the deck filter's combo box: %LX+50% y=145; the new-deck field %LX+300% y=165, its button %LX+36%
+#   the deck filter's combo box: %LX+50% y=109; the new-deck field %LX+300% y=137, its button %LX+36%
+#   — all three moved up in #162, which took *Create note* off the top of the page
 #
 # **The grade row is the one click here that a literal y cannot reach**, and this storyboard was
 # written wrong before it was written right. ADR-0035 §1 anchors the last control cluster to a line
@@ -58,21 +59,21 @@ shot 04-stepdown-open
 # shadow against, and no fixture ships a deck.
 mousemove %LX+86% 11 click 1
 sleep 1.5
-mousemove %LX+300% 165 click 1
+mousemove %LX+300% 137 click 1
 sleep 0.5
 sh xdotool type --delay 40 'Cuisine'
 sleep 0.5
-mousemove %LX+36% 165 click 1
+mousemove %LX+36% 137 click 1
 sleep 1
-mousemove %LX+300% 165 click 1
+mousemove %LX+300% 137 click 1
 sleep 0.5
 sh xdotool type --delay 40 'Voyage'
 sleep 0.5
-mousemove %LX+36% 165 click 1
+mousemove %LX+36% 137 click 1
 sleep 1
 # **The only thing in the application that floats** (ADR-0037 §1). Before this it was drawn in
 # *exactly* the page colour inside stock egui's unassigned grey hairline with no shadow, in every
 # capture this repository holds. It should now read as a slab sitting on top of the page.
-mousemove %LX+50% 145 click 1
+mousemove %LX+50% 109 click 1
 sleep 1
 shot 05-overlay


### PR DESCRIPTION
**`main` does not compile**, and chasing that turned up a defect in what
[#176](https://github.com/amin-bf/cairn/pull/176) shipped. Three fixes, smallest first.

## 1. `main` does not build

```
error[E0252]: the name `controls` is defined multiple times
```

#176 added `controls` to the multi-line `use crate::{…}` block; #163's branch added
`use crate::{controls, spacing, surface};` four lines below it. Neither touched the other's line, so
**git merged both with no conflict** and `149f7bc3` does not compile.

Nothing was wrong on either branch and nothing failed at merge time. It is `AGENTS.md`'s *Landing
work* preamble — parallel worktree sessions branch from `origin/main` and never see what merged
afterwards — arriving as a **semantic conflict git resolves cleanly**, which is a third failure mode
beside the two branch/signing rules written there.

Fixed the way #163 had already fixed it in its own uncommitted working copy, so that copy converges
rather than conflicts.

## 2. A row does not open when clicked on its own words

ADR-0039 §1 makes the band the row's open affordance. It was one for every part of itself **except
the part anyone would aim at**.

`ui.label` is `Label::selectable`d by default, and a selectable label senses **click and drag** so it
can put a text cursor in itself — so the label sitting on the band won the interaction and swallowed
every press landing on the note's preview. The band still opened on its **empty** part, which is why
this survived everything:

- the screen is pixel-identical either way, so no capture could show it;
- `notes.txt` aims `%LX+200%`, past a short preview — it passed;
- `baseline.txt` aims `%LX+19%`, which is *on* it — it did not, and produced the list under
  `05-notes-editor`'s name.

I found it by assuming the storyboard had gone stale and probing two x coordinates on one row:
`+19` did nothing, `+200` opened the editor, nothing visibly different.

**The test drives real pointer events**, because what broke was not the value of a `Sense` but which
widget won the interaction — only egui can answer that. It takes three passes and the first is the
part worth knowing: egui resolves interaction against the rects the *previous* frame allocated, so a
widget drawn for the first time in the same frame as the press is not there to be pressed. Checked
against the defect: reverted, it fails on exactly the assertion that names the word.

## 3. Two motion storyboards still aim at the old deck block

#162 moved the chrome up when *Create note* left the top of the page, and `motion.txt` /
`motion-light.txt` were not updated with the four `notes*` files. They are the two that photograph
**ADR-0037 §1's one thing that floats**, so `05-overlay` came out as a plain list — the deck-creating
clicks landed on empty page and the dropdown click hit *New deck*, which does nothing with an empty
field.

Verified by re-running both and looking: the dropdown is open over the page with its own fill and
hairline, holding *All decks*, *Unfiled*, *Voyage*, *Cuisine*.

`baseline.txt` and `light.txt` were **left alone**. They were also producing the list under the
editor's name, but the cause was fix 2 — moving their coordinates would have hidden the defect
instead of fixing it.

## Verification

- `cargo test --workspace` — **440 passed, 0 failed**; clippy and `fmt --check` clean.
- Every commit compiles on its own (`git rebase --exec cargo check`) and is signed.
- `motion.txt`, `motion-light.txt` and `baseline.txt` re-run and inspected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4vn2q3Bp6JxgmrHhZtgFe
